### PR TITLE
Fixes issue 204

### DIFF
--- a/testsuite/tests/effects-disallowed/Makefile
+++ b/testsuite/tests/effects-disallowed/Makefile
@@ -1,0 +1,18 @@
+#**************************************************************************
+#*                                                                        *
+#*                                OCaml                                   *
+#*                                                                        *
+#*                 Xavier Clerc, SED, INRIA Rocquencourt                  *
+#*                                                                        *
+#*   Copyright 2010 Institut National de Recherche en Informatique et     *
+#*     en Automatique.                                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+BASEDIR=../..
+include $(BASEDIR)/makefiles/Makefile.toplevel
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/effects-disallowed/when_test.ml
+++ b/testsuite/tests/effects-disallowed/when_test.ml
@@ -1,0 +1,11 @@
+(* TEST
+   * toplevel
+*)
+
+effect E : unit;;
+let () =
+  (match perform E with
+   | v -> v
+   | effect E k when (continue k (); false) -> assert false
+   | effect E k' -> continue k' ())
+;;

--- a/testsuite/tests/effects-disallowed/when_test.ml.reference
+++ b/testsuite/tests/effects-disallowed/when_test.ml.reference
@@ -1,0 +1,7 @@
+
+# * *     effect E : unit
+#           Characters 76-77:
+     | effect E k when (continue k (); false) -> assert false
+                                 ^
+Error: Unbound value k
+# 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4623,7 +4623,7 @@ and type_cases ?in_function env ty_arg ty_res ?conts partial_flag loc caselist =
   let cases =
     List.map2
       (fun (pat, (ext_env, unpacks), cont) {pc_lhs; pc_guard; pc_rhs} ->
-        let cont, ext_env =
+        let cont, ext_env' =
           match cont with
           | Some (id, desc) ->
               let ext_env =
@@ -4649,11 +4649,17 @@ and type_cases ?in_function env ty_arg ty_res ?conts partial_flag loc caselist =
           match pc_guard with
           | None -> None
           | Some scond ->
-              Some
+             (* It is crucial that the continuation is not used in the
+                `when' expression as the extent of the continuation is
+                yet to be determined. We make the continuation
+                inaccessible by typing the `when' expression using the
+                environment `ext_env' which does not bind the
+                continuation variable. *)
+             Some
                 (type_expect ext_env (wrap_unpacks scond unpacks)
                    Predef.type_bool)
         in
-        let exp = type_expect ?in_function ext_env sexp ty_res' in
+        let exp = type_expect ?in_function ext_env' sexp ty_res' in
         {
          c_lhs = pat;
          c_cont = cont;


### PR DESCRIPTION
.. by making the continuation variable inaccessible in `when` expressions. The fix is rather simple, we keep two typing environments live `ext_env` and `ext_env'`, where the latter is an extension of the former with the continuation variable bound. We use `ext_env` when typing the `when` expression, and `ext_env'` when typing the clause body.