### PR TITLE
Fix error on IA32

### DIFF
--- a/byterun/config.h
+++ b/byterun/config.h
@@ -139,7 +139,11 @@ typedef uint64 uintnat;
 /* An entire minor heap must fit inside one region
    of size 1 << Minor_heap_align_bits, which determines
    the maximum size of the heap */
+#if SIZEOF_PTR  <= 4
+#define Minor_heap_align_bits 20
+#else
 #define Minor_heap_align_bits 24
+#endif
 
 /* Default size of the minor zone. (words)  */
 #define Minor_heap_def 262144

--- a/byterun/platform.c
+++ b/byterun/platform.c
@@ -41,13 +41,13 @@ void caml_plat_event_trigger(caml_plat_event* e)
 #define Is_power_2(align) \
   ((align) != 0 && ((align) & ((align) - 1)) == 0)
 
-static asize_t round_up(asize_t size, asize_t align) {
+static uintnat round_up(uintnat size, uintnat align) {
   Assert(Is_power_2(align));
   return (size + align - 1) & ~(align - 1);
 }
 
 
-asize_t caml_mem_round_up_pages(asize_t size)
+uintnat caml_mem_round_up_pages(uintnat size)
 {
   return round_up(size, sysconf(_SC_PAGESIZE));
 }


### PR DESCRIPTION
* minor heap size overflow in caml_init_domain
* caml_mem_round_up_pages type missmatch