### PR TITLE
Fix a race condition in parallel/join.ml.

### DIFF
--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -827,9 +827,7 @@ static void domain_terminate() {
     Caml_state->critical_section_nesting = 0;
     acknowledge_all_pending_interrupts();
   }
-  caml_ev_resume();
-  caml_enter_blocking_section();
-  caml_ev_resume();
+  caml_plat_unlock(&domain_self->roots_lock);
   caml_plat_assert_all_locks_unlocked();
 }
 


### PR DESCRIPTION
The test used multiple `incr` from different threads with no sync.
Instead, use an array of separate flags.

Also, squash a warning by using an exception other than Failure
when matching on a particular string.