### PR TITLE
Reset realloc'ed stack to avoid useless scanning.

### DIFF
--- a/byterun/fiber.c
+++ b/byterun/fiber.c
@@ -381,6 +381,14 @@ void caml_realloc_stack(asize_t required_space, value* saved_vals, int nsaved)
   }
 
   load_stack(new_stack);
+
+  /* Reset old stack */
+  Stack_sp(old_stack) = 0;
+  Stack_dirty_domain(old_stack) = 0;
+  Stack_handle_value(old_stack) = Val_long(0);
+  Stack_handle_exception(old_stack) = Val_long(0);
+  Stack_handle_effect(old_stack) = Val_long(0);
+
   CAMLreturn0;
 }
 

--- a/byterun/fiber.c
+++ b/byterun/fiber.c
@@ -376,7 +376,6 @@ void caml_realloc_stack(asize_t required_space, value* saved_vals, int nsaved)
   Stack_dirty_domain(new_stack) = 0;
   if (Stack_dirty_domain(old_stack)) {
     Assert (Stack_dirty_domain(old_stack) == caml_domain_self());
-    Stack_dirty_domain(old_stack) = 0;
     dirty_stack(new_stack);
   }
 


### PR DESCRIPTION
When a stack is realloc’ed, it is worth resetting the old stack contents to avoid space leaks. Since the stack is being realloc’ed, it is currently running. Hence, no references to this stack from other heap objects are “useful”; such a reference cannot be used to resume the continuation represented by this stack, which would violate the one-shotness. If the program carries around such references, it would constitute a space leak. Resetting the stack avoids the need for the GC to scan the old copy of the realloc'ed stack.