### PR TITLE
Bvars

### DIFF
--- a/byterun/Makefile.common
+++ b/byterun/Makefile.common
@@ -29,7 +29,7 @@ PRIMS=\
   alloc.c array.c compare.c extern.c floats.c gc_ctrl.c hash.c \
   intern.c interp.c ints.c io.c lexing.c md5.c meta.c obj.c parsing.c \
   signals.c str.c sys.c terminfo.c callback.c weak.c finalise.c fiber.c \
-  dynlink.c backtrace.c domain.c
+  dynlink.c backtrace.c domain.c memory.c
 
 PUBLIC_INCLUDES=\
   alloc.h callback.h config.h custom.h fail.h hash.h intext.h \

--- a/byterun/memory.c
+++ b/byterun/memory.c
@@ -8,6 +8,7 @@
 #include "domain.h"
 #include "addrmap.h"
 #include "roots.h"
+#include "alloc.h"
 
 static void shared_heap_write_barrier(value obj, int field, value val)
 {
@@ -300,4 +301,112 @@ static int promoted_cas(value obj, int field, value oldval, value newval)
       shared_heap_write_barrier(obj, field, newval);
     return req.success;
   }
+}
+
+#define BVAR_EMPTY      0x10000
+#define BVAR_OWNER_MASK 0x0ffff
+
+CAMLprim value caml_bvar_create(value v)
+{
+  CAMLparam1(v);
+
+  value bv = caml_alloc_small(2, 0);
+  Init_field(bv, 0, v);
+  Init_field(bv, 1, Val_long(caml_domain_self()->id));
+
+  CAMLreturn (bv);
+}
+
+struct bvar_transfer_req {
+  value bv;
+  int new_owner;
+};
+
+static void handle_bvar_transfer(struct domain* self, void *reqp)
+{
+  struct bvar_transfer_req *req = reqp;
+  value bv = req->bv;
+  intnat stat = Long_val(Op_val(bv)[1]);
+  int owner = stat & BVAR_OWNER_MASK;
+
+  if (owner == self->id) {
+    caml_gc_log("Handling bvar transfer [%02d] -> [%02d]", owner, req->new_owner);
+    Op_val(bv)[0] = caml_promote(self, Op_val(bv)[0]);
+    Op_val(bv)[1] = Val_long((stat & ~BVAR_OWNER_MASK) | req->new_owner);
+  } else {
+    /* Race: by the time we handled the RPC, this bvar was
+       no longer owned by us. We recursively forward the
+       request before returning: this guarantees progress
+       since in the worst case all domains are tied up
+       and there's nobody left to win the race */
+    caml_gc_log("Stale bvar transfer [%02d] -> [%02d] ([%02d] got there first)",
+                self->id, req->new_owner, owner);
+    caml_domain_rpc(caml_domain_of_id(owner), &handle_bvar_transfer, req);
+  }
+}
+
+/* Get a bvar's status, transferring it if necessary */
+static intnat bvar_status(value bv)
+{
+  while (1) {
+    intnat stat = Long_val(Op_val(bv)[1]);
+    int owner = stat & BVAR_OWNER_MASK;
+    if (owner == caml_domain_self()->id)
+      return stat;
+
+    /* Otherwise, need to transfer */
+    struct bvar_transfer_req req = {bv, caml_domain_self()->id};
+    caml_gc_log("Transferring bvar from domain [%02d]", owner);
+    caml_domain_rpc(caml_domain_of_id(owner), &handle_bvar_transfer, &req);
+
+    /* We may not have ownership at this point: we might have just
+       handled an incoming ownership request right after we got
+       ownership. So, we have to loop. */
+  }
+}
+
+CAMLprim value caml_bvar_take(value bv)
+{
+  /* bvar operations need to operate on the promoted copy */
+  if (Is_young(bv) && Is_promoted_hd(Hd_val(bv))) {
+    bv = caml_addrmap_lookup(&caml_remembered_set.promotion, bv);
+  }
+
+  intnat stat = bvar_status(bv);
+  if (stat & BVAR_EMPTY) caml_raise_not_found();
+  CAMLassert(stat == caml_domain_self()->id);
+
+  value v = Op_val(bv)[0];
+  Op_val(bv)[0] = Val_unit;
+  Op_val(bv)[1] = Val_long(caml_domain_self()->id | BVAR_EMPTY);
+
+  return v;
+}
+
+CAMLprim value caml_bvar_put(value bv, value v)
+{
+  /* bvar operations need to operate on the promoted copy */
+  if (Is_young(bv) && Is_promoted_hd(Hd_val(bv))) {
+    bv = caml_addrmap_lookup(&caml_remembered_set.promotion, bv);
+  }
+
+  intnat stat = bvar_status(bv);
+  if (!(stat & BVAR_EMPTY)) caml_invalid_argument("Put to a full bvar");
+  CAMLassert(stat == (caml_domain_self()->id | BVAR_EMPTY));
+
+  if (!Is_young(bv)) shared_heap_write_barrier(bv, 0, v);
+  Op_val(bv)[0] = v;
+  Op_val(bv)[1] = Val_long(caml_domain_self()->id);
+
+  return Val_unit;
+}
+
+CAMLprim value caml_bvar_is_empty(value bv)
+{
+  /* bvar operations need to operate on the promoted copy */
+  if (Is_young(bv) && Is_promoted_hd(Hd_val(bv))) {
+    bv = caml_addrmap_lookup(&caml_remembered_set.promotion, bv);
+  }
+
+  return Val_int((Long_val(Op_val(bv)[1]) & BVAR_EMPTY) != 0);
 }

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -1,3 +1,12 @@
 external spawn : (unit -> unit) -> unit = "caml_domain_spawn"
 
 external self : unit -> int = "caml_ml_domain_id"
+
+
+module BVar = struct
+  type 'a t
+  external create : 'a -> 'a t = "caml_bvar_create"
+  external take : 'a t -> 'a = "caml_bvar_take"
+  external put : 'a t -> 'a -> unit = "caml_bvar_put"
+  external is_empty : 'a t -> bool = "caml_bvar_is_empty"
+end

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -1,3 +1,34 @@
 val spawn : (unit -> unit) -> unit
 
 val self : unit -> int
+
+module BVar : sig
+  (* A bvar is a reference, either empty or full,
+     supporting atomic "take" and "put" operations.
+
+     These are biased towards one domain. So, take
+     and put operations by the same domain will be
+     fast, while contended operations will be very
+     slow. *)
+  type 'a t
+
+  (* Create an (initially full) bvar *)
+  external create : 'a -> 'a t = "caml_bvar_create"
+
+  (* Remove the value from a bvar, leaving it empty.
+     Raises Not_found if the bvar is already empty.
+     If several domains concurrently attempt to take,
+     exactly one of them will succeed *)
+  external take : 'a t -> 'a = "caml_bvar_take"
+
+  (* Put a value into an empty bvar, leaving it full.
+     Raises Invalid_argument if the bvar is already full.
+     If several domains concurrently attempt to put,
+     exactly one of them will succeed *)
+  external put : 'a t -> 'a -> unit = "caml_bvar_put"
+
+  (* Check whether a bvar is empty. Being nonempty/empty is
+     no guarantee that a take/put will succeed: an intervening
+     take/put may occur *)
+  external is_empty : 'a t -> bool = "caml_bvar_is_empty"
+end


### PR DESCRIPTION
Implementation of bvars, used to represent continuations.

Here's a test for mutual exclusion:

https://gist.github.com/stedolan/4ec23cbdc2473de2adbd

Fixes a bug in fibers - due to use of caml_modify, the old continuation representation doesn't have proper mutual exclusion.