### PR TITLE
Testsuite fixes

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -17,17 +17,21 @@
 #  ;;
 #esac
 
+PREFIX=~/inst/ocaml
+
+set -e
+
 case $XARCH in
 i386)
   ./configure
   make world
   ;;
 x86_64)
-	./configure
-	make world
-	make world.opt
-	make -C testsuite one DIR=tests/effects
-	;;
+    mkdir -p $PREFIX
+    ./configure -prefix $PREFIX -with-debug-runtime
+    make -j4 world.opt
+    make -C testsuite all-enabled
+    ;;
 *)
   echo unknown arch
   exit 1

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -35,6 +35,14 @@ all: lib
 	done 2>&1 | tee _log
 	@$(MAKE) report
 
+.PHONY: all-enabled
+all-enabled: lib
+	@ls tests | fgrep -v -f disabled | \
+	  while read LINE; do \
+	    $(MAKE) $(NO_PRINT) exec-one DIR=tests/$$LINE; \
+	  done 2>&1 | tee _log
+	@$(MAKE) report
+
 .PHONY: list
 list: lib
 	@if [ -z "$(FILE)" ]; \

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -37,10 +37,12 @@ all: lib
 
 .PHONY: all-enabled
 all-enabled: lib
-	@ls tests | fgrep -v -f disabled | \
+	@sed -n 's/#.*//; /\//d; /./p' disabled > disabled-dirs
+	@ls tests | fgrep -v -f disabled-dirs | \
 	  while read LINE; do \
 	    $(MAKE) $(NO_PRINT) exec-one DIR=tests/$$LINE; \
 	  done 2>&1 | tee _log
+	@rm disabled-dirs
 	@$(MAKE) report
 
 .PHONY: list

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -30,6 +30,8 @@ tests/tool-ocaml/t350-heapcheck.ml
 
 # These depend on GC stats (#29)
 tests/match-exception/allocation.ml
+tests/asmcomp/optargs
+tests/asmcomp/staticalloc
 
 # ocamldebug is broken (#34)
 tool-debugger
@@ -37,6 +39,3 @@ tool-debugger
 # the pre-multicore threads library is broken (#100)
 lib-systhreads
 lib-threads
-
-# FIXME: these test cases depend on old C API/ABI
-asmcomp

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -39,5 +39,4 @@ lib-systhreads
 lib-threads
 
 # FIXME: these test cases depend on old C API/ABI
-gc-roots
 asmcomp

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -1,9 +1,43 @@
-asmcomp
-gc-roots
-lib-bigarray
-lib-bigarray-2
-lib-marshal
-lib-num
+# This file lists tests that are disabled.
+# Disabled tests must have comments linking to a Github issue number.
+# See https://github.com/ocamllabs/ocaml-multicore/issues/NNN
+
+# Either an entire directory or a specific file can be disabled here.
+# If an entire directory is listed, those tests won't even be run.
+
+
+# These depend on marshalling of closures or Custom_tag (#75)
+tests/lib-bigarray/bigarrays.ml
+tests/lib-marshal/
+tests/lib-num/
+tests/typing-objects/Tests.ml.principal.reference
+tests/typing-objects/Tests.ml.reference
+tests/lib-dynlink-bytecode/main
+tests/lib-dynlink-native/main
+
+# Effect backtraces are buggy (#108)
+tests/backtrace/backtrace_effects.ml
+
+# Unhandled effect semantics are wrong (#105)
+tests/effects/test6.ml
+
+# These depend on weak references and finalisers (#88, #92)
+tests/misc/weaklifetime.ml
+tests/misc/weaktest.ml
+tests/regression/pr5233/
+tests/tool-ocaml/t340-weak.ml
+tests/tool-ocaml/t350-heapcheck.ml
+
+# These depend on GC stats (#29)
+tests/match-exception/allocation.ml
+
+# ocamldebug is broken (#34)
+tool-debugger
+
+# the pre-multicore threads library is broken (#100)
 lib-systhreads
 lib-threads
-tool-debugger
+
+# FIXME: these test cases depend on old C API/ABI
+gc-roots
+asmcomp

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -1,0 +1,9 @@
+asmcomp
+gc-roots
+lib-bigarray
+lib-bigarray-2
+lib-marshal
+lib-num
+lib-systhreads
+lib-threads
+tool-debugger

--- a/testsuite/makefiles/summarize.awk
+++ b/testsuite/makefiles/summarize.awk
@@ -10,6 +10,15 @@
 #                                                                       #
 #########################################################################
 
