### PR TITLE
Prevent overlap between adjacent domains' TLS and minor heap areas

### DIFF
--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -212,19 +212,22 @@ void caml_init_domains(uintnat minor_size) {
 
   for (i = 0; i < Max_domains; i++) {
     struct dom_internal* dom = &all_domains[i];
+    uintnat domain_minor_heap_base;
+
     caml_plat_mutex_init(&dom->roots_lock);
     dom->running = 0;
     dom->state.id = i;
 
-    dom->tls_area = minor_heaps_base +
+    domain_minor_heap_base = minor_heaps_base +
       (uintnat)(1 << Minor_heap_align_bits) * (uintnat)i;
+    dom->tls_area = domain_minor_heap_base;
     dom->tls_area_end =
       caml_mem_round_up_pages(dom->tls_area +
                               sizeof(struct caml_domain_state));
     dom->minor_heap_area = /* skip guard page */
       caml_mem_round_up_pages(dom->tls_area_end + 1);
     dom->minor_heap_area_end =
-      dom->minor_heap_area + (1 << Minor_heap_align_bits);
+      domain_minor_heap_base + (1 << Minor_heap_align_bits);
   }
 
 


### PR DESCRIPTION
Without the fix, the minor heap area of a domain overlaps with the TLS area of the subsequent domain. For example, here is the debug output from `caml_init_domains`:

```
[-1] Initial stack limit: 8192k bytes
[-1] caml_init_domains[0]: tls_start=0x7f9200000000 tls_end=0x7f9200001000 minor_start=0x7f9200002000 minor_end=0x7f9201002000
[-1] caml_init_domains[1]: tls_start=0x7f9201000000 tls_end=0x7f9201001000 minor_start=0x7f9201002000 minor_end=0x7f9202002000
[-1] caml_init_domains[2]: tls_start=0x7f9202000000 tls_end=0x7f9202001000 minor_start=0x7f9202002000 minor_end=0x7f9203002000
[-1] caml_init_domains[3]: tls_start=0x7f9203000000 tls_end=0x7f9203001000 minor_start=0x7f9203002000 minor_end=0x7f9204002000
[-1] caml_init_domains[4]: tls_start=0x7f9204000000 tls_end=0x7f9204001000 minor_start=0x7f9204002000 minor_end=0x7f9205002000
[-1] caml_init_domains[5]: tls_start=0x7f9205000000 tls_end=0x7f9205001000 minor_start=0x7f9205002000 minor_end=0x7f9206002000
[-1] caml_init_domains[6]: tls_start=0x7f9206000000 tls_end=0x7f9206001000 minor_start=0x7f9206002000 minor_end=0x7f9207002000
[-1] caml_init_domains[7]: tls_start=0x7f9207000000 tls_end=0x7f9207001000 minor_start=0x7f9207002000 minor_end=0x7f9208002000
[-1] caml_init_domains[8]: tls_start=0x7f9208000000 tls_end=0x7f9208001000 minor_start=0x7f9208002000 minor_end=0x7f9209002000
```

observe that the end of the minor heap area of domain `i` overlaps with the tls area of domain `i+1`. The fix prevents overlap by correctly calculating the end of the minor heap area for a domain. 