### PR TITLE
Moved macro 'Assert' from private zone into public space in misc.h

### DIFF
--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -80,6 +80,9 @@ CAMLextern int caml_failed_assert (char *, char *, int);
 #define CAMLassert(x) ((void) 0)
 #endif
 
+#ifndef CAML_AVOID_CONFLICTS
+#define Assert CAMLassert
+#endif  
 
 #define CAML_STATIC_ASSERT_3(b, l) \
   typedef char static_assertion_failure_line_##l[(b) ? 1 : -1]
@@ -159,10 +162,6 @@ void caml_gc_log (char *, ...)
 #define Debug_uninit_stat    0xD7
 
 #endif /* DEBUG */
-
-#ifndef CAML_AVOID_CONFLICTS
-#define Assert CAMLassert
-#endif
 
 /* snprintf emulation for Win32 */
 


### PR DESCRIPTION
I believe the macro 'Assert' was wrongly defined inside a private zone in misc.h. I have moved the macro into public space.