### PR TITLE
Marking optimisations

### DIFF
--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -225,16 +225,12 @@ static intnat mark(value initial, intnat budget) {
     domain_state->stat_blocks_marked++;
     /* mark the current object */
     hd_v = Hd_val(v);
-    // caml_gc_log ("mark: v=0x%lx hd=0x%lx tag=%d sz=%lu",
-    //             v, hd_v, Tag_val(v), Wosize_val(v));
     if (Tag_hd (hd_v) == Stack_tag) {
-      // caml_gc_log ("mark: stack=%p", (value*)v);
       caml_darken_stack(v);
     } else if (Tag_hd (hd_v) < No_scan_tag) {
       int i;
       for (i = 0; i < Wosize_hd(hd_v); i++) {
         value child = Op_val(v)[i];
-        // caml_gc_log ("mark: v=%p i=%u child=%p",(value*)v,i,(value*)child);
         /* FIXME: this is wrong, as Debug_tag(N) is a valid value.
            However, it's a useful debugging aid for now */
         Assert(!Is_debug_tag(child) || child == Debug_uninit_major || child == Debug_uninit_minor);

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -199,6 +199,7 @@ static intnat do_some_marking(intnat budget) {
   status MARKED = global.MARKED;
   value* stack = Caml_state->mark_stack;
   uint64 stack_count = Caml_state->mark_stack_count;
+  uintnat blocks_marked = 0;
 
   while (budget > 0 && stack_count > 0) {
     value v = stack[--stack_count];
@@ -207,7 +208,7 @@ static intnat do_some_marking(intnat budget) {
     Assert(Is_markable(v));
     Assert(Tag_val(v) != Infix_tag);
 
-    domain_state->stat_blocks_marked++;
+    blocks_marked++;
     /* mark the current object */
     hd_v = Hd_val(v);
     if (Tag_hd (hd_v) == Stack_tag) {
@@ -245,6 +246,7 @@ static intnat do_some_marking(intnat budget) {
     }
     budget -= Whsize_hd(hd_v);
   }
+  Caml_state->stat_blocks_marked += blocks_marked;
   Caml_state->mark_stack_count = stack_count;
   return budget;
 }


### PR DESCRIPTION
Various optimisations to the marking loop, mainly to avoid unnecessarily touching too many bits of memory in the inner loop. Best read commit-by-commit.

On my machine, one iteration of gcstress goes from ~650ms before this patch to ~480ms afterwards.