### PR TITLE
Fixing is_main initialization in create_domain.

### DIFF
--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -148,7 +148,7 @@ static void create_domain(uintnat initial_minor_heap_size, int is_main) {
 
   if (d) {
     d->running = 1;
-    d->state.is_main = 0;
+    d->state.is_main = is_main;
     d->state.vm_inited = 0;
     d->state.internals = d;
     /* FIXME: shutdown RPC? */

--- a/byterun/memory.c
+++ b/byterun/memory.c
@@ -18,10 +18,10 @@ static void shared_heap_write_barrier(value obj, int field, value val)
       /* Add to remembered set */
       Ref_table_add(&caml_remembered_set.ref, obj, field);
     } else {
-      /* 
+      /*
          FIXME: should have an is_marking check
          don't want to do this all the time
-         
+
          unconditionally mark new value
       */
 
@@ -88,7 +88,7 @@ CAMLexport void caml_set_fields (value obj, value v)
 {
   int i;
   Assert (Is_block(obj));
-  
+
   for (i = 0; i < Wosize_val(obj); i++) {
     caml_modify_field(obj, i, v);
   }
@@ -103,7 +103,7 @@ CAMLexport void caml_blit_fields (value src, int srcoff, value dst, int dstoff, 
   Assert(dstoff + n <= Wosize_val(dst));
   Assert(Tag_val(src) != Infix_tag);
   Assert(Tag_val(dst) != Infix_tag);
-  
+
   /* we can't use memcpy/memmove since they may not do atomic word writes.
      for instance, they may copy a byte at a time */
   if (src == dst && srcoff < dstoff) {
@@ -220,7 +220,7 @@ static void handle_write_fault(struct domain* target, void* reqp) {
   struct write_fault_req* req = reqp;
   if (Is_promoted_hd(Hd_val(req->obj)) &&
       caml_owner_of_shared_block(req->obj) == target) {
-    caml_gc_log("Handling write fault for domain [%02d] on %p(%d)", target->id, req->obj, req->field);
+    caml_gc_log("Handling write fault for domain [%02d] on %p(%d)", target->id, (value*)req->obj, req->field);
     value local =
       caml_addrmap_lookup(&target->remembered_set->promotion_rev, req->obj);
     Op_val(local)[req->field] = req->val;

--- a/byterun/platform.h
+++ b/byterun/platform.h
@@ -126,8 +126,9 @@ INLINE void atomic_cas_strong(atomic_uintnat* p, uintnat vold, uintnat vnew) {
 
 
 
+
 typedef pthread_mutex_t caml_plat_mutex;
-#define caml_plat_mutex_init(m) pthread_mutex_init(m, 0);
+#define caml_plat_mutex_init(m) pthread_mutex_init(m,0)
 #define caml_plat_lock pthread_mutex_lock
 #define caml_plat_try_lock(l) (pthread_mutex_trylock(l) == 0)
 #define caml_plat_unlock pthread_mutex_unlock


### PR DESCRIPTION
Since the `is_main` field was always 0, lock on `pool_freelist` was used without being uninitialized [1] leading to mutual exclusion failures. This was the cause of strange behaviors with pools such as cycles, and the source of segfaults in #15. This in combination with the PR #18 fixes #15.

This PR additionally sets the owner of released pools to be NULL in order to better track ownership.

[1] https://github.com/ocamllabs/ocaml-multicore/blob/821b653592ddca80278e82903100deeb5934b6c2/byterun/shared_heap.c#L84