+BEGIN {
+    while ((getline line < "disabled") > 0) {
+        gsub(/#.*/, "", line);
+        if (line) {
+            disabled[line] = 1;
+        }
+    }
+}
+
 function check() {
     if (!in_test){
         printf("error at line %d: found test result without test start\n", NR);
@@ -36,8 +45,13 @@ function record_skip() {
 
 function record_fail() {
     check();
-    ++ failed;
-    fail[failidx++] = sprintf ("%s/%s", curdir, curfile);
+    testcase = sprintf ("%s/%s", curdir, curfile);
+    if (disabled[testcase]) {
+        ++ ndisabled;
+    } else {
+        ++ failed;
+        fail[failidx++] = testcase;
+    }
     clear();
 }
 
@@ -99,6 +113,7 @@ END {
         printf("Summary:\n");
         printf("  %3d test(s) passed\n", passed);
         printf("  %3d test(s) failed\n", failed);
+        printf("  %3d test(s) disabled\n", ndisabled);
         printf("  %3d unexpected error(s)\n", unexped);
         if (failed != 0){
             printf("\nList of failed tests:\n");

--- a/testsuite/tests/asmcomp/Makefile
+++ b/testsuite/tests/asmcomp/Makefile
@@ -51,23 +51,23 @@ MLCASES=optargs staticalloc
 
 CASES=fib tak quicksort quicksort2 soli \
       arith checkbound tagged-fib tagged-integr tagged-quicksort tagged-tak
-ARGS_fib=-DINT_INT -DFUN=fib main.c
-ARGS_tak=-DUNIT_INT -DFUN=takmain main.c
-ARGS_quicksort=-DSORT -DFUN=quicksort main.c
-ARGS_quicksort2=-DSORT -DFUN=quicksort main.c
-ARGS_soli=-DUNIT_INT -DFUN=solitaire main.c
-ARGS_integr=-DINT_FLOAT -DFUN=test main.c
+ARGS_fib=-ccopt -DINT_INT -ccopt -DFUN=fib main.c
+ARGS_tak=-ccopt -DUNIT_INT -ccopt -DFUN=takmain main.c
+ARGS_quicksort=-ccopt -DSORT -ccopt -DFUN=quicksort main.c
+ARGS_quicksort2=-ccopt -DSORT -ccopt -DFUN=quicksort main.c
+ARGS_soli=-ccopt -DUNIT_INT -ccopt -DFUN=solitaire main.c
+ARGS_integr=-ccopt -DINT_FLOAT -ccopt -DFUN=test main.c
 ARGS_arith=mainarith.c
-ARGS_checkbound=-DCHECKBOUND main.c
-ARGS_tagged-fib=-DINT_INT -DFUN=fib main.c
-ARGS_tagged-integr=-DINT_FLOAT -DFUN=test main.c
-ARGS_tagged-quicksort=-DSORT -DFUN=quicksort main.c
-ARGS_tagged-tak=-DUNIT_INT -DFUN=takmain main.c
+ARGS_checkbound=-ccopt -DCHECKBOUND main.c
+ARGS_tagged-fib=-ccopt -DINT_INT -ccopt -DFUN=fib main.c
+ARGS_tagged-integr=-ccopt -DINT_FLOAT -ccopt -DFUN=test main.c
+ARGS_tagged-quicksort=-ccopt -DSORT -ccopt -DFUN=quicksort main.c
+ARGS_tagged-tak=-ccopt -DUNIT_INT -ccopt -DFUN=takmain main.c
 
 tests: $(CASES:=.o)
 	@for c in $(CASES); do \
 	  printf " ... testing '$$c':"; \
-	  $(MAKE) one CC="$(CC) $(CFLAGS)" NAME=$$c; \
+	  $(MAKE) one NAME=$$c; \
 	done
 	@for c in $(MLCASES); do \
 	  printf " ... testing '$$c':"; \
@@ -79,7 +79,7 @@ one_ml:
 	./$(NAME).exe && echo " => passed" || echo " => failed"
 
 one:
-	@$(CC) -o $(NAME).out $(ARGS_$(NAME)) $(NAME).o $(ARCH).o \
+	@$(OCAMLOPT) -o $(NAME).out $(ARGS_$(NAME)) $(NAME).o $(ARCH).o \
 	&& echo " => passed" || echo " => failed"
 
 clean: defaultclean

--- a/testsuite/tests/asmcomp/amd64.S
+++ b/testsuite/tests/asmcomp/amd64.S
@@ -18,14 +18,8 @@
 
 #ifdef SYS_macosx
 #define CALL_GEN_CODE _call_gen_code
-#define CAML_C_CALL _caml_c_call
-#define CAML_NEGF_MASK _caml_negf_mask
-#define CAML_ABSF_MASK _caml_absf_mask
 #else
 #define CALL_GEN_CODE call_gen_code
-#define CAML_C_CALL caml_c_call
-#define CAML_NEGF_MASK caml_negf_mask
-#define CAML_ABSF_MASK caml_absf_mask
 #endif
 
         .globl  CALL_GEN_CODE
@@ -50,26 +44,3 @@ CALL_GEN_CODE:
         popq    %rbp
         popq    %rbx
         ret
-
-        .globl  CAML_C_CALL
-        .align  ALIGN
-CAML_C_CALL:
-        jmp     *%rax
-
-#ifdef SYS_macosx
-        .literal16
-#elif defined(SYS_mingw64) || defined(SYS_cygwin)
-        .section        .rodata.cst8
-#else
-        .section        .rodata.cst8,"aM",@progbits,8
-#endif
-        .globl  CAML_NEGF_MASK
-        .align  ALIGN
-CAML_NEGF_MASK:
-        .quad   0x8000000000000000, 0
-        .globl  CAML_ABSF_MASK
-        .align  ALIGN
-CAML_ABSF_MASK:
-        .quad   0x7FFFFFFFFFFFFFFF, 0
-
-        .comm   young_limit, 8

--- a/testsuite/tests/asmcomp/main.c
+++ b/testsuite/tests/asmcomp/main.c
@@ -14,12 +14,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-
-void caml_ml_array_bound_error(void)
-{
-  fprintf(stderr, "Fatal error: out-of-bound access in array or string\n");
-  exit(2);
-}
+#include <caml/mlvalues.h>
 
 void print_string(char * s)
 {
@@ -44,22 +39,22 @@ int cmpint(const void * i, const void * j)
 
 #endif
 
-int main(int argc, char **argv)
+CAMLprim value run_prog(value varg1, value varg2, value varg3)
 {
+  long arg1 = Long_val(varg1);
+  long arg2 = Long_val(varg2);
+  long arg3 = Long_val(varg3);
+  if (arg1+arg2+arg3); /* squash unused var warnings */
 #ifdef UNIT_INT
   { extern int FUN();
     extern int call_gen_code();
     printf("%d\n", call_gen_code(FUN));
   }
 #else
-  if (argc < 2) {
-    fprintf(stderr, "Usage: %s [int arg]\n", argv[0]);
-    exit(2);
-  }
 #ifdef INT_INT
   { extern int FUN();
     extern int call_gen_code();
-    printf("%d\n", call_gen_code(FUN, atoi(argv[1])));
+    printf("%d\n", call_gen_code(FUN, arg1));
   }
 #endif
 #ifdef INT_FLOAT
@@ -68,7 +63,7 @@ int main(int argc, char **argv)
 #define call_gen_code call_gen_code_float
 #endif
     extern double call_gen_code();
-    printf("%f\n", call_gen_code(FUN, atoi(argv[1])));
+    printf("%f\n", call_gen_code(FUN, arg1));
   }
 #endif
 #ifdef SORT
@@ -78,8 +73,8 @@ int main(int argc, char **argv)
     long * a, * b;
     long i;
 
-    srand(argc >= 3 ? atoi(argv[2]) : time((time_t *) 0));
-    n = atoi(argv[1]);
+    srand(arg2 ? arg2 : time(0));
+    n = arg1;
     a = (long *) malloc(n * sizeof(long));
     for (i = 0 ; i < n; i++) a[i] = rand() & 0xFFF;
 #ifdef DEBUG
@@ -103,9 +98,9 @@ int main(int argc, char **argv)
   { extern void checkbound1(), checkbound2();
     extern void call_gen_code();
     long x, y;
-    x = atoi(argv[1]);
-    if (argc >= 3) {
-      y = atoi(argv[2]);
+    x = arg1;
+    if (arg2) {
+      y = arg2;
       if ((unsigned long) x < (unsigned long) y)
         printf("Should not trap\n");
       else
@@ -121,5 +116,5 @@ int main(int argc, char **argv)
     printf("OK\n");
   }
 #endif
-  return 0;
+  return Val_unit;
 }

--- a/testsuite/tests/asmcomp/run.ml
+++ b/testsuite/tests/asmcomp/run.ml
@@ -1,0 +1,10 @@
+external run_prog : int -> int -> int -> unit = "run_prog"
+
+let arg n =
+  if n < Array.length Sys.argv then
+    int_of_string Sys.argv.(n)
+  else
+    0
+
+let () = run_prog (arg 1) (arg 2) (arg 3)
+

--- a/testsuite/tests/callback/Makefile
+++ b/testsuite/tests/callback/Makefile
@@ -10,6 +10,7 @@
 #                                                                       #
 #########################################################################
 
+
 BASEDIR=../..
 
 CC=$(NATIVECC) -I $(CTOPDIR)/byterun
@@ -26,8 +27,8 @@ default:
 
 .PHONY: run-byte
 run-byte: 
-	@echo " ... testing 'bytecode':"
 	@for f in *.ml; do \
+	  printf " ... testing 'bytecode':"; \
 	  F=`basename $$f .ml`; \
 		$(CC) -c $$F.c; \
 		$(OCAMLC) $(COMPFLAGS) -c $$F.mli; \
@@ -40,8 +41,8 @@ run-byte:
 .PHONY: run-opt
 run-opt: 
 	@if $(BYTECODE_ONLY); then : ; else \
-		echo " ... testing 'nativecode':"; \
 		for f in *.ml; do \
+			printf " ... testing 'nativecode':"; \
 			F=`basename $$f .ml`; \
 			$(CC) -c $$F.c; \
 			mv $$F.$(O) $$F.c.$(O); \

--- a/testsuite/tests/gc-roots/globrootsprim.c
+++ b/testsuite/tests/gc-roots/globrootsprim.c
@@ -18,54 +18,50 @@
 #include "caml/alloc.h"
 #include "caml/gc.h"
 
-struct block { value header; value v; };
+struct block { value header; caml_root v; };
 
-#define Block_val(v) ((struct block*) &((value*) v)[-1])
-#define Val_block(b) ((value) &((b)->v))
+#define Root_val(v) *((caml_root*) Data_abstract_val(v))
 
 value gb_get(value vblock)
 {
-  return Block_val(vblock)->v;
+  CAMLparam1 (vblock);
+  CAMLreturn (caml_read_root(Root_val(vblock)));
 }
 
 value gb_classic_register(value v)
 {
-  struct block * b = caml_stat_alloc(sizeof(struct block));
-  b->header = Make_header(1, 0, Caml_black);
-  b->v = v;
-  caml_register_global_root(&(b->v));
-  return Val_block(b);
+  CAMLparam1(v);
+  CAMLlocal1(b);
+  b = caml_alloc(Abstract_tag, 1);
+  Root_val(b) = caml_create_root(v);
+  CAMLreturn (b);
 }
 
 value gb_classic_set(value vblock, value newval)
 {
-  Block_val(vblock)->v = newval;
-  return Val_unit;
+  CAMLparam2(vblock, newval);
+  caml_modify_root(Root_val(vblock), newval);
+  CAMLreturn (Val_unit);
 }
 
 value gb_classic_remove(value vblock)
 {
-  caml_remove_global_root(&(Block_val(vblock)->v));
-  return Val_unit;
+  CAMLparam1(vblock);
+  caml_delete_root(Root_val(vblock));
+  CAMLreturn (Val_unit);
 }
 
 value gb_generational_register(value v)
 {
-  struct block * b = caml_stat_alloc(sizeof(struct block));
-  b->header = Make_header(1, 0, Caml_black);
-  b->v = v;
-  caml_register_generational_global_root(&(b->v));
-  return Val_block(b);
+  return gb_classic_register(v);
 }
 
 value gb_generational_set(value vblock, value newval)
 {
-  caml_modify_generational_global_root(&(Block_val(vblock)->v), newval);
-  return Val_unit;
+  return gb_classic_set(vblock, newval);
 }
 
 value gb_generational_remove(value vblock)
 {
-  caml_remove_generational_global_root(&(Block_val(vblock)->v));
-  return Val_unit;
+  return gb_classic_remove(vblock);
 }

--- a/testsuite/tests/typing-extensions/extensions.ml.reference
+++ b/testsuite/tests/typing-extensions/extensions.ml.reference
@@ -70,9 +70,9 @@ Error: The constructor M.A1 has type foo but was expected to be of type bar
   type foo += B3 = M.B1  (* Error: rebind private extension *)
                    ^^^^
 Error: The constructor M.B1 is private
-#     Characters 13-24:
+#     Characters 17-24:
   type foo += C = Unknown  (* Error: unbound extension *)
-              ^^^^^^^^^^^
+                  ^^^^^^^
 Error: Unbound constructor Unknown
 #                       module M : sig type foo type foo += A1 of int end
 type M.foo += A2 of int


### PR DESCRIPTION
Get the testsuite into slightly better shape. Disables several tests that aren't expected to work at the moment, but there are still 14 failing tests. Most of these are actually about weak references or marshalling, and should probably be moved into a different directory.