### PR TITLE
Scan dark stack

### DIFF
--- a/byterun/fiber.c
+++ b/byterun/fiber.c
@@ -7,6 +7,7 @@
 #include "alloc.h"
 #include "platform.h"
 #include "fix_code.h"
+#include "shared_heap.h"
 
 #ifdef NATIVE_CODE
 
@@ -73,6 +74,10 @@ static value save_stack ()
   Assert(caml_stack_high == Stack_high(old_stack));
   Assert(caml_extern_sp == caml_stack_high + Stack_sp(old_stack));
   dirty_stack(old_stack);
+  if (!Is_minor(old_stack) && caml_is_marked(old_stack)) {
+    //TODO: Only scan mutated part of the stack
+    caml_scan_stack(&caml_darken, old_stack);
+  }
   return old_stack;
 }
 

--- a/byterun/shared_heap.c
+++ b/byterun/shared_heap.c
@@ -153,27 +153,6 @@ static void pool_release(struct caml_heap_state* local, pool* pool) {
     local->pools_allocated--;
   }
 }
-#ifdef DEBUG
-
-static int detect_cycle (pool* p) {
-  pool *slow, *fast;
-
-  slow = fast = p;
-
-  while (fast != 0) {
-    slow = slow->next;
-    if (fast->next)
-      fast = fast->next->next;
-    else
-      fast = 0;
-    if (slow == fast && fast !=0)
-      return 1;
-  }
-  return 0;
-}
-
-#endif
-
 
 /* Allocating an object from a pool */
 
@@ -231,7 +210,6 @@ static void* pool_allocate(struct caml_heap_state* local, sizeclass sz) {
     local->full_pools[sz] = r;
   }
 
-  Assert(!detect_cycle(local->full_pools[sz]));
   Assert(r->next_obj == 0 || *r->next_obj == 0);
   return p;
 }

--- a/byterun/shared_heap.h
+++ b/byterun/shared_heap.h
@@ -16,13 +16,15 @@ void caml_shared_unpin(value v);
 
 int caml_mark_object(value);
 
+int caml_is_marked(value);
+
 intnat caml_sweep(struct caml_heap_state*, intnat);
 
 
 /* must be called during STW */
 void caml_cycle_heap_stw(void);
 
-/* must be called on each domain 
+/* must be called on each domain
    (after caml_cycle_heap_stw) */
 void caml_cycle_heap(struct caml_heap_state*);
 


### PR DESCRIPTION
Since parts of the major heap may be marked between major collections, it is necessary to ensure that stacks which happen to be marked but are run after marking are scanned again to handle subsequent mutations to the stack. Otherwise, there is a chance of failing to mark live objects on live stacks.

Of course, we might end up doing duplicate work with this solution, re-scanning unchanged parts of the stack. Is it worth optimising this to avoid duplicate work a la native code [1].

[1] https://github.com/kayceesrk/ocaml/blob/effects/asmrun/roots.c#L211