### PR TITLE
Do not initialize caml_parent_stack in caml_interprete

### DIFF
--- a/byterun/interp.c
+++ b/byterun/interp.c
@@ -268,7 +268,6 @@ value caml_interprete(code_t prog, asize_t prog_size)
   caml_external_raise = &exception_ctx;
 
   caml_trap_sp_off = 1;
-  caml_parent_stack = Val_long(0);
 
   sp = caml_extern_sp;
   pc = prog;


### PR DESCRIPTION
If caml_parent_stack was reset to NULL, then the link between parent and child fiber is severed if the child performs a C call which in turn calls back into OCaml. See the example here [1]. Build the example as `make COMP=MULTI`. With the fix you should see:

    [Caml] Call caml_to_c
    [C] Enter caml_to_c
    [C] Call c_to_caml
    [Caml] Enter c_to_caml
    [Caml] Handle effect E. Continuing..
    [Caml] Leave c_to_caml
    [C] Return from c_to_caml
    [C] Leave caml_to_c
    [Caml] Return from caml_to_c

and without it:

    [Caml] Call caml_to_c
    [C] Enter caml_to_c
    [C] Call c_to_caml
    [Caml] Enter c_to_caml
    Fatal error: exception Unhandled