### PR TITLE
Alloc API change (3/4)

### DIFF
--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2417,14 +2417,14 @@ let compunit size ulam =
 (*
 CAMLprim value caml_cache_public_method (value meths, value tag, value *cache)
 {
-  int li = 3, hi = Field(meths,0), mi;
+  int li = 3, hi = Field_imm(meths,0), mi;
   while (li < hi) { // no need to check the 1st time
     mi = ((li+hi) >> 1) | 1;
-    if (tag < Field(meths,mi)) hi = mi-2;
+    if (tag < Field_imm(meths,mi)) hi = mi-2;
     else li = mi;
   }
   *cache = (li-3)*sizeof(value)+1;
-  return Field (meths, li-1);
+  return Field_imm (meths, li-1);
 }
 *)
 

--- a/asmrun/backtrace.c
+++ b/asmrun/backtrace.c
@@ -385,7 +385,7 @@ CAMLprim value caml_get_exception_backtrace(value unit)
 
   arr = caml_alloc(Wosize_val(backtrace), 0);
   for (i = 0; i < Wosize_val(backtrace); i++) {
-    Store_field(arr, i, caml_convert_raw_backtrace_slot(Field(backtrace, i)));
+    Store_field(arr, i, caml_convert_raw_backtrace_slot(Field_imm(backtrace, i)));
   }
 
   res = caml_alloc_small(1, 0); caml_initialize_field(res, 0, arr); /* Some */

--- a/asmrun/fail.c
+++ b/asmrun/fail.c
@@ -102,8 +102,7 @@ void caml_raise_with_args(value tag, int nargs, value args[])
   CAMLlocal1 (bucket);
   int i;
 
-  Assert(1 + nargs <= Max_young_wosize);
-  bucket = caml_alloc_small (1 + nargs, 0);
+  bucket = caml_alloc (1 + nargs, 0);
   caml_initialize_field(bucket, 0, tag);
   for (i = 0; i < nargs; i++) caml_initialize_field(bucket, 1 + i, args[i]);
   caml_raise(bucket);

--- a/asmrun/natdynlink.c
+++ b/asmrun/natdynlink.c
@@ -29,7 +29,7 @@
 
 #define Handle_val(v) (*((void **) (v)))
 static value Val_handle(void* handle) {
-  value res = caml_alloc_small(1, Abstract_tag);
+  value res = caml_alloc(1, Abstract_tag);
   Handle_val(res) = handle;
   return res;
 }

--- a/byterun/Makefile
+++ b/byterun/Makefile
@@ -13,8 +13,8 @@
 
 include Makefile.common
 
-CFLAGS=-DCAML_NAME_SPACE $(BYTECCCOMPOPTS) $(IFLEXDIR)
-DFLAGS=-DCAML_NAME_SPACE -g -DDEBUG $(BYTECCCOMPOPTS) $(IFLEXDIR) -Werror-implicit-function-declaration
+CFLAGS=-DCAML_NAME_SPACE $(BYTECCCOMPOPTS) $(IFLEXDIR) -ggdb
+DFLAGS=-DCAML_NAME_SPACE -ggdb -DDEBUG $(BYTECCCOMPOPTS) $(IFLEXDIR) -Werror-implicit-function-declaration
 
 OBJS=$(COMMONOBJS) $(UNIX_OR_WIN32).o main.o
 DOBJS=$(OBJS:.o=.d.o) instrtrace.d.o

--- a/byterun/alloc.c
+++ b/byterun/alloc.c
@@ -46,11 +46,13 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
         Op_val(result)[i] = init_val;
       }
     }
+
+    if (tag == Stack_tag) Stack_sp(result) = 0;
   }else{
     result = caml_alloc_shr (wosize, tag);
-    if (tag == Stack_tag) Stack_sp(result) = 0;
-    result = caml_check_urgent_gc (result);
+    result = caml_check_urgent_gc(result);
   }
+
   return result;
 }
 
@@ -226,8 +228,8 @@ CAMLexport int caml_convert_flag_list(value list, const int *flags)
   int res;
   res = 0;
   while (list != Val_int(0)) {
-    res |= flags[Int_val(Field(list, 0))];
-    list = Field(list, 1);
+    res |= flags[Int_field(list, 0)];
+    list = Field_imm(list, 1);
   }
   return res;
 }
@@ -252,6 +254,8 @@ CAMLprim value caml_alloc_dummy_float (value size)
 
 CAMLprim value caml_update_dummy(value dummy, value newval)
 {
+  CAMLparam2(dummy, newval);
+  CAMLlocal1(x);
   mlsize_t size, i;
   tag_t tag;
 
@@ -268,10 +272,11 @@ CAMLprim value caml_update_dummy(value dummy, value newval)
     }
   }else{
     for (i = 0; i < size; i++){
-      caml_modify_field (dummy, i, Field(newval, i));
+      caml_read_field(newval, i, &x);
+      caml_modify_field (dummy, i, x);
     }
   }
-  return Val_unit;
+  CAMLreturn (Val_unit);
 }
 
 

--- a/byterun/backtrace.c
+++ b/byterun/backtrace.c
@@ -263,9 +263,9 @@ static void read_debug_info()
     evl = caml_input_val(chan);
     caml_input_val(chan); // Skip the list of absolute directory names
     /* Relocate events in event list */
