### PR TITLE
Alloc API changes (1/2)

### DIFF
--- a/byterun/alloc.c
+++ b/byterun/alloc.c
@@ -25,9 +25,6 @@
 #include "caml/fiber.h"
 #include "caml/domain.h"
 
-#define Setup_for_gc
-#define Restore_after_gc
-
 CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
 {
   value result;
@@ -38,7 +35,7 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
   if (wosize == 0){
     result = Atom (tag);
   }else if (wosize <= Max_young_wosize){
-    Alloc_small (result, wosize, tag);
+    Alloc_small (result, wosize, tag, { caml_handle_gc_interrupt(); });
     if (tag < No_scan_tag){
       for (i = 0; i < wosize; i++) Init_field (result, i, Val_unit);
     }
@@ -60,7 +57,7 @@ CAMLexport value caml_alloc_small (mlsize_t wosize, tag_t tag)
   Assert (wosize > 0);
   Assert (wosize <= Max_young_wosize);
   Assert (tag < 256);
-  Alloc_small (result, wosize, tag);
+  Alloc_small (result, wosize, tag, { caml_handle_gc_interrupt(); });
   return result;
 }
 

--- a/byterun/array.c
+++ b/byterun/array.c
@@ -49,11 +49,7 @@ CAMLprim value caml_array_get_float(value array, value index)
   if (idx < 0 || idx >= Wosize_val(array) / Double_wosize)
     caml_array_bound_error();
   d = Double_field(array, idx);
-#define Setup_for_gc
-#define Restore_after_gc
-  Alloc_small(res, Double_wosize, Double_tag);
-#undef Setup_for_gc
-#undef Restore_after_gc
+  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt(); });
   Store_double_val(res, d);
   return res;
 }
@@ -97,11 +93,7 @@ CAMLprim value caml_array_unsafe_get_float(value array, value index)
   value res;
 
   d = Double_field(array, Long_val(index));
-#define Setup_for_gc
-#define Restore_after_gc
-  Alloc_small(res, Double_wosize, Double_tag);
-#undef Setup_for_gc
-#undef Restore_after_gc
+  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt(); });
   Store_double_val(res, d);
   return res;
 }
@@ -142,11 +134,7 @@ CAMLprim value caml_make_float_vect(value len)
   if (wosize == 0)
     return Atom(0);
   else if (wosize <= Max_young_wosize){
-#define Setup_for_gc
-#define Restore_after_gc
-    Alloc_small (result, wosize, Double_array_tag);
-#undef Setup_for_gc
-#undef Restore_after_gc
+    Alloc_small (result, wosize, Double_array_tag, { caml_handle_gc_interrupt(); });
   }else if (wosize > Max_wosize)
     caml_invalid_argument("Array.make_float");
   else {

--- a/byterun/caml/alloc.h
+++ b/byterun/caml/alloc.h
@@ -26,6 +26,21 @@ extern "C" {
 #endif
 
 CAMLextern value caml_alloc (mlsize_t, tag_t);
+CAMLextern value caml_alloc_N(mlsize_t, tag_t, ...);
+CAMLextern value caml_alloc_1(tag_t, value);
+CAMLextern value caml_alloc_2(tag_t, value, value);
+CAMLextern value caml_alloc_3(tag_t, value, value, value);
+CAMLextern value caml_alloc_4(tag_t, value, value, value, value);
+CAMLextern value caml_alloc_5(tag_t, value, value, value, value,
+                              value);
+CAMLextern value caml_alloc_6(tag_t, value, value, value, value,
+                              value, value);
+CAMLextern value caml_alloc_7(tag_t, value, value, value, value,
+                              value, value, value);
+CAMLextern value caml_alloc_8(tag_t, value, value, value, value,
+                              value, value, value, value);
+CAMLextern value caml_alloc_9(tag_t, value, value, value, value,
+                              value, value, value, value, value);
 CAMLextern value caml_alloc_small (mlsize_t, tag_t);
 CAMLextern value caml_alloc_tuple (mlsize_t);
 CAMLextern value caml_alloc_string (mlsize_t);  /* size in bytes */

--- a/byterun/caml/domain.h
+++ b/byterun/caml/domain.h
@@ -18,9 +18,13 @@ struct domain {
   uintnat* mark_stack_count;
 };
 
-#define Caml_check_gc_interrupt() \
-  ((uintnat)caml_domain_state->young_ptr < caml_domain_state->young_limit)
-
+#ifdef __GNUC__
+  #define Caml_check_gc_interrupt(dom_st) \
+    __builtin_expect(((uintnat)(dom_st)->young_ptr < (dom_st)->young_limit), 0)
+#else
+  #define Caml_check_gc_interrupt(dom_st) \
+    ((uintnat)(dom_st)->young_ptr < (dom_st)->young_limit)
+#endif
 asize_t caml_norm_minor_heap_size (intnat);
 void caml_reallocate_minor_heap(asize_t);
 

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -126,8 +126,12 @@ void caml_gc_log (char *, ...)
 #define Debug_tag(x) (0xD700D7D7D700D6D7ul \
                       | ((uintnat) (x) << 16) \
                       | ((uintnat) (x) << 48))
+#define Is_debug_tag(x) \
+  (((x) & 0xD700D7D7D700D6D7ul) == 0xD700D7D7D700D6D7ul)
 #else
 #define Debug_tag(x) (0xD700D6D7ul | ((uintnat) (x) << 16))
+#define Is_debug_tag(x) \
+  (((x) & 0xD700D6D7ul) == 0xD700D6D7ul)
 #endif /* ARCH_SIXTYFOUR */
 
 /*

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -60,11 +60,7 @@ CAMLexport value caml_copy_double(double d)
 {
   value res;
 
-#define Setup_for_gc
-#define Restore_after_gc
-  Alloc_small(res, Double_wosize, Double_tag);
-#undef Setup_for_gc
-#undef Restore_after_gc
+  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt(); });
   Store_double_val(res, d);
   return res;
 }

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -126,6 +126,7 @@ static intnat mark(value initial, intnat budget) {
       for (i = 0; i < Wosize_hd(hd_v); i++) {
         value child = Op_val(v)[i];
         // caml_gc_log ("mark: v=%p i=%u child=%p",(value*)v,i,(value*)child);
+        Assert(!Is_debug_tag(child));
         if (Is_markable(child)) {
           child = mark_normalise(child);
           if (caml_mark_object(child)) {


### PR DESCRIPTION
Add the convenience functions `caml_alloc_<n>`, and simplify how `Alloc_small` works.