### PR TITLE
Remove unnecessary caml locals. Edit travis scripts for 32- and 64-bit builds.

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,15 +1,26 @@
+#case $XARCH in
+#i386)
+#  ./configure
+#  make world.opt
+#  sudo make install
+#  cd testsuite && make all
+#  git clone git://github.com/ocaml/camlp4
+#  cd camlp4 && ./configure && make && sudo make install
+#  git clone git://github.com/ocaml/opam
+#  cd opam && ./configure && make lib-ext && make && sudo make install
+#  opam init -y -a git://github.com/ocaml/opam-repository
+#  opam install -y utop
+#  ;;
+#*)
+#  echo unknown arch
+#  exit 1
+#  ;;
+#esac
+
 case $XARCH in
-i386)
+x86_64)
   ./configure
-  make world.opt
-  sudo make install
-  cd testsuite && make all
-  git clone git://github.com/ocaml/camlp4
-  cd camlp4 && ./configure && make && sudo make install
-  git clone git://github.com/ocaml/opam
-  cd opam && ./configure && make lib-ext && make && sudo make install
-  opam init -y -a git://github.com/ocaml/opam-repository
-  opam install -y utop
+  make world
   ;;
 *)
   echo unknown arch

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -18,7 +18,7 @@
 #esac
 
 case $XARCH in
-x86_64)
+x86_64|i386)
   ./configure
   make world
   ;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: c
 script: bash -ex .travis-ci.sh
 env:
    - XARCH=x86_64
+   - XARCH=i386

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: c
 script: bash -ex .travis-ci.sh
 env:
-   - XARCH=i386
+   - XARCH=x86_64

--- a/byterun/fiber.c
+++ b/byterun/fiber.c
@@ -69,7 +69,8 @@ void caml_init_fibers ()
 value caml_handle(value body, value hval, value hexn, value heff, intnat extra_args)
 {
   CAMLparam4(body, hval, hexn, heff);
-  CAMLlocal2(old_stack, new_stack);
+  CAMLlocal1(new_stack);
+  value old_stack;
   value *sp, *high;
 
   /* Push the trapsp, parent stack and extra args */
@@ -112,7 +113,8 @@ value caml_handle(value body, value hval, value hexn, value heff, intnat extra_a
 value caml_perform(value effect)
 {
   CAMLparam1(effect);
-  CAMLlocal3(cont, old_stack, new_stack);
+  CAMLlocal2(old_stack, new_stack);
+  value cont;
   value *sp;
   struct domain* self;
 
@@ -193,7 +195,7 @@ static value use_continuation(value cont)
 
 value caml_continue(value cont, value ret, intnat extra_args)
 {
-  CAMLparam2(cont,ret);
+  CAMLparam1(ret);
   CAMLlocal2(old_stack, new_stack);
   value *sp;
 
@@ -225,7 +227,7 @@ value caml_continue(value cont, value ret, intnat extra_args)
 value caml_finish(value ret)
 {
   CAMLparam1(ret);
-  CAMLlocal2(old_stack, new_stack);
+  value old_stack, new_stack;
   value *sp;
   value extra_args_v;
 


### PR DESCRIPTION
* Reverts the unnecessary `CAMLlocals` introduced in ocamllabs/ocaml-multicore@57237fc.
* Edits travis build scripts for simple 32- and 64-bit builds.