### PR TITLE
Stack pointer refactor

### DIFF
--- a/asmrun/amd64.S
+++ b/asmrun/amd64.S
@@ -168,19 +168,15 @@
 /* Stack switching operations */
 /******************************************************************************/
 
-/* Switch from OCaml to C stack. Clobbers REG & %r14. */
+/* Switch from OCaml to C stack. Clobbers %r14. */
 #define SWITCH_OCAML_TO_C_NO_CTXT(REG) \
     /* Save OCaml SP in the stack slot */ \
-        mov     %rsp, REG; \
-        LOAD_TL_VAR(caml_stack_high, %r14); \
-        subq    %r14, REG; \
-        sarq    $3, REG; \
         LOAD_TL_VAR(caml_current_stack, %r14); \
-        movq    REG, (%r14); \
+        movq    %rsp, Stack_sp(%r14); \
     /* Switch to system stack */ \
         LOAD_TL_VAR(caml_system_sp, %r14); \
+        movq    %rsp, 16(%r14); /* For DWARF CFI. See OFFXXX. */ \
         movq    %r14, %rsp; \
-        movq    REG, 16(%rsp); /* For DWARF CFI. See OFFXXX. */ \
         .cfi_def_cfa_offset 8 /* SYSCFAXXX */
 
 /* Switch from OCaml to C stack. Also builds a context at
@@ -191,16 +187,12 @@
         pushq   %r14; CFI_ADJUST(8); \
         SWITCH_OCAML_TO_C_NO_CTXT(REG)
 
-/* Switch from C to OCaml stack.  Clobbers REG & %r14. */
+/* Switch from C to OCaml stack.  Clobbers REG. */
 #define SWITCH_C_TO_OCAML_NO_CTXT(REG,CFA_OFF) \
     /* Switch to OCaml stack */ \
-        LOAD_TL_VAR(caml_stack_high, %r14); \
         LOAD_TL_VAR(caml_current_stack, REG); \
     /* REG is Stack_sp(caml_current_stack) */ \
-        movq    (REG), REG; \
-        salq    $3, REG; \
-        addq    REG, %r14; \
-        movq    %r14, %rsp; \
+        movq    Stack_sp(REG), %rsp; \
         .cfi_def_cfa_offset CFA_OFF
 
 /* Switch from C to OCaml stack. Also pops the context
@@ -1052,7 +1044,6 @@ CFI_STARTPROC
     /* In handler. %rax has exception */
         mov     %rax, %rbx
         LOAD_TL_VAR(caml_current_stack, %rsi)
-        movq    $0, Stack_sp(%rsi)                  /* zero SP */
         movq    Stack_handle_exception(%rsi), %r12  /* exception handler */
         movq    Stack_parent(%rsi), %rdi            /* parent stack. Never NULL here. */
     /* Switch stacks */
@@ -1070,7 +1061,6 @@ LBL(111):
     /* In handler. %rax has value */
         mov     %rax, %rbx
         LOAD_TL_VAR(caml_current_stack, %rsi)
-        movq    $0, Stack_sp(%rsi)                /* zero SP */
         movq    Stack_handle_value(%rsi), %r12    /* value handler */
         movq    Stack_parent(%rsi), %rdi          /* parent stack. Never NULL here. */
     /* Reset stack. First pop off fiber exn handler. */

