### PR TITLE
When profiling is enabled, run mcount on the C stack.

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -1012,12 +1012,22 @@ let emit_profile () =
        all the registers used for argument passing, so we don't
        need to preserve other regs.  We do need to initialize rbp
        like mcount expects it, though. *)
+    if not fp then I.lea (mem64 NONE (-8) RSP) rbp;
+    I.mov rsp r10;
+    I.mov r15 r11;
+    locate_domain_state r11;
+    cfi_remember_state ();
+    I.mov (domain_field Domainstate.Domain_system_sp R11) rsp;
+    cfi_def_cfa_offset 8;
     I.push r10;
-    if not fp then I.mov rsp rbp;
+    cfi_adjust_cfa_offset 8;
     (* No Spacetime instrumentation needed: [mcount] cannot call anything
        OCaml-related. *)
     emit_call "mcount";
-    I.pop r10
+    I.pop r10;
+    cfi_adjust_cfa_offset (-8);
+    I.mov r10 rsp;
+    cfi_restore_state()
   end
 
 let all_functions = ref []


### PR DESCRIPTION
This patch runs the profiling function `mcount` as a C extcall, using the system stack instead of fiber stacks. The `mcount` primitive only needs to see a return address at `*(rsp)` and a second return address at `*(rbp + 8)`, and never inspects the stack, so it doesn't care what stack it runs on.

This makes the profile slop space unnecessary. I'll send a separate PR to remove the slop space after #203 is merged, since otherwise there will be conflicts.