### PR TITLE
Shorten read barrier code on x86-64

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -707,8 +707,9 @@ let emit_instr fallthrough i =
       I.sub (nat s) rax;
       let bits = Domainstate.minor_heap_align_bits + Domainstate.minor_heap_sel_bits in
       let minor_val_bitmask = Nativeint.(logor one (shift_left minus_one bits)) in
-      I.mov (nat minor_val_bitmask) rdx;
-      I.test rdx rax;
+      (* The test instruction sign-extends a 32-bit immediate *)
+      assert (minor_val_bitmask = Nativeint.(minor_val_bitmask |> to_int32 |> of_int32));
+      I.test (nat minor_val_bitmask) rax;
       let lbl_call_read_barrier = new_label () in
       let lbl_return = new_label () in
       let lbl_frame = record_frame_label i.live false Debuginfo.none in

--- a/byterun/caml/config.h
+++ b/byterun/caml/config.h
@@ -173,7 +173,7 @@ typedef uint64_t uintnat;
 
 /* There may be at most 1<<Minor_heap_sel_bits minor
    heaps allocated */
-#define Minor_heap_sel_bits 8
+#define Minor_heap_sel_bits 7
 
 /* An entire minor heap must fit inside one region
    of size 1 << Minor_heap_align_bits, which determines

--- a/utils/domainstate.ml.c
+++ b/utils/domainstate.ml.c
@@ -1,4 +1,3 @@
-
 #define CAML_CONFIG_H_NO_TYPEDEFS
 #include "config.h"
 let minor_heap_sel_bits = Minor_heap_sel_bits


### PR DESCRIPTION
This patch lowers Max_domains from 256 to 128, which makes the read barrier mask fit in a sign-extended 32-bit immediate constant. This saves code size on x86-64, replacing a 13-byte sequence:

    movabs MASK64, %rdx
    test %rdx, %rax

with a 6-byte sequence:

    test MASK32, %rax