--- a/byterun/backtrace_prim.c
+++ b/byterun/backtrace_prim.c
@@ -353,7 +353,7 @@ CAMLprim value caml_get_current_callstack (value max_frames_value)
 {
   code_t* trace;
   intnat trace_len;
-  get_callstack(Caml_state->extern_sp, Caml_state->trap_sp_off,
+  get_callstack(Caml_state->current_stack->sp, Caml_state->trap_sp_off,
                 Caml_state->current_stack, Long_val(max_frames_value),
                 &trace, &trace_len);
   return alloc_callstack(trace, trace_len);

--- a/byterun/backtrace_prim.c
+++ b/byterun/backtrace_prim.c
@@ -301,7 +301,7 @@ static void get_callstack(value* sp, intnat trap_spoff,
       code_t p = caml_next_frame_pointer(stack_high, &sp, &trap_spoff);
       if (p == NULL) {
         if (parent == NULL) break;
-        sp = Stack_high(parent) + Stack_sp(parent);
+        sp = parent->sp;
         trap_spoff = Long_val(sp[0]);
         stack_high = Stack_high(parent);
         parent = Stack_parent(parent);
@@ -325,7 +325,7 @@ static void get_callstack(value* sp, intnat trap_spoff,
     while (trace_pos < *trace_size) {
       code_t p = caml_next_frame_pointer(stack_high, &sp, &trap_spoff);
       if (p == NULL) {
-        sp = Stack_high(parent) + Stack_sp(parent);
+        sp = parent->sp;
         trap_spoff = Long_val(sp[0]);
         stack_high = Stack_high(parent);
         parent = Stack_parent(parent);
@@ -369,7 +369,7 @@ CAMLprim value caml_get_continuation_callstack (value cont, value max_frames)
   stack = Ptr_val(caml_continuation_use(cont));
   {
     CAMLnoalloc; /* GC must not see the stack outside the cont */
-    sp = Stack_high(stack) + Stack_sp(stack);
+    sp = stack->sp;
     get_callstack(sp, Long_val(sp[0]), stack, Long_val(max_frames),
                   &trace, &trace_len);
     caml_continuation_replace(cont, stack);

--- a/byterun/callback.c
+++ b/byterun/callback.c
@@ -56,8 +56,8 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[])
   Stack_parent(domain_state->current_stack) = NULL;
 
   CAMLassert(narg + 4 <= 256);
-  domain_state->extern_sp -= narg + 4;
-  for (i = 0; i < narg; i++) domain_state->extern_sp[i] = args[i]; /* arguments */
+  domain_state->current_stack->sp -= narg + 4;
+  for (i = 0; i < narg; i++) domain_state->current_stack->sp[i] = args[i]; /* arguments */
 
   opcode_t code[7] = {
     callback_code[0], narg + 3,
@@ -65,12 +65,12 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[])
     callback_code[4], callback_code[5], callback_code[6]
   };
 
-  domain_state->extern_sp[narg] = Val_pc (code + 4); /* return address */
-  domain_state->extern_sp[narg + 1] = Val_unit;    /* environment */
-  domain_state->extern_sp[narg + 2] = Val_long(0); /* extra args */
-  domain_state->extern_sp[narg + 3] = closure;
+  domain_state->current_stack->sp[narg] = Val_pc (code + 4); /* return address */
+  domain_state->current_stack->sp[narg + 1] = Val_unit;    /* environment */
+  domain_state->current_stack->sp[narg + 2] = Val_long(0); /* extra args */
+  domain_state->current_stack->sp[narg + 3] = closure;
   res = caml_interprete(code, sizeof(code));
-  if (Is_exception_result(res)) domain_state->extern_sp += narg + 4; /* PR#1228 */
+  if (Is_exception_result(res)) domain_state->current_stack->sp += narg + 4; /* PR#1228 */
 
   Assert(Stack_parent(domain_state->current_stack) == NULL);
   Stack_parent(domain_state->current_stack) = parent_stack;

--- a/byterun/caml/fiber.h
+++ b/byterun/caml/fiber.h
@@ -9,7 +9,7 @@
 #include "roots.h"
 
 struct stack_info {
-  long sp;
+  void* sp;
   value handle_value;
   value handle_exn;
   value handle_effect;
@@ -27,7 +27,6 @@ struct stack_info {
  * the Op_val(stk) + Wosize_val(stk) is not 16-byte aligned. */
 #define Stack_high(stk) ((value*)(((uintnat)stk + sizeof(value) * stk->wosize) & (-1uLL << 4)))
 
-#define Stack_sp(stk) (stk)->sp
 #define Stack_handle_value(stk) (stk)->handle_value
 #define Stack_handle_exception(stk) (stk)->handle_exn
 #define Stack_handle_effect(stk) (stk)->handle_effect

--- a/byterun/caml/fiber.h
+++ b/byterun/caml/fiber.h
@@ -9,7 +9,11 @@
 #include "roots.h"
 
 struct stack_info {
+#ifdef NATIVE_CODE
   void* sp;
+#else
+  value* sp;
+#endif
   value handle_value;
   value handle_exn;
   value handle_effect;

--- a/byterun/caml/fiber.h
+++ b/byterun/caml/fiber.h
@@ -93,8 +93,6 @@ extern caml_root caml_global_data;
 struct stack_info* caml_alloc_main_stack (uintnat init_size);
 void caml_init_main_stack(void);
 void caml_scan_stack(scanning_action f, void* fdata, struct stack_info* stack);
-void caml_save_stack_gc();
-void caml_restore_stack_gc();
 void caml_restore_stack();
 void caml_realloc_stack (asize_t required_size, value* save, int nsave);
 void caml_change_max_stack_size (uintnat new_max_size);

--- a/byterun/caml/minor_gc.h
+++ b/byterun/caml/minor_gc.h
@@ -66,7 +66,6 @@ void caml_free_minor_tables(struct caml_minor_tables*);
 
 struct domain;
 CAMLextern value caml_promote(struct domain*, value root);
-int caml_stack_is_saved (void);
 
 #define Ref_table_add(ref_table, x) do {                                \
     struct caml_ref_table* ref = (ref_table);                           \

--- a/byterun/debugger.c
+++ b/byterun/debugger.c
@@ -269,7 +269,7 @@ void caml_debugger(enum event_kind event)
   if (dbg_socket == -1) return;  /* Not connected to a debugger. */
 
   /* Reset current frame */
-  frame = Caml_state->extern_sp + 1;
+  frame = Caml_state->current_stack->sp + 1;
 
   /* Report the event to the debugger */
   switch(event) {
@@ -356,7 +356,7 @@ void caml_debugger(enum event_kind event)
 #endif
       break;
     case REQ_INITIAL_FRAME:
-      frame = Caml_state->extern_sp + 1;
+      frame = Caml_state->current_stack->sp + 1;
       /* Fall through */
     case REQ_GET_FRAME:
       caml_putword(dbg_out, Caml_state->stack_high - frame);
@@ -402,7 +402,7 @@ void caml_debugger(enum event_kind event)
       caml_flush(dbg_out);
       break;
     case REQ_GET_ACCU:
-      putval(dbg_out, *Caml_state->extern_sp);
+      putval(dbg_out, *Caml_state->current_stack->sp);
       caml_flush(dbg_out);
       break;
     case REQ_GET_HEADER:

--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -618,13 +618,11 @@ CAMLexport void (*caml_leave_blocking_section_hook)(void) =
 CAMLexport void caml_leave_blocking_section() {
   caml_plat_lock(&domain_self->roots_lock);
   caml_leave_blocking_section_hook();
-  caml_restore_stack_gc();
   caml_process_pending_signals();
 }
 
 CAMLexport void caml_enter_blocking_section() {
   caml_process_pending_signals();
-  caml_save_stack_gc();
   caml_enter_blocking_section_hook();
   caml_plat_unlock(&domain_self->roots_lock);
 }

--- a/byterun/fiber.c
+++ b/byterun/fiber.c
@@ -194,11 +194,9 @@ static struct stack_info* save_stack ()
 {
   caml_domain_state* domain_state = Caml_state;
   struct stack_info* old_stack = domain_state->current_stack;
-  old_stack->sp = domain_state->extern_sp;
   Assert(domain_state->stack_threshold ==
          Stack_base(old_stack) + Stack_threshold / sizeof(value));
   Assert(domain_state->stack_high == Stack_high(old_stack));
-  Assert(domain_state->extern_sp == old_stack->sp);
   return old_stack;
 }
 
@@ -208,7 +206,6 @@ static void load_stack(struct stack_info* new_stack)
   domain_state->stack_threshold =
     Stack_base(new_stack) + Stack_threshold / sizeof(value);
   domain_state->stack_high = Stack_high(new_stack);
-  domain_state->extern_sp = new_stack->sp;
   domain_state->current_stack = new_stack;
 }
 
@@ -239,14 +236,14 @@ CAMLprim value caml_alloc_stack(value hval, value hexn, value heff)
 CAMLprim value caml_ensure_stack_capacity(value required_space)
 {
   asize_t req = Long_val(required_space);
-  if (Caml_state->extern_sp - req < Stack_base(Caml_state->current_stack))
+  if (Caml_state->current_stack->sp - req < Stack_base(Caml_state->current_stack))
     caml_realloc_stack(req, 0, 0);
   return Val_unit;
 }
 
 void caml_change_max_stack_size (uintnat new_max_size)
 {
-  asize_t size = Caml_state->stack_high - Caml_state->extern_sp
+  asize_t size = Caml_state->stack_high - Caml_state->current_stack->sp
                  + Stack_threshold / sizeof (value);
 
   if (new_max_size < size) new_max_size = size;

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -839,7 +839,6 @@ static intnat major_collection_slice(intnat howmuch,
   uintnat saved_ephe_cycle;
   uintnat saved_major_cycle;
 
-  caml_save_stack_gc();
   caml_ev_begin("major_gc/slice");
 
   if (!domain_state->sweeping_done) {
@@ -975,8 +974,6 @@ mark_again:
   domain_state->stat_major_words += domain_state->allocated_words;
   domain_state->allocated_words = 0;
 
-  caml_restore_stack_gc();
-
   if (is_complete_phase_sweep_ephe(d)) {
     saved_major_cycle = caml_major_cycles_completed;
     /* To handle the case where multiple domains try to finish the major
@@ -1031,11 +1028,9 @@ void caml_empty_mark_stack () {
 void caml_finish_marking () {
   if (!Caml_state->marking_done) {
     caml_ev_begin("major_gc/finish_marking");
-    caml_save_stack_gc();
     caml_empty_mark_stack();
     Caml_state->stat_major_words += Caml_state->allocated_words;
     Caml_state->allocated_words = 0;
-    caml_restore_stack_gc();
     caml_ev_end("major_gc/finish_marking");
   }
 }

--- a/byterun/meta.c
+++ b/byterun/meta.c
@@ -130,7 +130,7 @@ CAMLprim value caml_realloc_global(value size)
 
 CAMLprim value caml_get_current_environment(value unit)
 {
-  return *Caml_state->extern_sp;
+  return *Caml_state->current_stack->sp;
 }
 
 CAMLprim value caml_invoke_traced_function(value codeptr, value env, value arg)
@@ -162,9 +162,9 @@ CAMLprim value caml_invoke_traced_function(value codeptr, value env, value arg)
   value * osp, * nsp;
   int i;
 
-  osp = domain_state->extern_sp;
-  domain_state->extern_sp -= 4;
-  nsp = domain_state->extern_sp;
+  osp = domain_state->current_stack->sp;
+  domain_state->current_stack->sp -= 4;
+  nsp = domain_state->current_stack->sp;
   for (i = 0; i < 6; i++) nsp[i] = osp[i];
   nsp[6] = codeptr;
   nsp[7] = env;

--- a/byterun/shared_heap.c
+++ b/byterun/shared_heap.c
@@ -560,13 +560,11 @@ static void verify_object(struct heap_verify_state* st, value v) {
 }
 
 void caml_verify_heap(struct heap_verify_state* st) {
-  caml_save_stack_gc();
   while (st->sp) verify_object(st, st->stack[--st->sp]);
 
   caml_addrmap_clear(&st->seen);
   caml_stat_free(st->stack);
   caml_stat_free(st);
-  caml_restore_stack_gc();
 }
 
 

--- a/byterun/startup.c
+++ b/byterun/startup.c
@@ -372,7 +372,7 @@ CAMLexport void caml_main(char_os **argv)
   if (Is_exception_result(res)) {
     Caml_state->exn_bucket = Extract_exception(res);
     if (caml_debugger_in_use) {
-      Caml_state->extern_sp = &Caml_state->exn_bucket; /* The debugger needs the
+      Caml_state->current_stack->sp = &Caml_state->exn_bucket; /* The debugger needs the
                                                exception value.*/
       caml_debugger(UNCAUGHT_EXC);
     }
@@ -460,7 +460,7 @@ CAMLexport void caml_startup_code(
   if (Is_exception_result(res)) {
     Caml_state->exn_bucket = Extract_exception(res);
     if (caml_debugger_in_use) {
-      Caml_state->extern_sp = &Caml_state->exn_bucket; /* The debugger needs the
+      Caml_state->current_stack->sp = &Caml_state->exn_bucket; /* The debugger needs the
                                                exception value.*/
       caml_debugger(UNCAUGHT_EXC);
     }

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -186,8 +186,7 @@ static inline void caml_thread_save_runtime_state(void)
     = caml_spacetime_finaliser_trie_root;
 #endif
 #else
-  Stack_sp(Caml_state->current_stack) =
-    Caml_state->extern_sp - Caml_state->stack_high;
+  Caml_state->current_stack->sp = Caml_state->extern_sp;
   curr_thread->trap_sp_off = Caml_state->trap_sp_off;
   curr_thread->trap_barrier_off = Caml_state->trap_barrier_off;
   curr_thread->external_raise = Caml_state->external_raise;
@@ -297,7 +296,7 @@ static caml_thread_t caml_thread_new_info(void)
   stack = caml_stat_alloc(sizeof(value) * Thread_stack_size);
   stack->wosize = Thread_stack_size;
   stack->magic = 42;
-  Stack_sp(stack) = 0;
+  stack->sp = Stack_high(stack);
   Stack_handle_value(stack) = Val_long(0);
   Stack_handle_exception(stack) = Val_long(0);
   Stack_handle_effect(stack) = Val_long(0);

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -186,7 +186,7 @@ static inline void caml_thread_save_runtime_state(void)
     = caml_spacetime_finaliser_trie_root;
 #endif
 #else
-  Caml_state->current_stack->sp = Caml_state->extern_sp;
+  Caml_state->current_stack->sp = Caml_state->current_stack->sp;
   curr_thread->trap_sp_off = Caml_state->trap_sp_off;
   curr_thread->trap_barrier_off = Caml_state->trap_barrier_off;
   curr_thread->external_raise = Caml_state->external_raise;

--- a/otherlibs/threads/scheduler.c
+++ b/otherlibs/threads/scheduler.c
@@ -550,12 +550,12 @@ static void thread_reschedule(void)
   CAMLassert(curr_thread != NULL);
   /* Pop accu from event frame, making it look like a C_CALL frame
      followed by a RETURN frame */
-  accu = *Caml_state->extern_sp++;
+  accu = *Caml_state->current_stack->sp++;
   /* Reschedule */
   Assign(curr_thread->retval, accu);
   accu = schedule_thread();
   /* Push accu below C_CALL frame so that it looks like an event frame */
-  *--Caml_state->extern_sp = accu;
+  *--Caml_state->current_stack->sp = accu;
 }
 
 /* Request a re-scheduling as soon as possible */


### PR DESCRIPTION
Now that stacks no longer move during GC, it's safe to store stack pointers directly rather than as offsets. This simplifies the computations necessary to restore stack pointers in amd64.S.

This makes `caml_extern_sp` redundant, so it's removed. That makes `caml_save/restore_stack_gc` no-ops, so they're gone too.