### PR TITLE
Make physical equality aware of promotion duplication.

### DIFF
--- a/byterun/interp.c
+++ b/byterun/interp.c
@@ -1077,7 +1077,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
 
 #define Integer_comparison(typ,opname,tst) \
     Instruct(opname): \
-        accu = Val_int((typ) accu tst (typ) *sp++); Next;
+      accu = Val_int((typ) accu tst (typ) *sp++); Next;
 
     Integer_comparison(intnat,NEQ, !=)
     Integer_comparison(intnat,LTINT, <)

--- a/byterun/interp.c
+++ b/byterun/interp.c
@@ -1060,23 +1060,25 @@ value caml_interprete(code_t prog, asize_t prog_size)
     Instruct(ASRINT):
       accu = (value)((((intnat) accu - 1) >> Long_val(*sp++)) | 1); Next;
 
-#define Integer_comparison(typ,opname,tst) \
-    Instruct(opname): { \
-      if (Is_long (accu) || Is_long(*sp)) { \
-        accu = Val_int((typ) accu tst (typ) *sp++); \
-        Next; \
-      } \
-      if (Is_promoted_hd(Hd_val(accu)) && Is_young(accu)) \
-        accu = caml_addrmap_lookup(&caml_remembered_set.promotion, accu); \
-      value v2 = *(value*)sp; \
-      if (Is_promoted_hd(Hd_val(v2)) && Is_young(v2)) \
-        v2 = caml_addrmap_lookup(&caml_remembered_set.promotion, v2); \
-      accu = Val_int((typ) accu tst (typ) v2); \
-      sp++; \
-      Next; \
+    Instruct(EQ): {
+      if (Is_long (accu) || Is_long(*sp)) {
+        accu = Val_int((intnat) accu == (intnat) *sp++);
+        Next;
+      }
+      if (Is_promoted_hd(Hd_val(accu)) && Is_young(accu))
+        accu = caml_addrmap_lookup(&caml_remembered_set.promotion, accu);
+      value v2 = *(value*)sp;
+      if (Is_promoted_hd(Hd_val(v2)) && Is_young(v2))
+        v2 = caml_addrmap_lookup(&caml_remembered_set.promotion, v2);
+      accu = Val_int((intnat) accu == (intnat) v2);
+      sp++;
+      Next;
     }
 
-    Integer_comparison(intnat,EQ, ==)
+#define Integer_comparison(typ,opname,tst) \
+    Instruct(opname): \
+        accu = Val_int((typ) accu tst (typ) *sp++); Next;
+
     Integer_comparison(intnat,NEQ, !=)
     Integer_comparison(intnat,LTINT, <)
     Integer_comparison(intnat,LEINT, <=)


### PR DESCRIPTION
Promoting an object duplicates the object in the major heap and uses write barriers to ensure that the copies are in sync. However, physical equality breaks due to this duplication. Physical equality is essential for pattern matching polymorphic and extensible variants. See #7 for example. The fix ensures that the major heap object is always used when comparing promoted objects.

This fix is certainly not ideal since it adds a branch to every integer equality! We might perhaps add a special instruction for physical equality. This PR fixes #7.