### PR TITLE
Handle mark stack overflow by postponing marking of some pools.

### DIFF
--- a/byterun/caml/addrmap.h
+++ b/byterun/caml/addrmap.h
@@ -14,10 +14,11 @@ struct addrmap {
 
 #define ADDRMAP_INIT {0,0}
 
-
+int caml_addrmap_contains(struct addrmap* t, value v);
 value caml_addrmap_lookup(struct addrmap* t, value v);
 
 #define ADDRMAP_NOT_PRESENT ((value)(0))
+#define ADDRMAP_INVALID_KEY ((value)(0))
 
 value* caml_addrmap_insert_pos(struct addrmap* t, value v);
 
@@ -27,5 +28,52 @@ void caml_addrmap_insert(struct addrmap* t, value k, value v);
 void caml_addrmap_clear(struct addrmap* t);
 
 void caml_addrmap_iter(struct addrmap* t, void (*f)(value, value));
+
+/* iteration */
+typedef uintnat addrmap_iterator;
+static inline addrmap_iterator caml_addrmap_iter_ok(struct addrmap* t, addrmap_iterator i)
+{
+  if (i < t->size) {
+    Assert(t->entries[i].key != ADDRMAP_INVALID_KEY);
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+static inline addrmap_iterator caml_addrmap_next(struct addrmap* t, addrmap_iterator i)
+{
+  if (!t->entries) return (uintnat)(-1);
+  i++;
+  while (i < t->size && t->entries[i].key == ADDRMAP_INVALID_KEY) {
+    i++;
+  }
+  caml_addrmap_iter_ok(t, i); /* just for assert-checks */
+  return i;
+}
+
+static inline value caml_addrmap_iter_key(struct addrmap* t, addrmap_iterator i)
+{
+  Assert(caml_addrmap_iter_ok(t, i));
+  return t->entries[i].key;
+}
+
+static inline value caml_addrmap_iter_value(struct addrmap* t, addrmap_iterator i)
+{
+  Assert(caml_addrmap_iter_ok(t, i));
+  return t->entries[i].value;
+}
+
+static inline value* caml_addrmap_iter_val_pos(struct addrmap* t, addrmap_iterator i)
+{
+  Assert(caml_addrmap_iter_ok(t, i));
+  return &t->entries[i].value;
+}
+
+static inline addrmap_iterator caml_addrmap_iterator(struct addrmap* t)
+{
+  return caml_addrmap_next(t, (uintnat)(-1));
+}
+
 
 #endif

--- a/byterun/caml/shared_heap.h
+++ b/byterun/caml/shared_heap.h
@@ -1,8 +1,10 @@
 #ifndef CAML_SHARED_HEAP_H
 #define CAML_SHARED_HEAP_H
 
-struct caml_heap_state;
+#include "roots.h"
 
+struct caml_heap_state;
+struct pool;
 
 struct caml_heap_state* caml_init_shared_heap();
 
@@ -10,11 +12,14 @@ value* caml_shared_try_alloc(struct caml_heap_state*, mlsize_t wosize, tag_t tag
 
 uintnat caml_heap_size(struct caml_heap_state*);
 
+struct pool* caml_pool_of_shared_block(value v);
 struct domain* caml_owner_of_shared_block(value v);
 
 void caml_shared_unpin(value v);
 
 int caml_mark_object(value);
+
+void caml_redarken_pool(struct pool*, scanning_action);
 
 intnat caml_sweep(struct caml_heap_state*, intnat);
 

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -9,8 +9,15 @@
 #include "caml/globroots.h"
 #include "caml/domain.h"
 #include "caml/fiber.h"
+#include "caml/addrmap.h"
+#include "caml/platform.h"
 
-#define MARK_STACK_SIZE (1 << 20)
+/*
+  FIXME: This is far too small. A better policy would be to match
+  OCaml's: allow the mark stack to grow to major_heap / 32. However,
+  leaving it small for now means the overflow code gets more testing.
+*/
+#define MARK_STACK_SIZE (1 << 14)
 
 typedef enum { Phase_idle, Phase_marking } gc_phase_t;
 
@@ -21,11 +28,6 @@ static __thread gc_phase_t gc_phase = Phase_idle;
 static __thread uintnat stat_blocks_marked = 0;
 
 uintnat caml_percent_free = Percent_free_def;
-
-void caml_init_major_gc() {
-  caml_domain_state->mark_stack = caml_stat_alloc(MARK_STACK_SIZE * sizeof(value));
-  caml_domain_state->mark_stack_count = 0;
-}
 
 static uintnat default_slice_budget() {
   /*
@@ -71,16 +73,32 @@ static uintnat default_slice_budget() {
   //return 1ll << 50;
 }
 
+static void mark_stack_prune();
+static struct pool* find_pool_to_rescan();
+
+#define Is_markable(v) (Is_block(v) && !Is_minor(v))
+
 static void mark_stack_push(value v) {
   Assert(Is_block(v));
   if (caml_domain_state->mark_stack_count >= MARK_STACK_SIZE)
-    caml_fatal_error("mark stack overflow");
+    mark_stack_prune();
   caml_domain_state->mark_stack[caml_domain_state->mark_stack_count++] = v;
 }
 
+/* to fit scanning_action */
+static void mark_stack_push_act(value v, value* ignored) {
+  mark_stack_push(v);
+}
+
 static int mark_stack_pop(value* ret) {
-  if (caml_domain_state->mark_stack_count == 0)
-    return 0;
+  if (caml_domain_state->mark_stack_count == 0) {
+    struct pool* p = find_pool_to_rescan();
+    if (p) {
+      caml_redarken_pool(p, &mark_stack_push_act);
+    } else {
+      return 0;
+    }
+  }
   *ret = caml_domain_state->mark_stack[--caml_domain_state->mark_stack_count];
   return 1;
 }
@@ -90,7 +108,6 @@ static int mark_stack_pop(value* ret) {
 #else
 #define Is_markable(v) (Is_block(v) && !Is_minor(v))
 #endif
-
 
 static value mark_normalise(value v) {
   Assert(Is_markable(v));
@@ -248,4 +265,177 @@ void caml_finish_marking_domain (struct domain* domain) {
   caml_domain_state->allocated_words = 0;
   caml_restore_stack_gc();
   //caml_gc_log("caml_finish_marking_domain(1): domain=%d", domain->id);
+}
+
+static struct pool** pools_to_rescan;
+static int pools_to_rescan_count;
+static int pools_to_rescan_len;
+static caml_plat_mutex pools_to_rescan_lock;
+
+static struct pool* find_pool_to_rescan()
+{
+  struct pool* p;
+  caml_plat_lock(&pools_to_rescan_lock);
+  if (pools_to_rescan_count > 0) {
+    p = pools_to_rescan[--pools_to_rescan_count];
+    caml_gc_log("Redarkening pool %p (%d others left)", p, pools_to_rescan_count);
+  } else {
+    p = 0;
+  }
+  caml_plat_unlock(&pools_to_rescan_lock);
+  return p;
+}
+
+
+
+struct pool_count {
+  struct pool* pool;
+  int occurs;
+};
+
+static int pool_count_cmp(const void* a, const void* b)
+{
+  const struct pool_count* p = a;
+  const struct pool_count* q = b;
+  return p->occurs - q->occurs;
+}
+
+static void mark_stack_prune ()
+{
+  struct addrmap t = ADDRMAP_INIT;
+  int count = 0, entry;
+  addrmap_iterator i;
+  uintnat mark_stack_count = caml_domain_state->mark_stack_count;
+  value* mark_stack = caml_domain_state->mark_stack;
+
+  /* space used by the computations below */
+  uintnat table_max = mark_stack_count / 100;
+  if (table_max < 1000) table_max = 1000;
+
+  /* amount of space we want to free up */
+  int entries_to_free = (uintnat)(mark_stack_count * 0.20);
+
+  /* We compress the mark stack by removing all of the objects from a
+     subset of pools, which are rescanned later. For efficiency, we
+     want to select those pools which occur most frequently, so that
+     we need to rescan as few pools as possible. However, we do not
+     have space to build a complete histogram.
+
+     Using ~1% of the mark stack's space, we can find all of the
+     elements that occur at least 100 times using the Misra-Gries
+     heavy hitter algorithm (see J. Misra and D. Gries, "Finding
+     repeated elements", 1982). */
+
+  for (entry = 0; entry < mark_stack_count; entry++) {
+    struct pool* pool = caml_pool_of_shared_block(mark_stack[entry]);
+    if (!pool) continue;
+    value p = (value)pool;
+    if (caml_addrmap_contains(&t, p)) {
+      /* if it's already present, increase the count */
+      (*caml_addrmap_insert_pos(&t, p)) ++;
+    } else if (count < table_max) {
+      /* if there's space, insert it with count 1 */
+      *caml_addrmap_insert_pos(&t, p) = 1;
+      count++;
+    } else {
+      /* otherwise, decrease all entries by 1 */
+      struct addrmap s = ADDRMAP_INIT;
+      int scount = 0;
+      for (i = caml_addrmap_iterator(&t);
+           caml_addrmap_iter_ok(&t, i);
+           i = caml_addrmap_next(&t, i)) {
+        value k = caml_addrmap_iter_key(&t, i);
+        value v = caml_addrmap_iter_value(&t, i);
+        if (v > 1) {
+          *caml_addrmap_insert_pos(&s, k) = v - 1;
+          scount++;
+        }
+      }
+      caml_addrmap_clear(&t);
+      t = s;
+      count = scount;
+    }
+  }
+
+  /* t now contains all pools that occur at least 100 times.
+     If no pools occur at least 100 times, t is some arbitrary subset of pools.
+     Next, we get an accurate count of the occurrences of the pools in t */
+
+  for (i = caml_addrmap_iterator(&t);
+       caml_addrmap_iter_ok(&t, i);
+       i = caml_addrmap_next(&t, i)) {
+    *caml_addrmap_iter_val_pos(&t, i) = 0;
+  }
+  for (entry = 0; entry < mark_stack_count; entry++) {
+    value p = (value)caml_pool_of_shared_block(mark_stack[entry]);
+    if (p && caml_addrmap_contains(&t, p))
+      (*caml_addrmap_insert_pos(&t, p))++;
+  }
+
+  /* Next, find a subset of those pools that covers enough entries */
+
+  struct pool_count* pools = caml_stat_alloc(count * sizeof(struct pool_count));
+  int pos = 0;
+  for (i = caml_addrmap_iterator(&t);
+       caml_addrmap_iter_ok(&t, i);
+       i = caml_addrmap_next(&t, i)) {
+    struct pool_count* p = &pools[pos++];
+    p->pool = (struct pool*)caml_addrmap_iter_key(&t, i);
+    p->occurs = (int)caml_addrmap_iter_value(&t, i);
+  }
+  Assert(pos == count);
+  caml_addrmap_clear(&t);
+
+  qsort(pools, count, sizeof(struct pool_count), &pool_count_cmp);
+
+  int start = count, total = 0;
+  while (start > 0 && total < entries_to_free) {
+    start--;
+    total += pools[start].occurs;
+  }
+
+
+
+  for (i = start; i < count; i++) {
+    *caml_addrmap_insert_pos(&t, (value)pools[i].pool) = 1;
+  }
+  int out = 0;
+  for (entry = 0; entry < mark_stack_count; entry++) {
+    value v = mark_stack[entry];
+    value p = (value)caml_pool_of_shared_block(v);
+    if (!(p && caml_addrmap_contains(&t, p))) {
+      mark_stack[out++] = v;
+    }
+  }
+  caml_domain_state->mark_stack_count = out;
+
+  caml_gc_log("Mark stack overflow. Postponing %d pools (%.1f%%, leaving %d).",
+              count-start, 100. * (double)total / (double)mark_stack_count,
+              (int)caml_domain_state->mark_stack_count);
+
+
+  /* Add the pools to rescan to the global list.
+
+     This must be done after the mark stack is filtered, since other
+     threads race to remove pools from the global list. As soon as
+     pools_to_rescan_lock is released, we cannot rely on pools being
+     in the global list. */
+
+  caml_plat_lock(&pools_to_rescan_lock);
+  for (i = start; i < count; i++) {
+    if (pools_to_rescan_count == pools_to_rescan_len) {
+      pools_to_rescan_len = pools_to_rescan_len * 2 + 128;
+      pools_to_rescan =
+        caml_stat_resize(pools_to_rescan, pools_to_rescan_len * sizeof(struct pool*));
+    }
+    pools_to_rescan[pools_to_rescan_count++] = pools[i].pool;
+  }
+  caml_plat_unlock(&pools_to_rescan_lock);
+}
+
+
+void caml_init_major_gc() {
+  caml_domain_state->mark_stack = caml_stat_alloc(MARK_STACK_SIZE * sizeof(value));
+  caml_domain_state->mark_stack_count = 0;
+  caml_plat_mutex_init(&pools_to_rescan_lock);
 }


### PR DESCRIPTION
If the mark stack overflows, find some pools that occur frequently in the mark stack and mark those as needing rescanning.