### PR TITLE
Improve performance by doing fewer read barriers.

### DIFF
--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -436,6 +436,12 @@ let specialize_primitive p env ty ~has_constant_constructor =
     match (p, params) with
       (Psetfield(n, _, init), [_p1; p2]) ->
         Psetfield(n, maybe_pointer_type env p2, init)
+    | (Pfield (n, Pointer, mut), _) ->
+       (* try strength reduction based on the *result type* *)
+       let is_int = match is_function_type env ty with
+         | None -> Pointer
+         | Some (_p1, rhs) -> maybe_pointer_type env rhs in
+       Pfield (n, is_int, mut)
     | (Parraylength t, [p])   ->
         Parraylength(glb_array_type t (array_type_kind env p))
     | (Parrayrefu t, p1 :: _) ->

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -1029,7 +1029,7 @@ let transl_store_structure glob map prims str =
       match cc with
         Tcoerce_none ->
           Ident.add id
-            (Lprim(Pfield (pos, Pointer, Mutable),
+            (Lprim(Pfield (pos, Pointer, Immutable),
                    [Lprim(Pgetglobal glob, [], Location.none)],
                    Location.none))
             subst


### PR DESCRIPTION
  - Read barriers were done on references to global constants
    in native code due to a missed case in translmod.ml
  - Read barriers were done on loads of int refs due to a
    missed optimisation in translcore.ml