### PR TITLE
Fix stack promotion.

### DIFF
--- a/byterun/fiber.c
+++ b/byterun/fiber.c
@@ -458,6 +458,14 @@ void caml_clean_stack(value stack)
   }
 }
 
+void caml_clean_stack_domain(value stack, struct domain* domain)
+{
+  Assert(Tag_val(stack) == Stack_tag);
+  if (Stack_dirty_domain(stack) == domain) {
+    Stack_dirty_domain(stack) = 0;
+  }
+}
+
 void caml_scan_stack(scanning_action f, value stack)
 {
   value *low, *high, *sp;

--- a/byterun/fiber.h
+++ b/byterun/fiber.h
@@ -31,6 +31,7 @@ void caml_scan_stack(scanning_action, value stack);
 void caml_save_stack_gc();
 void caml_restore_stack_gc();
 void caml_clean_stack(value stack);
+void caml_clean_stack_domain(value stack, struct domain* domain);
 
 
 /* The table of global identifiers */


### PR DESCRIPTION
As a part of promoting the stack, objects pointed to by the stack should also be promoted. This commit fixes a bug that ignores the latter if the stack is on a minor heap; `caml_scan_dirty_stack` only scans dirty stack whereas stacks in a minor heap are never marked as dirty. The fix always scans the stack, and also marks it clean since the stack no longer points to a minor heap.

The unconditional stack scanning can be optimized by only scanning the stack if the stack is in the minor heap or in the major heap and is marked as dirty.