### PR TITLE
Various improvements and fixes.

### DIFF
--- a/byterun/caml/memory.h
+++ b/byterun/caml/memory.h
@@ -66,6 +66,10 @@ CAMLextern char *caml_alloc_for_heap (asize_t request);   /* Size in bytes. */
 CAMLextern void caml_free_for_heap (char *mem);
 CAMLextern int caml_add_to_heap (char *mem);
 
+#ifdef CAML_INTERNALS
+int caml_atomic_cas_raw (value* p, value oldv, value newv);
+#endif
+
 CAMLextern int caml_huge_fallback_count; /* FIXME KC: Make per domain */
 
 

--- a/byterun/caml/platform.h
+++ b/byterun/caml/platform.h
@@ -96,7 +96,6 @@ INLINE void atomic_store_rel(atomic_uintnat* p, uintnat v) {
 #error "unsupported platform (i.e. not x86)"
 #endif
 
-
 /* Spin-wait loops */
 
 #define Max_spins 1000
@@ -109,7 +108,6 @@ unsigned caml_plat_spin_wait(unsigned spins,
 #define GENSYM_2(name, l) GENSYM_3(name, l)
 #define GENSYM(name) GENSYM_2(name, __LINE__)
 
-
 #define SPIN_WAIT                                                       \
   unsigned GENSYM(caml__spins) = 0;                                     \
   for (; 1; cpu_relax(),                                                \
@@ -119,15 +117,12 @@ unsigned caml_plat_spin_wait(unsigned spins,
          caml_plat_spin_wait(GENSYM(caml__spins),                       \
                              __FILE__, __LINE__, __func__))
 
-
 INLINE uintnat atomic_load_wait_nonzero(atomic_uintnat* p) {
   SPIN_WAIT {
     uintnat v = atomic_load_acq(p);
     if (v) return v;
   }
 }
-
-
 
 /* Atomic read-modify-write instructions, with full fences */
 
@@ -152,10 +147,6 @@ INLINE void atomic_cas_strong(atomic_uintnat* p, uintnat vold, uintnat vnew) {
 #else
 #error "unsupported platform"
 #endif
-
-
-
-
 
 typedef pthread_mutex_t caml_plat_mutex;
 #define CAML_PLAT_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER

--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -81,6 +81,7 @@ static caml_plat_mutex all_domains_lock = CAML_PLAT_MUTEX_INITIALIZER;
 static caml_plat_cond all_domains_cond = CAML_PLAT_COND_INITIALIZER(&all_domains_lock);
 static dom_internal* stw_leader = 0;
 static struct dom_internal all_domains[Max_domains];
+static atomic_uintnat num_domains_running = {0};
 
 static uintnat minor_heaps_base;
 static __thread dom_internal* domain_self;
@@ -191,6 +192,7 @@ static void create_domain(uintnat initial_minor_heap_size) {
       }
       Assert(s->qhead == NULL);
       s->running = 1;
+      atomic_fetch_add(&num_domains_running, 1);
     }
     caml_plat_unlock(&s->lock);
   }
@@ -385,20 +387,7 @@ struct domain* caml_domain_self()
 
 int caml_domain_alone()
 {
-  int i, found = 0;
-  caml_plat_lock(&all_domains_lock);
-  for (i = 0;
-       i < Max_domains &&
-         !found;
-       i++) {
-    struct interruptor* s = &all_domains[i].interruptor;
-    if (s == &domain_self->interruptor) continue;
-    caml_plat_lock(&s->lock);
-    if (s->running) found = 1;
-    caml_plat_unlock(&s->lock);
-  }
-  caml_plat_unlock(&all_domains_lock);
-  return !found;
+  return atomic_load_acq(&num_domains_running) == 1;
 }
 
 struct domain* caml_owner_of_young_block(value v) {
@@ -822,6 +811,7 @@ static void domain_terminate() {
         Caml_state->sweeping_done) {
       finished = 1;
       s->running = 0;
+      atomic_fetch_add(&num_domains_running, -1);
       s->unique_id += Max_domains;
     }
     caml_plat_unlock(&s->lock);

--- a/testsuite/tests/parallel/domain_id.ml
+++ b/testsuite/tests/parallel/domain_id.ml
@@ -13,7 +13,7 @@ let test_domain_reuse () =
   (* checks that domain slots are getting reused quickly,
      by checking that subsequent domain IDs are an arithmetic
      progression (implies that you're getting the same domain
-     over and over, but its ID increases by Max_domains. 
+     over and over, but its ID increases by Max_domains.
 
      this test has to run first, since it makes assumptions
      about domain IDs *)


### PR DESCRIPTION
Fix a bug with handling of Infix tag objects being pointed to from
remebered major refs at the end of minor GC.

Introduce num_domains_running variable that keeps track of the same. Use
this for non atomic versions of atomic operations when only one domain
is running.

Remove suspect `caml_darken`s in minor_gc.c. 