### PR TITLE
Add .tbl files to byterun/Makefile

### DIFF
--- a/byterun/Makefile
+++ b/byterun/Makefile
@@ -119,7 +119,7 @@ install:
 	cp $(PROGRAMS) "$(INSTALL_BINDIR)"
 	cp $(LIBRARIES) "$(INSTALL_LIBDIR)"
 	mkdir -p "$(INSTALL_INCDIR)"
-	cp caml/*.h "$(INSTALL_INCDIR)"
+	cp caml/*.h caml/*.tbl "$(INSTALL_INCDIR)"
 
 # If primitives contain duplicated lines (e.g. because the code is defined
 # like


### PR DESCRIPTION
I installed Multicore OCaml via `opam` this evening, and, while installing `merlin`, I experienced the following error:
```
#=== ERROR while installing merlin.3.0.5 ======================================#
# opam-version 1.2.2
# os           linux
# command      make -j 4
# path         /home/belph/.opam-multicore/4.06.1+multicore/build/merlin.3.0.5
# compiler     4.06.1+multicore
# exit-code    2
# env-file     /home/belph/.opam-multicore/4.06.1+multicore/build/merlin.3.0.5/merlin-24175-ef0aa7.env
# stdout-file  /home/belph/.opam-multicore/4.06.1+multicore/build/merlin.3.0.5/merlin-24175-ef0aa7.out
# stderr-file  /home/belph/.opam-multicore/4.06.1+multicore/build/merlin.3.0.5/merlin-24175-ef0aa7.err
### stdout ###
# ocamlc -c -ccopt " \
# [...]
# ocamlc -c -ccopt " \
# 			-DNATIVE_CODE   \
# 			 -Isrc/analysis/ -Isrc/config/ -Isrc/extend/ -Isrc/frontend/ -Isrc/frontend/new/ -Isrc/frontend/old/ -Isrc/kernel/ -Isrc/ocaml/support/ -Isrc/ocaml/typer/ -Isrc/ocaml/typer/parsing/ -Isrc/ocaml/typer/typing/ -Isrc/ocaml/typer/utils/ -Isrc/platform/ -Isrc/sturgeon/ -Isrc/utils/   -o src/platform/os_ipc_stub.o " src/platform/os_ipc_stub.c
# OCamlMakefile:1135: recipe for target 'src/platform/platform_misc.o' failed
# OCamlMakefile:1135: recipe for target 'src/platform/os_ipc_stub.o' failed
# make[2]: Leaving directory '/home/belph/.opam-multicore/4.06.1+multicore/build/merlin.3.0.5'
# OCamlMakefile:780: recipe for target 'native-code' failed
# make[1]: Leaving directory '/home/belph/.opam-multicore/4.06.1+multicore/build/merlin.3.0.5'
# Makefile:56: recipe for target 'ocamlmerlin-server' failed
### stderr ###
# [...]
# compilation terminated.
# make[2]: *** [src/platform/platform_misc.o] Error 2
# make[2]: *** Waiting for unfinished jobs....
# In file included from /home/belph/.opam-multicore/4.06.1+multicore/lib/ocaml/caml/mlvalues.h:36:0,
#                  from src/platform/os_ipc_stub.c:27:
# /home/belph/.opam-multicore/4.06.1+multicore/lib/ocaml/caml/domain_state.h:17:28: fatal error: domain_state.tbl: No such file or directory
# compilation terminated.
# make[2]: *** [src/platform/os_ipc_stub.o] Error 2
# make[1]: *** [native-code] Error 2
# make: *** [ocamlmerlin-server] Error 2
```
Upon further inspection, it looks like the `.tbl` files in `byterun` are not being installed by `opam`. I was able to reproduce this with a build off of `master`:
```
 λ ~ git:(master) cd ocaml-multicore
 λ ocaml-multicore git:(master) ./configure -prefix /home/belph/built-ocaml-multicore
 λ ocaml-multicore git:(master) make world.opt |& tee log.install
 λ ocaml-multicore git:(master) ✗ make install |& tee -a log.install
 λ ocaml-multicore git:(master) ✗ ls ../built-ocaml-multicore/lib/ocaml/caml
address_class.h   compatibility.h  fail.h       instrtrace.h    major_gc.h  platform.h         sizeclasses.h  unixsupport.h
addrmap.h         config.h         fiber.h      instruct.h      md5.h       prims.h            socketaddr.h   version.h
alloc.h           custom.h         finalise.h   int64_emul.h    memory.h    printexc.h         spacetime.h    weak.h
backtrace.h       debugger.h       fix_code.h   int64_format.h  m.h         reverse.h          stack.h
backtrace_prim.h  domain.h         gc_ctrl.h    int64_native.h  minor_gc.h  roots.h            startup_aux.h
bigarray.h        domain_state.h   gc.h         interp.h        misc.h      s.h                startup.h
callback.h        dynlink.h        globroots.h  intext.h        mlvalues.h  shared_heap.h      sys.h
compact.h         eventlog.h       hash.h       io.h            osdeps.h    signals.h          threads.h
compare.h         exec.h           hooks.h      jumptbl.h       params.h    signals_machdep.h  ui.h
```
(As an aside, I'd imagine that any CI tests run based out of the build directory as opposed to the `-prefix` directory, meaning that this problem would not be immediately obvious from test failures...though I might be wrong.)

While it looks like a fix for this exact issue was added to `byterun/Makefile.common` in 499385d, I am not seeing where `Makefile.common` is actually used by `make world.opt`'s build process (I could just be missing it, but maybe _this_ is the real bug?).

I have gone ahead and patched `byterun/Makefile` in the meantime in this pull request, confirming that the problem is fixed after running `make install` again following the patch:
```
 λ ocaml-multicore git:(install-tbl) ✗ ls ../built-ocaml-multicore/lib/ocaml/caml/ | grep '\.tbl' 
byte_domain_state.tbl
domain_state.tbl
```

I haven't contributed to OCaml before, so it's also certainly possible that this is a known/in-progress issue; if so, apologies for the spam!