-    for (l = evl; l != Val_int(0); l = Field(l, 1)) {
-      value ev = Field(l, 0);
-      Store_field(ev, EV_POS, Val_long(Long_val(Field(ev, EV_POS)) + orig));
+    for (l = evl; l != Val_int(0); l = Field_imm(l, 1)) {
+      value ev = Field_imm(l, 0);
+      Store_field(ev, EV_POS, Val_long(Long_field(ev, EV_POS) + orig));
       n_events++;
     }
     /* Record event list */
@@ -281,16 +281,16 @@ static void read_debug_info()
 
   j = 0;
   for (i = 0; i < num_events; i++) {
-    for (l = Field(events_heap, i); l != Val_int(0); l = Field(l, 1)) {
+    for (l = Field_imm(events_heap, i); l != Val_int(0); l = Field_imm(l, 1)) {
       uintnat fnsz;
-      value ev = Field(l, 0);
+      value ev = Field_imm(l, 0);
 
       events[j].ev_pc =
-        (code_t)((char*)caml_start_code + Long_val(Field(ev, EV_POS)));
+        (code_t)((char*)caml_start_code + Long_val(Field_imm(ev, EV_POS)));
 
-      ev_start = Field (Field (ev, EV_LOC), LOC_START);
+      ev_start = Field_imm(Field_imm(ev, EV_LOC), LOC_START);
 
-      fnsz = caml_string_length(Field (ev_start, POS_FNAME))+1;
+      fnsz = caml_string_length(Field_imm(ev_start, POS_FNAME))+1;
       events[j].ev_filename = (char*)malloc(fnsz);
       if(events[j].ev_filename == NULL) {
         for(j--; j >= 0; j--)
@@ -300,16 +300,16 @@ static void read_debug_info()
         read_debug_info_error = "out of memory";
         CAMLreturn0;
       }
-      memcpy(events[j].ev_filename, String_val (Field (ev_start, POS_FNAME)),
+      memcpy(events[j].ev_filename, String_val (Field_imm(ev_start, POS_FNAME)),
              fnsz);
 
-      events[j].ev_lnum = Int_val (Field (ev_start, POS_LNUM));
+      events[j].ev_lnum = Int_val (Field_imm(ev_start, POS_LNUM));
       events[j].ev_startchr =
-        Int_val (Field (ev_start, POS_CNUM))
-        - Int_val (Field (ev_start, POS_BOL));
+        Int_val (Field_imm(ev_start, POS_CNUM))
+        - Int_val (Field_imm(ev_start, POS_BOL));
       events[j].ev_endchr =
-        Int_val (Field (Field (Field (ev, EV_LOC), LOC_END), POS_CNUM))
-        - Int_val (Field (ev_start, POS_BOL));
+        Int_val (Field_imm(Field_imm(Field_imm(ev, EV_LOC), LOC_END), POS_CNUM))
+        - Int_val (Field_imm(ev_start, POS_BOL));
 
       j++;
     }

--- a/byterun/caml/mlvalues.h
+++ b/byterun/caml/mlvalues.h
@@ -221,6 +221,7 @@ static inline void caml_read_field(value x, int i, value* ret) {
 
 #define Int_field(x, i) Int_val(Op_val(x)[i])
 #define Long_field(x, i) Long_val(Op_val(x)[i])
+#define Bool_field(x, i) Bool_val(Op_val(x)[i])
 
 typedef int32 opcode_t;
 typedef opcode_t * code_t;
@@ -235,7 +236,7 @@ typedef opcode_t * code_t;
 /* Forward_tag: forwarding pointer that the GC may silently shortcut.
    See stdlib/lazy.ml. */
 #define Forward_tag 250
-#define Forward_val(v) Field(v, 0)
+#define Forward_val(v) Field_imm(v, 0) /* FIXME: not immutable once shortcutting is implemented */
 
 /* If tag == Infix_tag : an infix header inside a closure */
 /* Infix_tag must be odd so that the infix header is scanned as an integer */
@@ -248,8 +249,8 @@ typedef opcode_t * code_t;
 
 /* Another special case: objects */
 #define Object_tag 248
-#define Class_val(val) Field((val), 0)
-#define Oid_val(val) Long_val(Field((val), 1))
+#define Class_val(val) Field_imm((val), 0)
+#define Oid_val(val) Long_field((val), 1)
 CAMLextern value caml_get_public_method (value obj, value tag);
 /* Called as:
    caml_callback(caml_get_public_method(obj, caml_hash_variant(name)), obj) */
@@ -267,7 +268,7 @@ CAMLextern value caml_get_public_method (value obj, value tag);
 #define Closure_tag 247
 #define Bytecode_val(val) (Pc_val(val))
 #define Val_bytecode(code) (Val_pc(code))
-#define Code_val(val) Bytecode_val(Field((val), 0))
+#define Code_val(val) Bytecode_val(Field_imm((val), 0))
 
 /* This tag is used (with Forward_tag) to implement lazy values.
    See major_gc.c and stdlib/lazy.ml. */

--- a/byterun/custom.c
+++ b/byterun/custom.c
@@ -28,6 +28,7 @@ CAMLexport value caml_alloc_custom(const struct custom_operations * ops,
   value result;
 
   wosize = 1 + (size + sizeof(value) - 1) / sizeof(value);
+  /* FIXME: what about custom finalizers on the minor heap? */
   if (ops->finalize == NULL && wosize <= Max_young_wosize) {
     result = caml_alloc_small(wosize, Custom_tag);
     Custom_ops_val(result) = ops;

--- a/byterun/debugger.c
+++ b/byterun/debugger.c
@@ -385,12 +385,12 @@ void caml_debugger(enum event_kind event)
       break;
     case REQ_GET_ENVIRONMENT:
       i = caml_getword(dbg_in);
-      putval(dbg_out, Field(Env(frame), i));
+      putval(dbg_out, Field_imm(Env(frame), i));
       caml_flush(dbg_out);
       break;
     case REQ_GET_GLOBAL:
       i = caml_getword(dbg_in);
-      putval(dbg_out, Field(caml_read_root(caml_global_data), i));
+      putval(dbg_out, Field_imm(caml_read_root(caml_global_data), i));
       caml_flush(dbg_out);
       break;
     case REQ_GET_ACCU:
@@ -407,7 +407,7 @@ void caml_debugger(enum event_kind event)
       i = caml_getword(dbg_in);
       if (Tag_val(val) != Double_array_tag) {
         putch(dbg_out, 0);
-        putval(dbg_out, Field(val, i));
+        putval(dbg_out, Op_val(val)[i]);
       } else {
         double d = Double_field(val, i);
         putch(dbg_out, 1);

--- a/byterun/fail.c
+++ b/byterun/fail.c
@@ -99,7 +99,7 @@ static value get_exception(int exn, const char* exn_name)
     fprintf(stderr, "Fatal error %s during domain creation\n", exn_name);
     exit(2);
   }
-  return Field(caml_read_root(caml_global_data), exn);
+  return Field_imm(caml_read_root(caml_global_data), exn);
 }
 
 #define GET_EXCEPTION(exn) get_exception(exn, #exn)

--- a/byterun/fiber.c
+++ b/byterun/fiber.c
@@ -482,7 +482,7 @@ CAMLprim value caml_clone_continuation (value cont)
     caml_invalid_argument ("continuation already taken");
 
   prev_target = Val_unit;
-  source = Field (cont, 0);
+  caml_read_field(cont, 0, &source);
 
   do {
     Assert (Is_block (source) && Tag_val(source) == Stack_tag);

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -39,8 +39,8 @@ CAMLexport double caml_Double_val(value val)
   union { value v[2]; double d; } buffer;
 
   Assert(sizeof(double) == 2 * sizeof(value));
-  buffer.v[0] = Field(val, 0);
-  buffer.v[1] = Field(val, 1);
+  buffer.v[0] = Op_val(val)[0];
+  buffer.v[1] = Op_val(val)[1];
   return buffer.d;
 }
 
@@ -50,8 +50,8 @@ CAMLexport void caml_Store_double_val(value val, double dbl)
 
   Assert(sizeof(double) == 2 * sizeof(value));
   buffer.d = dbl;
-  Field(val, 0) = buffer.v[0];
-  Field(val, 1) = buffer.v[1];
+  Op_val(val)[0] = buffer.v[0];
+  Op_val(val)[1] = buffer.v[1];
 }
 
 #endif

--- a/byterun/gc_ctrl.c
+++ b/byterun/gc_ctrl.c
@@ -53,73 +53,6 @@ extern uintnat caml_allocation_policy;    /*        see freelist.c */
 
 #define Next(hp) ((hp) + Bhsize_hp (hp))
 
-#ifdef DEBUG
-
-#if 0
-/* Check that [v]'s header looks good.  [v] must be a block in the heap. */
-static void check_head (value v)
-{
-  Assert (Is_block (v));
-  Assert (Is_in_heap (v));
-
-  Assert (Wosize_val (v) != 0);
-  Assert (Color_hd (Hd_val (v)) != Caml_blue);
-  Assert (Is_in_heap (v));
-  if (Tag_val (v) == Infix_tag){
-    int offset = Wsize_bsize (Infix_offset_val (v));
-    value trueval = Val_op (&Field (v, -offset));
-    Assert (Tag_val (trueval) == Closure_tag);
-    Assert (Wosize_val (trueval) > offset);
-    Assert (Is_in_heap (&Field (trueval, Wosize_val (trueval) - 1)));
-  }else{
-    Assert (Is_in_heap (&Field (v, Wosize_val (v) - 1)));
-  }
-  if (Tag_val (v) ==  Double_tag){
-    Assert (Wosize_val (v) == Double_wosize);
-  }else if (Tag_val (v) == Double_array_tag){
-    Assert (Wosize_val (v) % Double_wosize == 0);
-  }
-}
-
-static void check_block (char *hp)
-{
-  mlsize_t i;
-  value v = Val_hp (hp);
-  value f;
-
-  check_head (v);
-  switch (Tag_hp (hp)){
-  case Abstract_tag: break;
-  case String_tag:
-    break;
-  case Double_tag:
-    Assert (Wosize_val (v) == Double_wosize);
-    break;
-  case Double_array_tag:
-    Assert (Wosize_val (v) % Double_wosize == 0);
-    break;
-  case Custom_tag:
-    Assert (!Is_in_heap (Custom_ops_val (v)));
-    break;
-
-  case Infix_tag:
-    Assert (0);
-    break;
-
-  default:
-    Assert (Tag_hp (hp) < No_scan_tag);
-    for (i = 0; i < Wosize_hp (hp); i++){
-      f = Field (v, i);
-      if (Is_block (f) && Is_in_heap (f)){
-        check_head (f);
-        Assert (Color_val (f) != Caml_blue);
-      }
-    }
-  }
-}
-#endif
-#endif /* DEBUG */
-
 /* Check the heap structure (if compiled in debug mode) and
    gather statistics; return the stats if [returnstats] is true,
    otherwise return [Val_unit].
@@ -381,25 +314,25 @@ CAMLprim value caml_gc_set(value v)
   asize_t newminsize;
   uintnat oldpolicy;
 
-  caml_startup_params.verb_gc = Long_val (Field (v, 3));
+  caml_startup_params.verb_gc = Long_field (v, 3);
 
 #ifndef NATIVE_CODE
-  caml_change_max_stack_size (Long_val (Field (v, 5)));
+  caml_change_max_stack_size (Long_field (v, 5));
 #endif
 
-  newpf = norm_pfree (Long_val (Field (v, 2)));
+  newpf = norm_pfree (Long_field (v, 2));
   if (newpf != caml_percent_free){
     caml_percent_free = newpf;
     caml_gc_message (0x20, "New space overhead: %d%%\n", caml_percent_free);
   }
 
-  newpm = norm_pmax (Long_val (Field (v, 4)));
+  newpm = norm_pmax (Long_field (v, 4));
   if (newpm != caml_percent_max){
     caml_percent_max = newpm;
     caml_gc_message (0x20, "New max overhead: %d%%\n", caml_percent_max);
   }
 
-  newheapincr = Long_val (Field (v, 1));
+  newheapincr = Long_field (v, 1);
   if (newheapincr != caml_major_heap_increment){
     caml_major_heap_increment = newheapincr;
     if (newheapincr > 1000){
@@ -411,7 +344,7 @@ CAMLprim value caml_gc_set(value v)
     }
   }
   oldpolicy = caml_allocation_policy;
-  caml_set_allocation_policy (Long_val (Field (v, 6)));
+  caml_set_allocation_policy (Long_field (v, 6));
   if (oldpolicy != caml_allocation_policy){
     caml_gc_message (0x20, "New allocation policy: %d\n",
                      caml_allocation_policy);
@@ -419,7 +352,7 @@ CAMLprim value caml_gc_set(value v)
 
     /* Minor heap size comes last because it will trigger a minor collection
        (thus invalidating [v]) and it can raise [Out_of_memory]. */
-  newminsize = caml_norm_minor_heap_size (Long_val (Field (v, 0)));
+  newminsize = caml_norm_minor_heap_size (Long_field (v, 0));
   if (newminsize != caml_minor_heap_size){
     caml_gc_message (0x20, "New minor heap size: %luk bytes\n",
                      newminsize/1024);

--- a/byterun/globroots.c
+++ b/byterun/globroots.c
@@ -70,10 +70,12 @@ CAMLexport void caml_delete_root(caml_root root)
 CAMLexport value caml_read_root(caml_root root)
 {
   value v = (value)root;
+  value x;
   Assert(root);
   Assert(Hd_val(root));
-  Assert(Field(v,1) == Val_int(0) || Field(v,1) == Val_int(1));
-  return Field(v, 0);
+  Assert(Int_field(v,1) == 0 || Int_field(v,1) == 1);
+  caml_read_field(v, 0, &x);
+  return x;
 }
 
 CAMLexport void caml_modify_root(caml_root root, value newv)
@@ -104,8 +106,9 @@ void caml_cleanup_deleted_roots()
 
   r = roots_all;
   while (Is_block(r)) {
-    value next = Field(r, 2);
-    if (Field(r, 1) == Val_int(0)) {
+    Assert(!Is_foreign(Op_val(r)[2]));
+    value next = Op_val(r)[2];
+    if (Int_field(r, 1) == 0) {
       /* root was deleted, remove from list */
       if (first) {
         roots_all = next;

--- a/byterun/hash.c
+++ b/byterun/hash.c
@@ -180,13 +180,14 @@ CAMLexport uint32 caml_hash_mix_string(uint32 h, value s)
 
 CAMLprim value caml_hash(value count, value limit, value seed, value obj)
 {
-  value queue[HASH_QUEUE_SIZE]; /* Queue of values to examine */
+  CAMLparam4(count, limit, seed, obj);
+  CAMLlocalN(queue, HASH_QUEUE_SIZE); /* Queue of values to examine */
   intnat rd;                    /* Position of first value in queue */
   intnat wr;                    /* One past position of last value in queue */
   intnat sz;                    /* Max number of values to put in queue */
   intnat num;                   /* Max number of meaningful values to see */
   uint32 h;                     /* Rolling hash */
-  value v;
+  CAMLlocal1(v);
   mlsize_t i, len;
 
   sz = Long_val(limit);
@@ -266,7 +267,7 @@ CAMLprim value caml_hash(value count, value limit, value seed, value obj)
         /* Copy fields into queue, not exceeding the total size [sz] */
         for (i = 0, len = Wosize_val(v); i < len; i++) {
           if (wr >= sz) break;
-          queue[wr++] = Field(v, i);
+          caml_read_field(v, i, &queue[wr++]);
         }
         break;
       }
@@ -276,7 +277,7 @@ CAMLprim value caml_hash(value count, value limit, value seed, value obj)
   FINAL_MIX(h);
   /* Fold result to the range [0, 2^30-1] so that it is a nonnegative
      OCaml integer both on 32 and 64-bit platforms. */
-  return Val_int(h & 0x3FFFFFFFU);
+  CAMLreturn (Val_int(h & 0x3FFFFFFFU));
 }
 
 CAMLprim value caml_hash_univ_param(value count, value limit, value obj)

--- a/byterun/instrtrace.c
+++ b/byterun/instrtrace.c
@@ -149,7 +149,7 @@ caml_trace_value_file (value v, code_t prog, int proglen, FILE * f)
         };
         if (i > 0)
           putc (' ', f);
-        fprintf (f, "%#lx", Field (v, i));
+        fprintf (f, "%#lx", Op_val (v)[i]);
       };
       if (s > 0)
         putc (')', f);

--- a/byterun/intern.c
+++ b/byterun/intern.c
@@ -345,7 +345,7 @@ static value intern_rec(mlsize_t whsize, mlsize_t num_objects)
     case OFreshOID:
       /* Refresh the object ID */
       /* but do not do it for predefined exception slots */
-      if (Int_val(Field(dest, 1)) >= 0)
+      if (Int_field(dest, 1) >= 0)
         caml_set_oo_id(dest);
       /* Pop item and iterate */
       stack_pop(&S);

--- a/byterun/lexing.c
+++ b/byterun/lexing.c
@@ -129,7 +129,7 @@ static void run_mem(char *pc, value mem, value curr_pos) {
       Store_field(mem,dst,curr_pos);
     } else {
       /*      fprintf(stderr,"[%hhu] <- [%hhu]\n",dst,src) ; */
-      Store_field(mem,dst,Field(mem, src));
+      Store_field(mem,dst,Val_long(Long_field(mem, src)));
     }
   }
 }
@@ -147,7 +147,7 @@ static void run_tag(char *pc, value mem) {
       Store_field(mem,dst,Val_int(-1));
     } else {
       /*      fprintf(stderr,"[%hhu] <- [%hhu]\n",dst,src) ; */
-      Store_field(mem,dst, Field(mem, src));
+      Store_field(mem,dst, Val_long(Long_field(mem, src)));
     }
   }
 }

--- a/byterun/meta.c
+++ b/byterun/meta.c
@@ -82,7 +82,7 @@ CAMLprim value caml_realloc_global(value size)
                  (unsigned)requested_size);
     new_global_data = caml_alloc_shr(requested_size, 0);
     for (i = 0; i < actual_size; i++)
-      caml_initialize_field(new_global_data, i, Field(old_global_data, i));
+      caml_initialize_field(new_global_data, i, Field_imm(old_global_data, i));
     for (i = actual_size; i < requested_size; i++){
       caml_initialize_field(new_global_data, i, Val_long(0));
     }

--- a/byterun/printexc.c
+++ b/byterun/printexc.c
@@ -46,21 +46,34 @@ static void add_string(struct stringbuf *buf, char *s)
 CAMLexport char * caml_format_exception(value exn)
 {
   mlsize_t start, i;
-  value bucket, v;
   struct stringbuf buf;
   char intbuf[64];
   char * res;
+  CAMLparam1(exn);
+  CAMLlocal4(bucket, v, exnclass, field1);
 
   buf.ptr = buf.data;
   buf.end = buf.data + sizeof(buf.data) - 1;
+  /* An exception class is a value with tag Object_tag, whose first
+     field is a string naming the exception.
+     Exceptions that take parameters (e.g. Invalid_argument) are blocks
+     with tag 0, where the first field is the exception class.
+     Exceptions without parameters (e.g. Not_found) are just the exception
+     class. */
   if (Tag_val(exn) == 0) {
-    add_string(&buf, String_val(Field(Field(exn, 0), 0)));
+    /* Field 0 of exn is the exception class, which is immutable */
+    exnclass = Field_imm(exn, 0);
+    add_string(&buf, String_val(Field_imm(exnclass, 0)));
     /* Check for exceptions in the style of Match_failure and Assert_failure */
-    if (Wosize_val(exn) == 2 &&
-        Is_block(Field(exn, 1)) &&
-        Tag_val(Field(exn, 1)) == 0 &&
-        caml_is_special_exception(Field(exn, 0))) {
-      bucket = Field(exn, 1);
+    if (Wosize_val(exn) == 2) {
+      caml_read_field(exn, 1, &field1);
+    } else {
+      field1 = Val_unit;
+    }
+    if (Is_block(field1) &&
+        Tag_val(field1) == 0 &&
+        caml_is_special_exception(exnclass)) {
+      bucket = field1;
       start = 0;
     } else {
       bucket = exn;
@@ -69,7 +82,7 @@ CAMLexport char * caml_format_exception(value exn)
     add_char(&buf, '(');
     for (i = start; i < Wosize_val(bucket); i++) {
       if (i > start) add_string(&buf, ", ");
-      v = Field(bucket, i);
+      caml_read_field(bucket, i, &v);
       if (Is_long(v)) {
         snprintf(intbuf, sizeof(intbuf),
                  "%" ARCH_INTNAT_PRINTF_FORMAT "d", Long_val(v));
@@ -83,15 +96,18 @@ CAMLexport char * caml_format_exception(value exn)
       }
     }
     add_char(&buf, ')');
-  } else
-    add_string(&buf, String_val(Field(exn, 0)));
+  } else {
+    /* Exception without parameters */
+    exnclass = exn;
+    add_string(&buf, String_val(Field_imm(exnclass, 0)));
+  }
 
   *buf.ptr = 0;              /* Terminate string */
   i = buf.ptr - buf.data + 1;
   res = malloc(i);
   if (res == NULL) return NULL;
   memmove(res, buf.data, i);
-  return res;
+  CAMLreturnT (char*, res);
 }
 
 

--- a/byterun/weak.c
+++ b/byterun/weak.c
@@ -39,13 +39,21 @@ CAMLprim value caml_weak_create (value len)
 
 CAMLprim value caml_weak_set (value ar, value n, value el)
 {
-  caml_modify_field(ar, n, el);
-  return Val_unit;
+  CAMLparam3(ar, n, el);
+  int idx = Int_val(n);
+  if (idx < 0 || idx >= Wosize_val(ar)) caml_array_bound_error();
+  caml_modify_field(ar, idx, el);
+  CAMLreturn (Val_unit);
 }
 
 CAMLprim value caml_weak_get (value ar, value n)
 {
-  return Field(ar, n);
+  CAMLparam2(ar, n);
+  CAMLlocal1(x);
+  int idx = Int_val(n);
+  if (idx < 0 || idx >= Wosize_val(ar)) caml_array_bound_error();
+  caml_read_field(ar, idx, &x);
+  CAMLreturn (x);
 }
 
 CAMLprim value caml_weak_get_copy (value ar, value n)

--- a/otherlibs/bigarray/bigarray_stubs.c
+++ b/otherlibs/bigarray/bigarray_stubs.c
@@ -200,7 +200,7 @@ CAMLprim value caml_ba_create(value vkind, value vlayout, value vdim)
   if (num_dims < 1 || num_dims > CAML_BA_MAX_NUM_DIMS)
     caml_invalid_argument("Bigarray.create: bad number of dimensions");
   for (i = 0; i < num_dims; i++) {
-    dim[i] = Long_val(Field(vdim, i));
+    dim[i] = Long_field(vdim, i);
     if (dim[i] < 0)
       caml_invalid_argument("Bigarray.create: negative dimension");
   }
@@ -1050,14 +1050,14 @@ CAMLprim value caml_ba_slice(value vb, value vind)
   /* Compute offset and check bounds */
   if ((b->flags & CAML_BA_LAYOUT_MASK) == CAML_BA_C_LAYOUT) {
     /* We slice from the left */
-    for (i = 0; i < num_inds; i++) index[i] = Long_val(Field(vind, i));
+    for (i = 0; i < num_inds; i++) index[i] = Long_field(vind, i);
     for (/*nothing*/; i < b->num_dims; i++) index[i] = 0;
     offset = caml_ba_offset(b, index);
     sub_dims = b->dim + num_inds;
   } else {
     /* We slice from the right */
     for (i = 0; i < num_inds; i++)
-      index[b->num_dims - num_inds + i] = Long_val(Field(vind, i));
+      index[b->num_dims - num_inds + i] = Long_field(vind, i);
     for (i = 0; i < b->num_dims - num_inds; i++) index[i] = 1;
     offset = caml_ba_offset(b, index);
     sub_dims = b->dim;
@@ -1240,7 +1240,7 @@ CAMLprim value caml_ba_reshape(value vb, value vdim)
     caml_invalid_argument("Bigarray.reshape: bad number of dimensions");
   num_elts = 1;
   for (i = 0; i < num_dims; i++) {
-    dim[i] = Long_val(Field(vdim, i));
+    dim[i] = Long_field(vdim, i);
     if (dim[i] < 0)
       caml_invalid_argument("Bigarray.reshape: negative dimension");
     num_elts *= dim[i];

--- a/otherlibs/bigarray/mmap_unix.c
+++ b/otherlibs/bigarray/mmap_unix.c
@@ -110,7 +110,7 @@ CAMLprim value caml_ba_map_file(value vfd, value vkind, value vlayout,
   if (num_dims < 1 || num_dims > CAML_BA_MAX_NUM_DIMS)
     caml_invalid_argument("Bigarray.mmap: bad number of dimensions");
   for (i = 0; i < num_dims; i++) {
-    dim[i] = Long_val(Field(vdim, i));
+    dim[i] = Long_field(vdim, i);
     if (dim[i] == -1 && i == major_dim) continue;
     if (dim[i] < 0)
       caml_invalid_argument("Bigarray.create: negative dimension");

--- a/otherlibs/bigarray/mmap_win32.c
+++ b/otherlibs/bigarray/mmap_win32.c
@@ -65,7 +65,7 @@ CAMLprim value caml_ba_map_file(value vfd, value vkind, value vlayout,
   if (num_dims < 1 || num_dims > CAML_BA_MAX_NUM_DIMS)
     caml_invalid_argument("Bigarray.mmap: bad number of dimensions");
   for (i = 0; i < num_dims; i++) {
-    dim[i] = Long_val(Field(vdim, i));
+    dim[i] = Long_field(vdim, i);
     if (dim[i] == -1 && i == major_dim) continue;
     if (dim[i] < 0)
       caml_invalid_argument("Bigarray.create: negative dimension");

--- a/otherlibs/graph/events.c
+++ b/otherlibs/graph/events.c
@@ -257,7 +257,7 @@ value caml_gr_wait_event(value eventlist) /* ML */
   mask = 0;
   poll = False;
   while (eventlist != Val_int(0)) {
-    switch (Int_val(Field(eventlist, 0))) {
+    switch (Int_field(eventlist, 0)) {
     case 0:                     /* Button_down */
       mask |= ButtonPressMask | OwnerGrabButtonMask; break;
     case 1:                     /* Button_up */
@@ -269,7 +269,7 @@ value caml_gr_wait_event(value eventlist) /* ML */
     case 4:                     /* Poll */
       poll = True; break;
     }
-    eventlist = Field(eventlist, 1);
+    eventlist = Field_imm(eventlist, 1);
   }
   if (poll)
     return caml_gr_wait_event_poll();

--- a/otherlibs/graph/fill.c
+++ b/otherlibs/graph/fill.c
@@ -35,6 +35,8 @@ value caml_gr_fill_rect(value vx, value vy, value vw, value vh)
 
 value caml_gr_fill_poly(value array)
 {
+  CAMLparam1 (array);
+  CAMLlocal1 (coord);
   XPoint * points;
   int npoints, i;
 
@@ -42,8 +44,9 @@ value caml_gr_fill_poly(value array)
   npoints = Wosize_val(array);
   points = (XPoint *) caml_stat_alloc(npoints * sizeof(XPoint));
   for (i = 0; i < npoints; i++) {
-    points[i].x = Int_val(Field(Field(array, i), 0));
-    points[i].y = Bcvt(Int_val(Field(Field(array, i), 1)));
+    caml_read_field(array, i, &coord);
+    points[i].x = Int_field(coord, 0);
+    points[i].y = Bcvt(Int_field(coord, 1));
   }
   if(caml_gr_remember_modeflag)
     XFillPolygon(caml_gr_display, caml_gr_bstore.win, caml_gr_bstore.gc, points,
@@ -56,7 +59,7 @@ value caml_gr_fill_poly(value array)
     XFlush(caml_gr_display);
   }
   stat_free((char *) points);
-  return Val_unit;
+  CAMLreturn (Val_unit);
 }
 
 value caml_gr_fill_arc_nat(value vx, value vy, value vrx, value vry, value va1,

--- a/otherlibs/graph/make_img.c
+++ b/otherlibs/graph/make_img.c
@@ -17,22 +17,25 @@
 
 value caml_gr_make_image(value m)
 {
+  CAMLparam1 (m);
+  CAMLlocal2 (im, line);
   int width, height;
-  value im;
   Bool has_transp;
   XImage * idata, * imask;
   char * bdata, * bmask;
   int i, j, rgb;
-  value line;
   GC gc;
 
   caml_gr_check_open();
   height = Wosize_val(m);
   if (height == 0) return caml_gr_new_image(0, 0);
-  width = Wosize_val(Field(m, 0));
-  for (i = 1; i < height; i++)
-    if (Wosize_val(Field(m, i)) != width)
+  caml_read_field(m, 0, &line);
+  width = Wosize_val(line);
+  for (i = 1; i < height; i++) {
+    caml_read_field(m, i, &line);
+    if (Wosize_val(line) != width)
       caml_gr_fail("make_image: lines of different lengths", NULL);
+  }
 
   /* Build an XImage for the data part of the image */
   idata =
@@ -47,9 +50,9 @@ value caml_gr_make_image(value m)
   has_transp = False;
 
   for (i = 0; i < height; i++) {
-    line = Field(m, i);
+    caml_read_field(m, i, &line);
     for (j = 0; j < width; j++) {
-      rgb = Int_val(Field(line, j));
+      rgb = Int_field(line, j);
       if (rgb == Transparent) { has_transp = True; rgb = 0; }
       XPutPixel(idata, j, i, caml_gr_pixel_rgb(rgb));
     }
@@ -67,9 +70,9 @@ value caml_gr_make_image(value m)
     imask->data = bmask;
 
     for (i = 0; i < height; i++) {
-      line = Field(m, i);
+      caml_read_field(m, i, &line);
       for (j = 0; j < width; j++) {
-        rgb = Int_val(Field(line, j));
+        rgb = Int_field(line, j);
         XPutPixel(imask, j, i, rgb != Transparent);
       }
     }
@@ -93,5 +96,5 @@ value caml_gr_make_image(value m)
     XFreeGC(caml_gr_display, gc);
   }
   XFlush(caml_gr_display);
-  return im;
+  CAMLreturn (im);
 }

--- a/otherlibs/str/strstubs.c
+++ b/otherlibs/str/strstubs.c
@@ -70,12 +70,12 @@ enum {
 };
 
 /* Accessors in a compiled regexp */
-#define Prog(re) Field(re, 0)
-#define Cpool(re) Field(re, 1)
-#define Normtable(re) Field(re, 2)
-#define Numgroups(re) Int_val(Field(re, 3))
-#define Numregisters(re) Int_val(Field(re, 4))
-#define Startchars(re) Int_val(Field(re, 5))
+#define Prog(re) Field_imm(re, 0)
+#define Cpool(re) Field_imm(re, 1)
+#define Normtable(re) Field_imm(re, 2)
+#define Numgroups(re) Int_val(Field_imm(re, 3))
+#define Numregisters(re) Int_val(Field_imm(re, 4))
+#define Startchars(re) Int_val(Field_imm(re, 5))
 
 /* Record positions of matched groups */
 #define NUM_GROUPS 32
@@ -488,8 +488,8 @@ CAMLprim value re_replacement_text(value repl, value groups, value orig)
         c -= '0';
         if (c*2 >= Wosize_val(groups))
           failwith("Str.replace: reference to unmatched group");
-        start = Long_val(Field(groups, c*2));
-        end = Long_val(Field(groups, c*2 + 1));
+        start = Long_field(groups, c*2);
+        end = Long_field(groups, c*2 + 1);
         if (start == (mlsize_t) -1)
           failwith("Str.replace: reference to unmatched group");
         len += end - start;
@@ -515,8 +515,8 @@ CAMLprim value re_replacement_text(value repl, value groups, value orig)
       case '0': case '1': case '2': case '3': case '4':
       case '5': case '6': case '7': case '8': case '9':
         c -= '0';
-        start = Long_val(Field(groups, c*2));
-        end = Long_val(Field(groups, c*2 + 1));
+        start = Long_field(groups, c*2);
+        end = Long_field(groups, c*2 + 1);
         len = end - start;
         memmove (q, &Byte(orig, start), len);
         q += len;

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -372,9 +372,9 @@ static void st_decode_sigset(value vset, sigset_t * set)
 {
   sigemptyset(set);
   while (vset != Val_int(0)) {
-    int sig = caml_convert_signal_number(Int_val(Field(vset, 0)));
+    int sig = caml_convert_signal_number(Int_field(vset, 0));
     sigaddset(set, sig);
-    vset = Field(vset, 1);
+    vset = Field_imm(vset, 1);
   }
 }
 

--- a/otherlibs/threads/scheduler.c
+++ b/otherlibs/threads/scheduler.c
@@ -473,10 +473,7 @@ try_again:
             w = inter_fdlist_set(th->writefds, &writefds, &retcode);
             e = inter_fdlist_set(th->exceptfds, &exceptfds, &retcode);
             if (r != NO_FDS || w != NO_FDS || e != NO_FDS) {
-              value retval = alloc_small(3, TAG_RESUMED_SELECT);
-              Field(retval, 0) = r;
-              Field(retval, 1) = w;
-              Field(retval, 2) = e;
+              value retval = caml_alloc_3(TAG_RESUMED_SELECT, r, w, e);
               Assign(th->retval, retval);
               th->status = RUNNABLE;
               if (run_thread == NULL) run_thread = th; /* Found one. */

--- a/otherlibs/unix/cstringv.c
+++ b/otherlibs/unix/cstringv.c
@@ -17,12 +17,17 @@
 
 char ** cstringvect(value arg)
 {
+  CAMLparam1 (arg);
+  CAMLlocal1 (x);
   char ** res;
   mlsize_t size, i;
 
   size = Wosize_val(arg);
   res = (char **) caml_stat_alloc((size + 1) * sizeof(char *));
-  for (i = 0; i < size; i++) res[i] = String_val(Field(arg, i));
+  for (i = 0; i < size; i++) {
+    caml_read_field(arg, i, &x);
+    res[i] = String_val(x);
+  }
   res[size] = NULL;
-  return res;
+  CAMLreturnT (char**, res);
 }

--- a/otherlibs/unix/errmsg.c
+++ b/otherlibs/unix/errmsg.c
@@ -21,6 +21,6 @@ extern int error_table[];
 CAMLprim value unix_error_message(value err)
 {
   int errnum;
-  errnum = Is_block(err) ? Int_val(Field(err, 0)) : error_table[Int_val(err)];
+  errnum = Is_block(err) ? Int_field(err, 0) : error_table[Int_val(err)];
   return copy_string(strerror(errnum));
 }

--- a/otherlibs/unix/getaddrinfo.c
+++ b/otherlibs/unix/getaddrinfo.c
@@ -77,18 +77,18 @@ CAMLprim value unix_getaddrinfo(value vnode, value vserv, value vopts)
   /* Parse options, set hints */
   memset(&hints, 0, sizeof(hints));
   hints.ai_family = PF_UNSPEC;
-  for (/*nothing*/; Is_block(vopts); vopts = Field(vopts, 1)) {
-    v = Field(vopts, 0);
+  for (/*nothing*/; Is_block(vopts); vopts = Field_imm(vopts, 1)) {
+    v = Field_imm(vopts, 0);
     if (Is_block(v))
       switch (Tag_val(v)) {
       case 0:                   /* AI_FAMILY of socket_domain */
-        hints.ai_family = socket_domain_table[Int_val(Field(v, 0))];
+        hints.ai_family = socket_domain_table[Int_val(Field_imm(v, 0))];
         break;
       case 1:                   /* AI_SOCKTYPE of socket_type */
-        hints.ai_socktype = socket_type_table[Int_val(Field(v, 0))];
+        hints.ai_socktype = socket_type_table[Int_val(Field_imm(v, 0))];
         break;
       case 2:                   /* AI_PROTOCOL of int */
-        hints.ai_protocol = Int_val(Field(v, 0));
+        hints.ai_protocol = Int_val(Field_imm(v, 0));
         break;
       }
     else

--- a/otherlibs/unix/gmtime.c
+++ b/otherlibs/unix/gmtime.c
@@ -65,15 +65,15 @@ CAMLprim value unix_mktime(value t)
   value tmval = Val_unit, clkval = Val_unit;
 
   Begin_roots2(tmval, clkval);
-    tm.tm_sec = Int_val(Field(t, 0));
-    tm.tm_min = Int_val(Field(t, 1));
-    tm.tm_hour = Int_val(Field(t, 2));
-    tm.tm_mday = Int_val(Field(t, 3));
-    tm.tm_mon = Int_val(Field(t, 4));
-    tm.tm_year = Int_val(Field(t, 5));
-    tm.tm_wday = Int_val(Field(t, 6));
-    tm.tm_yday = Int_val(Field(t, 7));
-    tm.tm_isdst = -1; /* tm.tm_isdst = Bool_val(Field(t, 8)); */
+    tm.tm_sec = Int_field(t, 0);
+    tm.tm_min = Int_field(t, 1);
+    tm.tm_hour = Int_field(t, 2);
+    tm.tm_mday = Int_field(t, 3);
+    tm.tm_mon = Int_field(t, 4);
+    tm.tm_year = Int_field(t, 5);
+    tm.tm_wday = Int_field(t, 6);
+    tm.tm_yday = Int_field(t, 7);
+    tm.tm_isdst = -1; /* tm.tm_isdst = Bool_val(Field_imm(t, 8)); */
     clock = mktime(&tm);
     if (clock == (time_t) -1) unix_error(ERANGE, "mktime", Nothing);
     tmval = alloc_tm(&tm);

--- a/otherlibs/unix/setgroups.c
+++ b/otherlibs/unix/setgroups.c
@@ -34,7 +34,7 @@ CAMLprim value unix_setgroups(value groups)
 
   size = Wosize_val(groups);
   gidset = (gid_t *) caml_stat_alloc(size * sizeof(gid_t));
-  for (i = 0; i < size; i++) gidset[i] = Int_val(Field(groups, i));
+  for (i = 0; i < size; i++) gidset[i] = Int_field(groups, i);
 
   n = setgroups(size, gidset);
 

--- a/otherlibs/unix/signals.c
+++ b/otherlibs/unix/signals.c
@@ -31,9 +31,9 @@ static void decode_sigset(value vset, sigset_t * set)
 {
   sigemptyset(set);
   while (vset != Val_int(0)) {
-    int sig = caml_convert_signal_number(Int_val(Field(vset, 0)));
+    int sig = caml_convert_signal_number(Int_field(vset, 0));
     sigaddset(set, sig);
-    vset = Field(vset, 1);
+    vset = Field_imm(vset, 1);
   }
 }
 

--- a/otherlibs/unix/socketaddr.c
+++ b/otherlibs/unix/socketaddr.c
@@ -58,7 +58,7 @@ void get_sockaddr(value mladr,
   case 0:                       /* ADDR_UNIX */
     { value path;
       mlsize_t len;
-      path = Field(mladr, 0);
+      path = Field_imm(mladr, 0);
       len = string_length(path);
       adr->s_unix.sun_family = AF_UNIX;
       if (len >= sizeof(adr->s_unix.sun_path)) {
@@ -73,11 +73,11 @@ void get_sockaddr(value mladr,
 #endif
   case 1:                       /* ADDR_INET */
 #ifdef HAS_IPV6
-    if (string_length(Field(mladr, 0)) == 16) {
+    if (string_length(Field_imm(mladr, 0)) == 16) {
       memset(&adr->s_inet6, 0, sizeof(struct sockaddr_in6));
       adr->s_inet6.sin6_family = AF_INET6;
-      adr->s_inet6.sin6_addr = GET_INET6_ADDR(Field(mladr, 0));
-      adr->s_inet6.sin6_port = htons(Int_val(Field(mladr, 1)));
+      adr->s_inet6.sin6_addr = GET_INET6_ADDR(Field_imm(mladr, 0));
+      adr->s_inet6.sin6_port = htons(Int_val(Field_imm(mladr, 1)));
 #ifdef SIN6_LEN
       adr->s_inet6.sin6_len = sizeof(struct sockaddr_in6);
 #endif
@@ -87,8 +87,8 @@ void get_sockaddr(value mladr,
 #endif
     memset(&adr->s_inet, 0, sizeof(struct sockaddr_in));
     adr->s_inet.sin_family = AF_INET;
-    adr->s_inet.sin_addr = GET_INET_ADDR(Field(mladr, 0));
-    adr->s_inet.sin_port = htons(Int_val(Field(mladr, 1)));
+    adr->s_inet.sin_addr = GET_INET_ADDR(Field_imm(mladr, 0));
+    adr->s_inet.sin_port = htons(Int_val(Field_imm(mladr, 1)));
 #ifdef SIN6_LEN
     adr->s_inet.sin_len = sizeof(struct sockaddr_in);
 #endif

--- a/otherlibs/unix/sockopt.c
+++ b/otherlibs/unix/sockopt.c
@@ -238,7 +238,7 @@ unix_setsockopt_aux(char * name,
     optsize = sizeof(optval.lg);
     optval.lg.l_onoff = Is_block (val);
     if (optval.lg.l_onoff)
-      optval.lg.l_linger = Int_val (Field (val, 0));
+      optval.lg.l_linger = Int_field (val, 0);
     break;
   case TYPE_TIMEVAL:
     f = Double_val(val);

--- a/otherlibs/unix/termios.c
+++ b/otherlibs/unix/termios.c
@@ -253,7 +253,7 @@ static void decode_terminal_status(value v, int field)
     case Bool:
       { int * dst = (int *) (*pc++);
         int msk = *pc++;
-        if (Bool_val(Field(v, field)))
+        if (Bool_field(v, field))
           *dst |= msk;
         else
           *dst &= ~msk;
@@ -263,7 +263,7 @@ static void decode_terminal_status(value v, int field)
         int ofs = *pc++;
         int num = *pc++;
         int msk = *pc++;
-        i = Int_val(Field(v, field)) - ofs;
+        i = Int_field(v, field) - ofs;
         if (i >= 0 && i < num) {
           *dst = (*dst & ~msk) | pc[i];
         } else {
@@ -273,7 +273,7 @@ static void decode_terminal_status(value v, int field)
         break; }
     case Speed:
       { int which = *pc++;
-        int baud = Int_val(Field(v, field));
+        int baud = Int_field(v, field);
         int res = 0;
         for (i = 0; i < NSPEEDS; i++) {
           if (baud == speedtable[i].baud) {
@@ -292,7 +292,7 @@ static void decode_terminal_status(value v, int field)
         break; }
     case Char:
       { int which = *pc++;
-        terminal_status.c_cc[which] = Int_val(Field(v, field));
+        terminal_status.c_cc[which] = Int_field(v, field);
         break; }
     }
   }

--- a/otherlibs/unix/unixsupport.c
+++ b/otherlibs/unix/unixsupport.c
@@ -270,7 +270,7 @@ value unix_error_of_code (int errcode)
 extern int code_of_unix_error (value error)
 {
   if (Is_block(error)) {
-    return Int_val(Field(error, 0));
+    return Int_field(error, 0);
   } else {
     return error_table[Int_val(error)];
   }

--- a/otherlibs/win32graph/events.c
+++ b/otherlibs/win32graph/events.c
@@ -110,13 +110,12 @@ static value caml_gr_wait_allocate_result(int mouse_x, int mouse_y,
                                           int button,
                                           int keypressed, int key)
 {
-  value res = alloc_small(5, 0);
-  Field(res, 0) = Val_int(mouse_x);
-  Field(res, 1) = Val_int(grwindow.height - 1 - mouse_y);
-  Field(res, 2) = Val_bool(button);
-  Field(res, 3) = Val_bool(keypressed);
-  Field(res, 4) = Val_int(key & 0xFF);
-  return res;
+  return caml_alloc_5(0,
+    Val_int(mouse_x),
+    Val_int(grwindow.height - 1 - mouse_y),
+    Val_bool(button),
+    Val_bool(keypressed),
+    Val_int(key & 0xFF));
 }
 
 static value caml_gr_wait_event_poll(void)
@@ -177,7 +176,7 @@ CAMLprim value caml_gr_wait_event(value eventlist) /* ML */
   mask = 0;
   poll = 0;
   while (eventlist != Val_int(0)) {
-    switch (Int_val(Field(eventlist, 0))) {
+    switch (Int_field(eventlist, 0)) {
     case 0:                     /* Button_down */
       mask |= EVENT_BUTTON_DOWN; break;
     case 1:                     /* Button_up */
@@ -189,7 +188,7 @@ CAMLprim value caml_gr_wait_event(value eventlist) /* ML */
     case 4:                     /* Poll */
       poll = 1; break;
     }
-    eventlist = Field(eventlist, 1);
+    eventlist = Field_imm(eventlist, 1);
   }
   if (poll)
     return caml_gr_wait_event_poll();

--- a/otherlibs/win32unix/accept.c
+++ b/otherlibs/win32unix/accept.c
@@ -56,9 +56,7 @@ CAMLprim value unix_accept(sock)
   Begin_roots2 (fd, adr)
     fd = win_alloc_socket(snew);
     adr = alloc_sockaddr(&addr, addr_len, snew);
-    res = alloc_small(2, 0);
-    Field(res, 0) = fd;
-    Field(res, 1) = adr;
+    res = caml_alloc_2(0, fd, adr);
   End_roots();
   return res;
 }

--- a/otherlibs/win32unix/createprocess.c
+++ b/otherlibs/win32unix/createprocess.c
@@ -28,7 +28,7 @@ value win_create_process_native(value cmd, value cmdline, value env,
 
   exefile = search_exe_in_path(String_val(cmd));
   if (env != Val_int(0)) {
-    envp = String_val(Field(env, 0));
+    envp = String_val(Field_imm(env, 0));
   } else {
     envp = NULL;
   }

--- a/otherlibs/win32unix/errmsg.c
+++ b/otherlibs/win32unix/errmsg.c
@@ -25,7 +25,7 @@ CAMLprim value unix_error_message(value err)
   int errnum;
   char buffer[512];
 
-  errnum = Is_block(err) ? Int_val(Field(err, 0)) : error_table[Int_val(err)];
+  errnum = Is_block(err) ? Int_field(err, 0) : error_table[Int_val(err)];
   if (errnum > 0)
     return copy_string(strerror(errnum));
   if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,

--- a/otherlibs/win32unix/pipe.c
+++ b/otherlibs/win32unix/pipe.c
@@ -36,9 +36,7 @@ CAMLprim value unix_pipe(value unit)
   Begin_roots2(readfd, writefd)
     readfd = win_alloc_handle(readh);
     writefd = win_alloc_handle(writeh);
-    res = alloc_small(2, 0);
-    Field(res, 0) = readfd;
-    Field(res, 1) = writefd;
+    res = caml_alloc_2(0, readfd, writefd);
   End_roots();
   return res;
 }

--- a/otherlibs/win32unix/sendrecv.c
+++ b/otherlibs/win32unix/sendrecv.c
@@ -76,9 +76,9 @@ CAMLprim value unix_recvfrom(value sock, value buff, value ofs, value len,
     }
     memmove (&Byte(buff, Long_val(ofs)), iobuf, ret);
     adr = alloc_sockaddr(&addr, addr_len, -1);
-    res = alloc_small(2, 0);
-    Field(res, 0) = Val_int(ret);
-    Field(res, 1) = adr;
+    res = caml_alloc_2(0,
+      Val_int(ret),
+      adr);
   End_roots();
   return res;
 }

--- a/otherlibs/win32unix/sockopt.c
+++ b/otherlibs/win32unix/sockopt.c
@@ -138,9 +138,7 @@ unix_getsockopt_aux(char * name,
     if (optval.lg.l_onoff == 0) {
       return Val_int(0);        /* None */
     } else {
-      value res = alloc_small(1, 0); /* Some */
-      Field(res, 0) = Val_int(optval.lg.l_linger);
-      return res;
+      return caml_alloc_1(0, Val_int(optval.lg.l_linger)); /* Some */
     }
   case TYPE_TIMEVAL:
     return copy_double((double) optval.tv.tv_sec
@@ -149,13 +147,9 @@ unix_getsockopt_aux(char * name,
     if (optval.i == 0) {
       return Val_int(0);        /* None */
     } else {
-      value err, res;
+      value err;
       err = unix_error_of_code(optval.i);
-      Begin_root(err);
-        res = alloc_small(1, 0); /* Some */
-        Field(res, 0) = err;
-      End_roots();
-      return res;
+      return caml_alloc_1(0, err);
     }
   default:
     unix_error(EINVAL, name, Nothing);
@@ -182,7 +176,7 @@ unix_setsockopt_aux(char * name,
     optsize = sizeof(optval.lg);
     optval.lg.l_onoff = Is_block (val);
     if (optval.lg.l_onoff)
-      optval.lg.l_linger = Int_val (Field (val, 0));
+      optval.lg.l_linger = Int_field (val, 0);
     break;
   case TYPE_TIMEVAL:
     f = Double_val(val);

--- a/otherlibs/win32unix/system.c
+++ b/otherlibs/win32unix/system.c
@@ -36,7 +36,6 @@ CAMLprim value win_system(cmd)
   leave_blocking_section();
   caml_stat_free(buf);
   if (ret == -1) uerror("system", Nothing);
-  st = alloc_small(1, 0); /* Tag 0: Exited */
-  Field(st, 0) = Val_int(ret);
+  st = caml_alloc_1(0, Val_int(ret)); /* Tag 0: Exited */
   return st;
 }

--- a/otherlibs/win32unix/unixsupport.c
+++ b/otherlibs/win32unix/unixsupport.c
@@ -234,8 +234,7 @@ value unix_error_of_code (int errcode)
   errconstr =
       cst_to_constr(errcode, error_table, sizeof(error_table)/sizeof(int), -1);
   if (errconstr == Val_int(-1)) {
-    err = alloc_small(1, 0);
-    Field(err, 0) = Val_int(errcode);
+    err = caml_alloc_1(0, Val_int(errcode));
   } else {
     err = errconstr;
   }
@@ -259,11 +258,11 @@ void unix_error(int errcode, char *cmdname, value cmdarg)
         invalid_argument("Exception Unix.Unix_error not initialized,"
                          " please link unix.cma");
     }
-    res = alloc_small(4, 0);
-    Field(res, 0) = *unix_error_exn;
-    Field(res, 1) = err;
-    Field(res, 2) = name;
-    Field(res, 3) = arg;
+    res = caml_alloc_4(0,
+      *unix_error_exn,
+      err,
+      name,
+      arg);
   End_roots();
   mlraise(res);
 }

--- a/otherlibs/win32unix/windir.c
+++ b/otherlibs/win32unix/windir.c
@@ -40,9 +40,7 @@ CAMLprim value win_findfirst(name)
     }
     valname = copy_string(fileinfo.cFileName);
     valh = win_alloc_handle(h);
-    v = alloc_small(2, 0);
-    Field(v,0) = valname;
-    Field(v,1) = valh;
+    v = caml_alloc_2(0, valname, valh);
   End_roots();
   return v;
 }

--- a/otherlibs/win32unix/winwait.c
+++ b/otherlibs/win32unix/winwait.c
@@ -21,16 +21,10 @@
 
 static value alloc_process_status(HANDLE pid, int status)
 {
-  value res, st;
+  value st;
 
-  st = alloc(1, 0);
-  Field(st, 0) = Val_int(status);
-  Begin_root (st);
-    res = alloc_small(2, 0);
-    Field(res, 0) = Val_long((intnat) pid);
-    Field(res, 1) = st;
-  End_roots();
-  return res;
+  st = caml_alloc_1(0, Val_int(status));
+  return caml_alloc_2(0, Val_long((intnat) pid), st);
 }
 
 enum { CAML_WNOHANG = 1, CAML_WUNTRACED = 2 };


### PR DESCRIPTION
(the expected number of pull requests keeps increasing, but I'm pretty sure the next one will be the last...)

Remove most uses of `Field`. This pull request handles the large number of fairly-easy cases. The next one will contain some trickier ones that require more careful review (places where the current code relies on subtle GC invariants).

The changes to win32unix and win32graph are untested.