### PR TITLE
Install .tbl files.

### DIFF
--- a/byterun/Makefile.common
+++ b/byterun/Makefile.common
@@ -66,7 +66,7 @@ install::
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) libcamlrun.$(A)
 	if test -d "$(INSTALL_LIBDIR)/caml"; then : ; \
 	  else mkdir "$(INSTALL_LIBDIR)/caml"; fi
-	for i in caml/*.h; do \
+	for i in caml/*.h caml/*.tbl; do \
 	  sed -f ../tools/cleanup-header $$i \
 	      > "$(INSTALL_LIBDIR)/$$i"; \
 	done


### PR DESCRIPTION
The `.tbl` files are [included by installed headers](https://github.com/ocamllabs/ocaml-multicore/blob/9749637d6642b48f330483a73c41c336713fbc47/byterun/caml/domain_state.h#L17), so they need to be installed, too.