### PR TITLE
R14 globals

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -963,15 +963,18 @@ let emit_instr fallthrough i =
       I.call (label lbl)
   | Lpushtrap ->
       cfi_adjust_cfa_offset 8;
-      I.push r14;
-      cfi_adjust_cfa_offset 8;
       I.mov r15 r14;
       locate_domain_state r14;
-      I.mov (domain_field Domainstate.Domain_stack_high R14) r14;
-      I.sub rsp r14;
+      I.push (domain_field Domainstate.Domain_exn_handler R14);
+      cfi_adjust_cfa_offset 8;
+      I.sub rsp (mem64 NONE 0 RSP);
+      I.mov rsp (domain_field Domainstate.Domain_exn_handler R14);
       stack_offset := !stack_offset + 16
   | Lpoptrap ->
-      I.pop r14;
+      I.add rsp (mem64 NONE 0 RSP);
+      I.mov r15 r14;
+      locate_domain_state r14;
+      I.pop (domain_field Domainstate.Domain_exn_handler R14);
       cfi_adjust_cfa_offset (-8);
       I.add (int 8) rsp;
       cfi_adjust_cfa_offset (-8);
@@ -988,11 +991,11 @@ let emit_instr fallthrough i =
           emit_call "caml_reraise_exn";
           record_frame Reg.Set.empty true i.dbg
       | Lambda.Raise_notrace ->
-          I.mov r15 rsp;
-          locate_domain_state rsp;
-          I.mov (domain_field Domainstate.Domain_stack_high RSP) rsp;
-          I.sub r14 rsp;
-          I.pop r14;
+          I.mov r15 r14;
+          locate_domain_state r14;
+          I.mov (domain_field Domainstate.Domain_exn_handler R14) rsp;
+          I.add rsp (mem64 NONE 0 RSP);
+          I.pop (domain_field Domainstate.Domain_exn_handler R14);
           I.ret ()
       end
 

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -167,13 +167,8 @@ let load_symbol_addr s arg =
   else
     I.mov (sym (emit_symbol s)) arg
 
-let locate_domain_state tgt =
-  let bits = Domainstate.minor_heap_align_bits in
-  let dom_mask = Nativeint.(shift_left minus_one bits) in
-  I.and_ (nat dom_mask) tgt
-
-let domain_field f base_reg =
-  mem64 QWORD (Domainstate.idx_of_field f * 8) base_reg
+let domain_field f =
+  mem64 QWORD (Domainstate.idx_of_field f * 8) R14
 
 (* Output a label *)
 
@@ -550,19 +545,13 @@ let emit_instr fallthrough i =
       load_symbol_addr s (res i 0)
   | Lop(Icall_ind { label_after; }) ->
       if Config.stats then begin
-        I.push r11;
-        I.mov r15 r11;
-        locate_domain_state r11;
-        I.inc (domain_field Domainstate.Domain_call_ind R11);
-        I.pop r11;
+        I.inc (domain_field Domainstate.Domain_call_ind);
       end;
         I.call (arg i 0);
         record_frame i.live false i.dbg ~label:label_after
   | Lop(Icall_imm { func; label_after; }) ->
       if Config.stats then begin
-        I.mov r15 r11;
-        locate_domain_state r11;
-        I.inc (domain_field Domainstate.Domain_call_imm R11);
+        I.inc (domain_field Domainstate.Domain_call_imm);
       end;
       add_used_symbol func;
       emit_call func;
@@ -570,11 +559,7 @@ let emit_instr fallthrough i =
   | Lop(Itailcall_ind { label_after = _; }) ->
       output_epilogue begin fun () ->
       if Config.stats then begin
-        I.push r11;
-        I.mov r15 r11;
-        locate_domain_state r11;
-        I.inc (domain_field Domainstate.Domain_tailcall_ind R11);
-        I.pop r11;
+        I.inc (domain_field Domainstate.Domain_tailcall_ind);
       end;
       I.jmp (arg i 0);
       (* TODO KC: Spacetime
@@ -587,17 +572,13 @@ let emit_instr fallthrough i =
       begin
         if func = !function_name then begin
           if Config.stats then begin
-            I.mov r15 r11;
-            locate_domain_state r11;
-            I.inc (domain_field Domainstate.Domain_tailcall_imm R11);
+            I.inc (domain_field Domainstate.Domain_tailcall_imm);
           end;
           I.jmp (label !tailrec_entry_point)
         end else begin
           output_epilogue begin fun () ->
             if Config.stats then begin
-              I.mov r15 r11;
-              locate_domain_state r11;
-              I.inc (domain_field Domainstate.Domain_tailcall_imm R11)
+              I.inc (domain_field Domainstate.Domain_tailcall_imm)
           end;
           add_used_symbol func;
           emit_jump func
@@ -619,31 +600,27 @@ let emit_instr fallthrough i =
         record_frame i.live false i.dbg ~label:label_after;
         (* caml_c_call preserves the old value of %r15, but this may no longer
            be the correct minor heap pointer, so we reload young_ptr *)
-        locate_domain_state r15;
         if Config.stats then begin
-          I.inc (domain_field Domainstate.Domain_extcall_alloc_stackargs R15)
+          I.inc (domain_field Domainstate.Domain_extcall_alloc_stackargs)
         end;
-        I.mov (domain_field Domainstate.Domain_young_ptr R15) r15;
+        I.mov (domain_field Domainstate.Domain_young_ptr) r15;
       end else if alloc then begin
         load_symbol_addr func rax;
         emit_call "caml_c_call";
         record_frame i.live false i.dbg ~label:label_after;
         (* caml_c_call preserves the old value of %r15, but this may no longer
            be the correct minor heap pointer, so we reload young_ptr *)
-        locate_domain_state r15;
         if Config.stats then begin
-          I.inc (domain_field Domainstate.Domain_extcall_alloc R15)
+          I.inc (domain_field Domainstate.Domain_extcall_alloc)
         end;
-        I.mov (domain_field Domainstate.Domain_young_ptr R15) r15;
+        I.mov (domain_field Domainstate.Domain_young_ptr) r15;
       end else begin
         I.mov rsp r10;
-        I.mov r15 r11;
-        locate_domain_state r11;
         if Config.stats then begin
-          I.inc (domain_field Domainstate.Domain_extcall_noalloc R15);
+          I.inc (domain_field Domainstate.Domain_extcall_noalloc);
         end;
         cfi_remember_state ();
-        I.mov (domain_field Domainstate.Domain_system_sp R11) rsp;
+        I.mov (domain_field Domainstate.Domain_system_sp) rsp;
         cfi_def_cfa_offset 8;
         I.push r10;
         cfi_adjust_cfa_offset 8;
@@ -669,10 +646,7 @@ let emit_instr fallthrough i =
   | Lop(Iload(chunk, addr)) ->
       let dest = res i 0 in
       if Config.stats then begin
-        I.push r15;
-        locate_domain_state r15;
-        I.inc (domain_field Domainstate.Domain_immutable_loads R15);
-        I.pop r15;
+        I.inc (domain_field Domainstate.Domain_immutable_loads);
       end;
       begin match chunk with
       | Word_int | Word_val ->
@@ -696,9 +670,7 @@ let emit_instr fallthrough i =
       end
   | Lop Iloadmut ->
       if Config.stats then begin
-        I.mov r15 rax;
-        locate_domain_state rax;
-        I.inc (domain_field Domainstate.Domain_mutable_loads RAX);
+        I.inc (domain_field Domainstate.Domain_mutable_loads);
       end;
       I.mov (mem64 QWORD 0 ~base:(arg64 i 0) (arg64 i 1) ~scale:8) (reg i.res.(0));
       I.mov (res i 0) rax;
@@ -723,10 +695,7 @@ let emit_instr fallthrough i =
           rb_frame = lbl_frame } :: !read_barrier_call_sites
   | Lop(Istore(chunk, addr, is_assignment)) ->
       if Config.stats && is_assignment then begin
-        I.push r15;
-        locate_domain_state r15;
-        I.inc (domain_field Domainstate.Domain_immutable_stores R15);
-        I.pop r15;
+        I.inc (domain_field Domainstate.Domain_immutable_stores);
       end;
       begin match chunk with
       | Word_int | Word_val ->
@@ -748,13 +717,11 @@ let emit_instr fallthrough i =
       if !fastcode_flag then begin
         let lbl_redo = new_label() in
         def_label lbl_redo;
-        I.mov r15 rax;
         I.sub (int n) r15;
-        locate_domain_state rax;
         if Config.stats then begin
-          I.inc (domain_field Domainstate.Domain_allocations RAX);
+          I.inc (domain_field Domainstate.Domain_allocations);
         end;
-        I.cmp (domain_field Domainstate.Domain_young_limit RAX) r15;
+        I.cmp (domain_field Domainstate.Domain_young_limit) r15;
         let lbl_call_gc = new_label() in
         let dbg =
           if not Config.spacetime then Debuginfo.none
@@ -777,9 +744,7 @@ let emit_instr fallthrough i =
             gc_spacetime; } :: !call_gc_sites
       end else begin
         if Config.stats then begin
-          I.mov r15 rax;
-          locate_domain_state rax;
-          I.inc (domain_field Domainstate.Domain_allocations RAX);
+          I.inc (domain_field Domainstate.Domain_allocations);
         end;
         if Config.spacetime then begin
           (* spacetime_before_uninstrumented_call ~node_ptr:(arg i 0)
@@ -963,18 +928,14 @@ let emit_instr fallthrough i =
       I.call (label lbl)
   | Lpushtrap ->
       cfi_adjust_cfa_offset 8;
-      I.mov r15 r14;
-      locate_domain_state r14;
-      I.push (domain_field Domainstate.Domain_exn_handler R14);
+      I.push (domain_field Domainstate.Domain_exn_handler);
       cfi_adjust_cfa_offset 8;
       I.sub rsp (mem64 NONE 0 RSP);
-      I.mov rsp (domain_field Domainstate.Domain_exn_handler R14);
+      I.mov rsp (domain_field Domainstate.Domain_exn_handler);
       stack_offset := !stack_offset + 16
   | Lpoptrap ->
       I.add rsp (mem64 NONE 0 RSP);
-      I.mov r15 r14;
-      locate_domain_state r14;
-      I.pop (domain_field Domainstate.Domain_exn_handler R14);
+      I.pop (domain_field Domainstate.Domain_exn_handler);
       cfi_adjust_cfa_offset (-8);
       I.add (int 8) rsp;
       cfi_adjust_cfa_offset (-8);
@@ -991,11 +952,9 @@ let emit_instr fallthrough i =
           emit_call "caml_reraise_exn";
           record_frame Reg.Set.empty true i.dbg
       | Lambda.Raise_notrace ->
-          I.mov r15 r14;
-          locate_domain_state r14;
-          I.mov (domain_field Domainstate.Domain_exn_handler R14) rsp;
+          I.mov (domain_field Domainstate.Domain_exn_handler) rsp;
           I.add rsp (mem64 NONE 0 RSP);
-          I.pop (domain_field Domainstate.Domain_exn_handler R14);
+          I.pop (domain_field Domainstate.Domain_exn_handler);
           I.ret ()
       end
 
@@ -1017,10 +976,8 @@ let emit_profile () =
        like mcount expects it, though. *)
     if not fp then I.lea (mem64 NONE (-8) RSP) rbp;
     I.mov rsp r10;
-    I.mov r15 r11;
-    locate_domain_state r11;
     cfi_remember_state ();
-    I.mov (domain_field Domainstate.Domain_system_sp R11) rsp;
+    I.mov (domain_field Domainstate.Domain_system_sp) rsp;
     cfi_def_cfa_offset 8;
     I.push r10;
     cfi_adjust_cfa_offset 8;
@@ -1114,12 +1071,10 @@ let fundecl fundecl =
     let (overflow,ret) = new_label(), new_label() in
     let threshold_offset = Domainstate.stack_ctx_words * 8 + stack_threshold_size in
     I.lea (mem64 NONE (-(max_stack_size + threshold_offset)) RSP) r10;
-    I.mov r15 r11;
-    locate_domain_state r11;
     if Config.stats then begin
-      I.inc (domain_field Domainstate.Domain_stackoverflow_checks R11);
+      I.inc (domain_field Domainstate.Domain_stackoverflow_checks);
     end;
-    I.cmp (domain_field Domainstate.Domain_current_stack R11) r10;
+    I.cmp (domain_field Domainstate.Domain_current_stack) r10;
     I.jb (label overflow);
     def_label ret;
     handle_overflow := Some (overflow, ret)

--- a/asmrun/amd64.S
+++ b/asmrun/amd64.S
@@ -103,12 +103,6 @@
 #define CAML_CONFIG_H_NO_TYPEDEFS
 #include "../byterun/caml/config.h"
 
-#define GET_DOMAIN_STATE(reg) \
-  movq  %r14, reg
-
-/* CR mshinwell: We should optimize the case where there are multiple
-   loads/stores in one go to the domain state block. */
-
         .set    domain_curr_field, 0
 #define DOMAIN_STATE(c_type, name) \
         .equ    domain_field_caml_##name, domain_curr_field ; \
@@ -121,28 +115,23 @@
 /* Load address of field from the current domain state block.  Clobbers only
  * the destination. */
 #define ADDR_TL_VAR(var,dstreg) \
-        GET_DOMAIN_STATE(dstreg) ; \
-        leaq (8 * domain_field_##var)(dstreg), dstreg
+        leaq Caml_state(var), dstreg
 
 /* Load from the current domain state block.  Clobbers only the destination. */
 #define LOAD_TL_VAR(var,dstreg) \
-        GET_DOMAIN_STATE(dstreg) ; \
-        movq (8 * domain_field_##var)(dstreg), dstreg
+        movq Caml_state(var), dstreg
 
-/* Store to the current domain state block.  Clobbers %r11. */
+/* Store to the current domain state block.  Clobbers nothing. */
 #define STORE_TL_VAR(srcreg, var) \
-        GET_DOMAIN_STATE(%r11)  ; \
-        movq srcreg, (8 * domain_field_##var)(%r11)
+        movq srcreg, Caml_state(var)
 
-/* Test against a value in the current domain block.  Clobbers %r11. */
+/* Test against a value in the current domain block.  Clobbers nothing. */
 #define TEST_TL_VAR(value, var) \
-        GET_DOMAIN_STATE(%r11)  ; \
-        testq value, (8 * domain_field_##var)(%r11)
+        testq value, Caml_state(var)
 
-/* Compare against a value in the current domain block.  Clobbers %rax. */
+/* Compare against a value in the current domain block.  Clobbers nothing. */
 #define CMP_TL_VAR(var, reg) \
-        GET_DOMAIN_STATE(%rax)  ; \
-        cmpq (8 * domain_field_##var)(%rax), reg
+        cmpq Caml_state(var), reg
 
 /* Load address of global [label] in register [dst]. */
 #if defined(__PIC__) && !defined(SYS_mingw64) && !defined(SYS_cygwin)
@@ -156,13 +145,13 @@
 /* Push the current exception handler.
    (Stored as an offset, to survive stack reallocations). Clobbers REG */
 #define PUSH_EXN_HANDLER(REG) \
-        LOAD_TL_VAR(caml_exn_handler, REG); \
+        LOAD_TL_VAR(exn_handler, REG); \
         pushq   REG; CFI_ADJUST(8); \
         subq    %rsp, 0(%rsp)
 
 /* Pop the current exception handler. Undoes PUSH_EXN_HANDLER. Clobbers REG. */
 #define POP_EXN_HANDLER(REG) \
-        ADDR_TL_VAR(caml_exn_handler, REG); \
+        ADDR_TL_VAR(exn_handler, REG); \
         addq    %rsp, 0(%rsp); \
         popq    (REG); CFI_ADJUST(-8)
 
@@ -173,10 +162,10 @@
 /* Switch from OCaml to C stack. Clobbers REG. */
 #define SWITCH_OCAML_TO_C_NO_CTXT(REG) \
     /* Save OCaml SP in the stack slot */ \
-        LOAD_TL_VAR(caml_current_stack, REG); \
+        LOAD_TL_VAR(current_stack, REG); \
         movq    %rsp, Stack_sp(REG); \
     /* Switch to system stack */ \
-        LOAD_TL_VAR(caml_system_sp, REG); \
+        LOAD_TL_VAR(system_sp, REG); \
         movq    %rsp, 16(REG); /* For DWARF CFI. See OFFXXX. */ \
         movq    REG, %rsp; \
         .cfi_def_cfa_offset 8 /* SYSCFAXXX */
@@ -192,7 +181,7 @@
 /* Switch from C to OCaml stack.  Clobbers REG. */
 #define SWITCH_C_TO_OCAML_NO_CTXT(REG,CFA_OFF) \
     /* Switch to OCaml stack */ \
-        LOAD_TL_VAR(caml_current_stack, REG); \
+        LOAD_TL_VAR(current_stack, REG); \
     /* REG is Stack_sp(caml_current_stack) */ \
         movq    Stack_sp(REG), %rsp; \
         .cfi_def_cfa_offset CFA_OFF
@@ -207,7 +196,7 @@
 
 /* Load Caml_state->exn_handler into %rsp and restores prior exn_handler. Clobbers %r11. */
 #define RESTORE_EXN_HANDLER_OCAML \
-        LOAD_TL_VAR(caml_exn_handler, %rsp); \
+        LOAD_TL_VAR(exn_handler, %rsp); \
         .cfi_def_cfa_offset 16; \
         POP_EXN_HANDLER(%r11)
 
@@ -418,7 +407,7 @@ CFI_ENDPROC
 
 #define CAML_CALL_ENTER_C \
         subq    $8, %rsp; CFI_ADJUST(8); \
-        ADDR_TL_VAR(caml_current_stack, %rbx); \
+        ADDR_TL_VAR(current_stack, %rbx); \
         pushq   %rbx; CFI_ADJUST(8); \
         movq    (%rbx), %rbx; \
         pushq   (%rbx); CFI_ADJUST(8); \
@@ -497,7 +486,7 @@ CFI_ENDPROC
         call    GCALL(caml_update_gc_regs_slot);                               \
         CLEANUP_AFTER_C_CALL;                                                  \
     /* Save caml_young_ptr */                                                  \
-        STORE_TL_VAR(%r15, caml_young_ptr);                                    \
+        STORE_TL_VAR(%r15, young_ptr);                                    \
     /* Save floating-point registers */                                        \
         subq    $(16*8), %rsp; CFI_ADJUST (16*8);                              \
         movsd   %xmm0, 0*8(%rsp);                                              \
@@ -521,7 +510,7 @@ CFI_ENDPROC
         CAML_CALL_ENTER_C;                                                     \
         CLEANUP_AFTER_C_CALL;                                                  \
     /* Restore caml_young_ptr */                                               \
-        LOAD_TL_VAR(caml_young_ptr, %r15);                                     \
+        LOAD_TL_VAR(young_ptr, %r15);                                     \
     /* Restore all regs used by the code generator */                          \
         movsd   0*8(%rsp), %xmm0;                                              \
         movsd   1*8(%rsp), %xmm1;                                              \
@@ -651,7 +640,7 @@ FUNCTION(G(caml_call_read_barrier))
 CFI_STARTPROC
         /* Save %r10, and use it as a temp to switch stacks. */
         pushq   %r10; CFI_ADJUST(8)
-        LOAD_TL_VAR(caml_system_sp, %r10)
+        LOAD_TL_VAR(system_sp, %r10)
         popq    -8(%r10); CFI_ADJUST(-8)
         SWITCH_OCAML_TO_C(%r10)
         movq    -8(%rsp), %r10
@@ -682,7 +671,7 @@ CFI_STARTPROC
         movq    (%rsp), C_ARG_1;        /* rax = base */
         movq    32(%rsp), C_ARG_2;      /* rdx = offset */
     /* Save caml_young_ptr */
-        STORE_TL_VAR(%r15, caml_young_ptr);
+        STORE_TL_VAR(%r15, young_ptr);
     /* Save floating-point registers */
         subq    $(16*8), %rsp; CFI_ADJUST (16*8);
         movsd   %xmm0, 0*8(%rsp);
@@ -708,7 +697,7 @@ CFI_STARTPROC
     /* Result is in %rax */
         CLEANUP_AFTER_C_CALL;
     /* Restore caml_young_ptr */
-        LOAD_TL_VAR(caml_young_ptr, %r15);
+        LOAD_TL_VAR(young_ptr, %r15);
     /* Restore all regs used by the code generator */
         movsd   0*8(%rsp), %xmm0;
         movsd   1*8(%rsp), %xmm1;
@@ -754,7 +743,7 @@ FUNCTION(G(caml_alloc1))
 CFI_STARTPROC
 LBL(caml_alloc1):
         subq    $16, %r15
-        CMP_TL_VAR(caml_young_limit, %r15)
+        CMP_TL_VAR(young_limit, %r15)
         jb      LBL(100)
         ret
 LBL(100):
@@ -771,7 +760,7 @@ FUNCTION(G(caml_alloc2))
 CFI_STARTPROC
 LBL(caml_alloc2):
         subq    $24, %r15
-        CMP_TL_VAR(caml_young_limit, %r15)
+        CMP_TL_VAR(young_limit, %r15)
         jb      LBL(101)
         ret
 LBL(101):
@@ -788,7 +777,7 @@ FUNCTION(G(caml_alloc3))
 CFI_STARTPROC
 LBL(caml_alloc3):
         subq    $32, %r15
-        CMP_TL_VAR(caml_young_limit, %r15)
+        CMP_TL_VAR(young_limit, %r15)
         jb      LBL(102)
         ret
 LBL(102):
@@ -806,7 +795,7 @@ CFI_STARTPROC
 LBL(caml_allocN):
         pushq   %rax; CFI_ADJUST(8)        /* save desired size */
         subq    %rax, %r15
-        CMP_TL_VAR(caml_young_limit, %r15)
+        CMP_TL_VAR(young_limit, %r15)
         jb      LBL(103)
         addq    $8, %rsp; CFI_ADJUST (-8)  /* drop desired size */
         ret
@@ -814,7 +803,7 @@ LBL(103):
         movq    (%rsp), %rax
         addq    %rax, %r15
         /* Save desired size on system stack */
-        LOAD_TL_VAR(caml_system_sp, %rax)
+        LOAD_TL_VAR(system_sp, %rax)
         popq    -8(%rax); CFI_ADJUST(-8)
         SWITCH_OCAML_TO_C(%rax)
         subq    $16, %rsp; CFI_ADJUST(16)
@@ -822,7 +811,7 @@ LBL(103):
         call    LBL(do_gc)
         LEAVE_FUNCTION
         SWITCH_C_TO_OCAML(%rax)
-        LOAD_TL_VAR(caml_system_sp, %rax)
+        LOAD_TL_VAR(system_sp, %rax)
         movq    -8(%rax), %rax
         jmp     LBL(caml_allocN)
 CFI_ENDPROC
@@ -841,7 +830,7 @@ LBL(caml_c_call):
         SWITCH_OCAML_TO_C(%r10)
         ENTER_FUNCTION
     /* Make the alloc ptr available to the C code */
-        STORE_TL_VAR(%r15, caml_young_ptr)
+        STORE_TL_VAR(%r15, young_ptr)
     /* Call the function (address in %rax) */
         PREPARE_FOR_C_CALL
         .cfi_remember_state
@@ -851,7 +840,7 @@ LBL(caml_c_call):
         .cfi_restore_state
         CLEANUP_AFTER_C_CALL
     /* Prepare for return to OCaml */
-        LOAD_TL_VAR(caml_young_ptr, %r15)
+        LOAD_TL_VAR(young_ptr, %r15)
     /* Load ocaml stack and restore global variables */
         LEAVE_FUNCTION
         SWITCH_C_TO_OCAML(%r10)
@@ -869,7 +858,7 @@ CFI_STARTPROC
         SWITCH_OCAML_TO_C(%r10)
         ENTER_FUNCTION
     /* Make the alloc ptr available to the C code */
-        STORE_TL_VAR(%r15, caml_young_ptr)
+        STORE_TL_VAR(%r15, young_ptr)
     /* Copy arguments from OCaml to C stack */
 LBL(105):
         subq    $8, %r12
@@ -883,7 +872,7 @@ LBL(106):
         call    *%rax
         CLEANUP_AFTER_C_CALL
     /* Prepare for return to OCaml */
-        LOAD_TL_VAR(caml_young_ptr, %r15)
+        LOAD_TL_VAR(young_ptr, %r15)
     /* Load ocaml stack and restore global variables */
         LEAVE_FUNCTION
         SWITCH_C_TO_OCAML(%r10)
@@ -913,26 +902,26 @@ LBL(caml_start_program):
     /* Load young_ptr into %r15 */
         movq    Caml_state(young_ptr), %r15
     /* Build context on system stack for DWARF CFI */
-        ADDR_TL_VAR(caml_current_stack, %r13)
+        ADDR_TL_VAR(current_stack, %r13)
         pushq   %r13; CFI_ADJUST(8)
         pushq   $0 ; CFI_ADJUST(8) /* will be filled in at SWITCH_OCAML_TO_C. See OFFXXX. */
     /* System stack is captured unaligned. Hence, any OCaml to C calls
      * are expected to explicitly align stack using ENTER_FUNCTION and such. */
-        STORE_TL_VAR(%rsp, caml_system_sp)
+        STORE_TL_VAR(%rsp, system_sp)
     /* Switch from C to OCaml stack. CFA offset -8 refers to OCAMLCFAXXX. */
         SWITCH_C_TO_OCAML_NO_CTXT(%r10,-8)
     /* Setup alloc ptr */
-        LOAD_TL_VAR(caml_young_ptr, %r15)
+        LOAD_TL_VAR(young_ptr, %r15)
     /* Build a handler for exceptions raised in OCaml */
         lea     LBL(109)(%rip), %r13
         pushq   %r13; CFI_ADJUST(8)
     /* dummy prev trap. Important that this is 0 for indicating CFI last frame.
      * See OCAMLCFAXXX. */
         pushq   $0 ; CFI_ADJUST(8)
-        STORE_TL_VAR(%rsp, caml_exn_handler)
+        STORE_TL_VAR(%rsp, exn_handler)
     /* Call the OCaml code */
         .cfi_remember_state
-        LOAD_TL_VAR(caml_system_sp, %r13)
+        LOAD_TL_VAR(system_sp, %r13)
         call    GCALL(caml_enter_caml)
 LBL(108):
         .cfi_def_cfa_offset 120
@@ -943,7 +932,7 @@ LBL(108):
         popq    %r12; CFI_ADJUST(-8)   /* dummy register */
 LBL(110):
     /* Update alloc ptr */
-        STORE_TL_VAR(%r15,caml_young_ptr)
+        STORE_TL_VAR(%r15,young_ptr)
     /* Return to C stack. */
         SWITCH_OCAML_TO_C_NO_CTXT(%r10)
     /* Pop the C exception handler and DWARF cfi info. */
@@ -969,20 +958,20 @@ CFI_ENDPROC
 FUNCTION(G(caml_raise_exn))
 CFI_STARTPROC
 LBL(caml_raise_exn):
-        TEST_TL_VAR($1, caml_backtrace_active)
+        TEST_TL_VAR($1, backtrace_active)
         jne   LBL(116)
         RESTORE_EXN_HANDLER_OCAML
         ret
 LBL(116):
-        STORE_TL_VAR($0, caml_backtrace_pos)
+        STORE_TL_VAR($0, backtrace_pos)
 LBL(117):
         movq    %rsp, %r10        /* Save OCaml stack pointer */
         movq    %rax, %r12        /* Save exception bucket */
-        LOAD_TL_VAR(caml_system_sp, %rsp)
+        LOAD_TL_VAR(system_sp, %rsp)
         movq    %rax, C_ARG_1     /* arg 1: exception bucket */
         movq    (%r10), C_ARG_2   /* arg 2: pc of raise */
         leaq    8(%r10), C_ARG_3  /* arg 3: sp at raise */
-        LOAD_TL_VAR(caml_exn_handler, C_ARG_4)
+        LOAD_TL_VAR(exn_handler, C_ARG_4)
                                   /* arg 4: sp of handler */
         ENTER_FUNCTION
         PREPARE_FOR_C_CALL
@@ -996,7 +985,7 @@ CFI_ENDPROC
 
 FUNCTION(G(caml_reraise_exn))
 CFI_STARTPROC
-        TEST_TL_VAR($1, caml_backtrace_active)
+        TEST_TL_VAR($1, backtrace_active)
         jne   LBL(117)
         RESTORE_EXN_HANDLER_OCAML
         ret
@@ -1081,7 +1070,7 @@ FUNCTION(G(caml_fiber_exn_handler))
 CFI_STARTPROC
     /* In handler. %rax has exception */
         mov     %rax, %rbx
-        LOAD_TL_VAR(caml_current_stack, %rsi)
+        LOAD_TL_VAR(current_stack, %rsi)
         movq    Stack_handle_exception(%rsi), %r12  /* exception handler */
         movq    Stack_parent(%rsi), %rdi            /* parent stack. Never NULL here. */
     /* Switch stacks */
@@ -1098,7 +1087,7 @@ CFI_STARTPROC
 LBL(111):
     /* In handler. %rax has value */
         mov     %rax, %rbx
-        LOAD_TL_VAR(caml_current_stack, %rsi)
+        LOAD_TL_VAR(current_stack, %rsi)
         movq    Stack_handle_value(%rsi), %r12    /* value handler */
         movq    Stack_parent(%rsi), %rdi          /* parent stack. Never NULL here. */
     /* Reset stack. First pop off fiber exn handler. */
@@ -1119,7 +1108,7 @@ CFI_STARTPROC
         %rbx: freshly allocated continuation */
         mov     %rax, %r12                      /* r8,r9,r12,r13 are preserved across C call */
         mov     %rbx, %r13
-        LOAD_TL_VAR(caml_current_stack, %rbx)   /* Second argument */
+        LOAD_TL_VAR(current_stack, %rbx)   /* Second argument */
         movq    Stack_parent(%rbx), %rdi        /* Parent stack. */
         cmpq    $0, %rdi                        /* Parent is NULL? */
         je      LBL(112)
@@ -1150,7 +1139,7 @@ CFI_STARTPROC
         movq    %rax, %r12                      /* r8,r9,r12,r13 are preserved across C call */
         movq    %rbx, %r13
         movq    %rdi, %r8
-        LOAD_TL_VAR(caml_current_stack, %rbx)
+        LOAD_TL_VAR(current_stack, %rbx)
         movq    Stack_parent(%rbx), %rdi         /* Parent stack */   
         cmpq    $0, %rdi                         /* Parent is Null? */
         je      LBL(113)
@@ -1189,7 +1178,7 @@ CFI_STARTPROC
         je      2f
         movq    Stack_parent(%rax), %rax
         jmp     1b
-2:      LOAD_TL_VAR(caml_current_stack, %rcx)
+2:      LOAD_TL_VAR(current_stack, %rcx)
         movq    %rcx, Stack_parent(%rax)
     /* %rdi has new stack */
         SWITCH_OCAML_STACKS
@@ -1213,7 +1202,7 @@ CFI_STARTPROC
 /*        test    $0xf, %rsp */
 /*        jz      1f */
 /*        int3 */
-1:      LOAD_TL_VAR(caml_current_stack, %r11)
+1:      LOAD_TL_VAR(current_stack, %r11)
         movq    %rsp, %r10
         subq    %r11, %r10      /* %r10: number of bytes left on stack */
         /* can be two words over: the return addresses */

--- a/asmrun/amd64.S
+++ b/asmrun/amd64.S
@@ -112,27 +112,6 @@
 
 #define Caml_state(var) (8*domain_field_caml_##var)(%r14)
 
-/* Load address of field from the current domain state block.  Clobbers only
- * the destination. */
-#define ADDR_TL_VAR(var,dstreg) \
-        leaq Caml_state(var), dstreg
-
-/* Load from the current domain state block.  Clobbers only the destination. */
-#define LOAD_TL_VAR(var,dstreg) \
-        movq Caml_state(var), dstreg
-
-/* Store to the current domain state block.  Clobbers nothing. */
-#define STORE_TL_VAR(srcreg, var) \
-        movq srcreg, Caml_state(var)
-
-/* Test against a value in the current domain block.  Clobbers nothing. */
-#define TEST_TL_VAR(value, var) \
-        testq value, Caml_state(var)
-
-/* Compare against a value in the current domain block.  Clobbers nothing. */
-#define CMP_TL_VAR(var, reg) \
-        cmpq Caml_state(var), reg
-
 /* Load address of global [label] in register [dst]. */
 #if defined(__PIC__) && !defined(SYS_mingw64) && !defined(SYS_cygwin)
 #define LEA_VAR(label,dst) \
@@ -145,13 +124,13 @@
 /* Push the current exception handler.
    (Stored as an offset, to survive stack reallocations). Clobbers REG */
 #define PUSH_EXN_HANDLER(REG) \
-        LOAD_TL_VAR(exn_handler, REG); \
+        movq	Caml_state(exn_handler), REG; \
         pushq   REG; CFI_ADJUST(8); \
         subq    %rsp, 0(%rsp)
 
 /* Pop the current exception handler. Undoes PUSH_EXN_HANDLER. Clobbers REG. */
 #define POP_EXN_HANDLER(REG) \
-        ADDR_TL_VAR(exn_handler, REG); \
+        leaq	Caml_state(exn_handler), REG; \
         addq    %rsp, 0(%rsp); \
         popq    (REG); CFI_ADJUST(-8)
 
@@ -162,10 +141,10 @@
 /* Switch from OCaml to C stack. Clobbers REG. */
 #define SWITCH_OCAML_TO_C_NO_CTXT(REG) \
     /* Save OCaml SP in the stack slot */ \
-        LOAD_TL_VAR(current_stack, REG); \
+        movq	Caml_state(current_stack), REG; \
         movq    %rsp, Stack_sp(REG); \
     /* Switch to system stack */ \
-        LOAD_TL_VAR(system_sp, REG); \
+        movq	Caml_state(system_sp), REG; \
         movq    %rsp, 16(REG); /* For DWARF CFI. See OFFXXX. */ \
         movq    REG, %rsp; \
         .cfi_def_cfa_offset 8 /* SYSCFAXXX */
@@ -181,7 +160,7 @@
 /* Switch from C to OCaml stack.  Clobbers REG. */
 #define SWITCH_C_TO_OCAML_NO_CTXT(REG,CFA_OFF) \
     /* Switch to OCaml stack */ \
-        LOAD_TL_VAR(current_stack, REG); \
+        movq	Caml_state(current_stack), REG; \
     /* REG is Stack_sp(caml_current_stack) */ \
         movq    Stack_sp(REG), %rsp; \
         .cfi_def_cfa_offset CFA_OFF
@@ -196,7 +175,7 @@
 
 /* Load Caml_state->exn_handler into %rsp and restores prior exn_handler. Clobbers %r11. */
 #define RESTORE_EXN_HANDLER_OCAML \
-        LOAD_TL_VAR(exn_handler, %rsp); \
+        movq	Caml_state(exn_handler), %rsp; \
         .cfi_def_cfa_offset 16; \
         POP_EXN_HANDLER(%r11)
 
@@ -407,7 +386,7 @@ CFI_ENDPROC
 
 #define CAML_CALL_ENTER_C \
         subq    $8, %rsp; CFI_ADJUST(8); \
-        ADDR_TL_VAR(current_stack, %rbx); \
+        leaq	Caml_state(current_stack), %rbx; \
         pushq   %rbx; CFI_ADJUST(8); \
         movq    (%rbx), %rbx; \
         pushq   (%rbx); CFI_ADJUST(8); \
@@ -486,7 +465,7 @@ CFI_ENDPROC
         call    GCALL(caml_update_gc_regs_slot);                               \
         CLEANUP_AFTER_C_CALL;                                                  \
     /* Save caml_young_ptr */                                                  \
-        STORE_TL_VAR(%r15, young_ptr);                                    \
+        movq	%r15, Caml_state(young_ptr);                                    \
     /* Save floating-point registers */                                        \
         subq    $(16*8), %rsp; CFI_ADJUST (16*8);                              \
         movsd   %xmm0, 0*8(%rsp);                                              \
@@ -510,7 +489,7 @@ CFI_ENDPROC
         CAML_CALL_ENTER_C;                                                     \
         CLEANUP_AFTER_C_CALL;                                                  \
     /* Restore caml_young_ptr */                                               \
-        LOAD_TL_VAR(young_ptr, %r15);                                     \
+        movq	Caml_state(young_ptr), %r15;                                     \
     /* Restore all regs used by the code generator */                          \
         movsd   0*8(%rsp), %xmm0;                                              \
         movsd   1*8(%rsp), %xmm1;                                              \
@@ -640,7 +619,7 @@ FUNCTION(G(caml_call_read_barrier))
 CFI_STARTPROC
         /* Save %r10, and use it as a temp to switch stacks. */
         pushq   %r10; CFI_ADJUST(8)
-        LOAD_TL_VAR(system_sp, %r10)
+        movq	Caml_state(system_sp), %r10
         popq    -8(%r10); CFI_ADJUST(-8)
         SWITCH_OCAML_TO_C(%r10)
         movq    -8(%rsp), %r10
@@ -671,7 +650,7 @@ CFI_STARTPROC
         movq    (%rsp), C_ARG_1;        /* rax = base */
         movq    32(%rsp), C_ARG_2;      /* rdx = offset */
     /* Save caml_young_ptr */
-        STORE_TL_VAR(%r15, young_ptr);
+        movq	%r15, Caml_state(young_ptr);
     /* Save floating-point registers */
         subq    $(16*8), %rsp; CFI_ADJUST (16*8);
         movsd   %xmm0, 0*8(%rsp);
@@ -697,7 +676,7 @@ CFI_STARTPROC
     /* Result is in %rax */
         CLEANUP_AFTER_C_CALL;
     /* Restore caml_young_ptr */
-        LOAD_TL_VAR(young_ptr, %r15);
+        movq	Caml_state(young_ptr), %r15;
     /* Restore all regs used by the code generator */
         movsd   0*8(%rsp), %xmm0;
         movsd   1*8(%rsp), %xmm1;
@@ -743,7 +722,7 @@ FUNCTION(G(caml_alloc1))
 CFI_STARTPROC
 LBL(caml_alloc1):
         subq    $16, %r15
-        CMP_TL_VAR(young_limit, %r15)
+        cmpq	Caml_state(young_limit), %r15
         jb      LBL(100)
         ret
 LBL(100):
@@ -760,7 +739,7 @@ FUNCTION(G(caml_alloc2))
 CFI_STARTPROC
 LBL(caml_alloc2):
         subq    $24, %r15
-        CMP_TL_VAR(young_limit, %r15)
+        cmpq	Caml_state(young_limit), %r15
         jb      LBL(101)
         ret
 LBL(101):
@@ -777,7 +756,7 @@ FUNCTION(G(caml_alloc3))
 CFI_STARTPROC
 LBL(caml_alloc3):
         subq    $32, %r15
-        CMP_TL_VAR(young_limit, %r15)
+        cmpq	Caml_state(young_limit), %r15
         jb      LBL(102)
         ret
 LBL(102):
@@ -795,7 +774,7 @@ CFI_STARTPROC
 LBL(caml_allocN):
         pushq   %rax; CFI_ADJUST(8)        /* save desired size */
         subq    %rax, %r15
-        CMP_TL_VAR(young_limit, %r15)
+        cmpq	Caml_state(young_limit), %r15
         jb      LBL(103)
         addq    $8, %rsp; CFI_ADJUST (-8)  /* drop desired size */
         ret
@@ -803,7 +782,7 @@ LBL(103):
         movq    (%rsp), %rax
         addq    %rax, %r15
         /* Save desired size on system stack */
-        LOAD_TL_VAR(system_sp, %rax)
+        movq	Caml_state(system_sp), %rax
         popq    -8(%rax); CFI_ADJUST(-8)
         SWITCH_OCAML_TO_C(%rax)
         subq    $16, %rsp; CFI_ADJUST(16)
@@ -811,7 +790,7 @@ LBL(103):
         call    LBL(do_gc)
         LEAVE_FUNCTION
         SWITCH_C_TO_OCAML(%rax)
-        LOAD_TL_VAR(system_sp, %rax)
+        movq	Caml_state(system_sp), %rax
         movq    -8(%rax), %rax
         jmp     LBL(caml_allocN)
 CFI_ENDPROC
@@ -830,7 +809,7 @@ LBL(caml_c_call):
         SWITCH_OCAML_TO_C(%r10)
         ENTER_FUNCTION
     /* Make the alloc ptr available to the C code */
-        STORE_TL_VAR(%r15, young_ptr)
+        movq	%r15, Caml_state(young_ptr)
     /* Call the function (address in %rax) */
         PREPARE_FOR_C_CALL
         .cfi_remember_state
@@ -840,7 +819,7 @@ LBL(caml_c_call):
         .cfi_restore_state
         CLEANUP_AFTER_C_CALL
     /* Prepare for return to OCaml */
-        LOAD_TL_VAR(young_ptr, %r15)
+        movq	Caml_state(young_ptr), %r15
     /* Load ocaml stack and restore global variables */
         LEAVE_FUNCTION
         SWITCH_C_TO_OCAML(%r10)
@@ -858,7 +837,7 @@ CFI_STARTPROC
         SWITCH_OCAML_TO_C(%r10)
         ENTER_FUNCTION
     /* Make the alloc ptr available to the C code */
-        STORE_TL_VAR(%r15, young_ptr)
+        movq	%r15, Caml_state(young_ptr)
     /* Copy arguments from OCaml to C stack */
 LBL(105):
         subq    $8, %r12
@@ -872,7 +851,7 @@ LBL(106):
         call    *%rax
         CLEANUP_AFTER_C_CALL
     /* Prepare for return to OCaml */
-        LOAD_TL_VAR(young_ptr, %r15)
+        movq	Caml_state(young_ptr), %r15
     /* Load ocaml stack and restore global variables */
         LEAVE_FUNCTION
         SWITCH_C_TO_OCAML(%r10)
@@ -902,26 +881,26 @@ LBL(caml_start_program):
     /* Load young_ptr into %r15 */
         movq    Caml_state(young_ptr), %r15
     /* Build context on system stack for DWARF CFI */
-        ADDR_TL_VAR(current_stack, %r13)
+        leaq	Caml_state(current_stack), %r13
         pushq   %r13; CFI_ADJUST(8)
         pushq   $0 ; CFI_ADJUST(8) /* will be filled in at SWITCH_OCAML_TO_C. See OFFXXX. */
     /* System stack is captured unaligned. Hence, any OCaml to C calls
      * are expected to explicitly align stack using ENTER_FUNCTION and such. */
-        STORE_TL_VAR(%rsp, system_sp)
+        movq	%rsp, Caml_state(system_sp)
     /* Switch from C to OCaml stack. CFA offset -8 refers to OCAMLCFAXXX. */
         SWITCH_C_TO_OCAML_NO_CTXT(%r10,-8)
     /* Setup alloc ptr */
-        LOAD_TL_VAR(young_ptr, %r15)
+        movq	Caml_state(young_ptr), %r15
     /* Build a handler for exceptions raised in OCaml */
         lea     LBL(109)(%rip), %r13
         pushq   %r13; CFI_ADJUST(8)
     /* dummy prev trap. Important that this is 0 for indicating CFI last frame.
      * See OCAMLCFAXXX. */
         pushq   $0 ; CFI_ADJUST(8)
-        STORE_TL_VAR(%rsp, exn_handler)
+        movq	%rsp, Caml_state(exn_handler)
     /* Call the OCaml code */
         .cfi_remember_state
-        LOAD_TL_VAR(system_sp, %r13)
+        movq	Caml_state(system_sp), %r13
         call    GCALL(caml_enter_caml)
 LBL(108):
         .cfi_def_cfa_offset 120
@@ -932,7 +911,7 @@ LBL(108):
         popq    %r12; CFI_ADJUST(-8)   /* dummy register */
 LBL(110):
     /* Update alloc ptr */
-        STORE_TL_VAR(%r15,young_ptr)
+        movq	%r15, Caml_state(young_ptr)
     /* Return to C stack. */
         SWITCH_OCAML_TO_C_NO_CTXT(%r10)
     /* Pop the C exception handler and DWARF cfi info. */
@@ -958,20 +937,20 @@ CFI_ENDPROC
 FUNCTION(G(caml_raise_exn))
 CFI_STARTPROC
 LBL(caml_raise_exn):
-        TEST_TL_VAR($1, backtrace_active)
+        testq	$1, Caml_state(backtrace_active)
         jne   LBL(116)
         RESTORE_EXN_HANDLER_OCAML
         ret
 LBL(116):
-        STORE_TL_VAR($0, backtrace_pos)
+        movq	$0, Caml_state(backtrace_pos)
 LBL(117):
         movq    %rsp, %r10        /* Save OCaml stack pointer */
         movq    %rax, %r12        /* Save exception bucket */
-        LOAD_TL_VAR(system_sp, %rsp)
+        movq	Caml_state(system_sp), %rsp
         movq    %rax, C_ARG_1     /* arg 1: exception bucket */
         movq    (%r10), C_ARG_2   /* arg 2: pc of raise */
         leaq    8(%r10), C_ARG_3  /* arg 3: sp at raise */
-        LOAD_TL_VAR(exn_handler, C_ARG_4)
+        movq	Caml_state(exn_handler), C_ARG_4
                                   /* arg 4: sp of handler */
         ENTER_FUNCTION
         PREPARE_FOR_C_CALL
@@ -985,7 +964,7 @@ CFI_ENDPROC
 
 FUNCTION(G(caml_reraise_exn))
 CFI_STARTPROC
-        TEST_TL_VAR($1, backtrace_active)
+        testq	$1, Caml_state(backtrace_active)
         jne   LBL(117)
         RESTORE_EXN_HANDLER_OCAML
         ret
@@ -1070,7 +1049,7 @@ FUNCTION(G(caml_fiber_exn_handler))
 CFI_STARTPROC
     /* In handler. %rax has exception */
         mov     %rax, %rbx
-        LOAD_TL_VAR(current_stack, %rsi)
+        movq	Caml_state(current_stack), %rsi
         movq    Stack_handle_exception(%rsi), %r12  /* exception handler */
         movq    Stack_parent(%rsi), %rdi            /* parent stack. Never NULL here. */
     /* Switch stacks */
@@ -1087,7 +1066,7 @@ CFI_STARTPROC
 LBL(111):
     /* In handler. %rax has value */
         mov     %rax, %rbx
-        LOAD_TL_VAR(current_stack, %rsi)
+        movq	Caml_state(current_stack), %rsi
         movq    Stack_handle_value(%rsi), %r12    /* value handler */
         movq    Stack_parent(%rsi), %rdi          /* parent stack. Never NULL here. */
     /* Reset stack. First pop off fiber exn handler. */
@@ -1108,7 +1087,7 @@ CFI_STARTPROC
         %rbx: freshly allocated continuation */
         mov     %rax, %r12                      /* r8,r9,r12,r13 are preserved across C call */
         mov     %rbx, %r13
-        LOAD_TL_VAR(current_stack, %rbx)   /* Second argument */
+        movq	Caml_state(current_stack), %rbx   /* Second argument */
         movq    Stack_parent(%rbx), %rdi        /* Parent stack. */
         cmpq    $0, %rdi                        /* Parent is NULL? */
         je      LBL(112)
@@ -1139,7 +1118,7 @@ CFI_STARTPROC
         movq    %rax, %r12                      /* r8,r9,r12,r13 are preserved across C call */
         movq    %rbx, %r13
         movq    %rdi, %r8
-        LOAD_TL_VAR(current_stack, %rbx)
+        movq	Caml_state(current_stack), %rbx
         movq    Stack_parent(%rbx), %rdi         /* Parent stack */   
         cmpq    $0, %rdi                         /* Parent is Null? */
         je      LBL(113)
@@ -1178,7 +1157,7 @@ CFI_STARTPROC
         je      2f
         movq    Stack_parent(%rax), %rax
         jmp     1b
-2:      LOAD_TL_VAR(current_stack, %rcx)
+2:      movq	Caml_state(current_stack), %rcx
         movq    %rcx, Stack_parent(%rax)
     /* %rdi has new stack */
         SWITCH_OCAML_STACKS
@@ -1202,7 +1181,7 @@ CFI_STARTPROC
 /*        test    $0xf, %rsp */
 /*        jz      1f */
 /*        int3 */
-1:      LOAD_TL_VAR(current_stack, %r11)
+1:      movq	Caml_state(current_stack), %r11
         movq    %rsp, %r10
         subq    %r11, %r10      /* %r10: number of bytes left on stack */
         /* can be two words over: the return addresses */

--- a/asmrun/amd64.S
+++ b/asmrun/amd64.S
@@ -104,8 +104,7 @@
 #include "../byterun/caml/config.h"
 
 #define GET_DOMAIN_STATE(reg) \
-  movq  %r15, reg ; \
-  andq  $(0xffffffffffffffff << Minor_heap_align_bits), reg
+  movq  %r14, reg
 
 /* CR mshinwell: We should optimize the case where there are multiple
    loads/stores in one go to the domain state block. */
@@ -116,6 +115,8 @@
         .set    domain_curr_field, domain_curr_field + 1
 #include "../byterun/caml/domain_state.tbl"
 #undef DOMAIN_STATE
+
+#define Caml_state(var) (8*domain_field_caml_##var)(%r14)
 
 /* Load address of field from the current domain state block.  Clobbers only
  * the destination. */
@@ -181,7 +182,7 @@
         .cfi_def_cfa_offset 8 /* SYSCFAXXX */
 
 /* Switch from OCaml to C stack. Also builds a context at
- * the bottom of the OCaml stack. Clobbers REG & %r14. */
+ * the bottom of the OCaml stack. Clobbers REG. */
 #define SWITCH_OCAML_TO_C(REG) \
     /* Build caml_context at the bottom of the stack */ \
         pushq   $0 ; CFI_ADJUST(8); \
@@ -197,14 +198,14 @@
         .cfi_def_cfa_offset CFA_OFF
 
 /* Switch from C to OCaml stack. Also pops the context
- * from the bottom of the OCaml stack. Clobbers REG & %r14. */
+ * from the bottom of the OCaml stack. Clobbers REG. */
 #define SWITCH_C_TO_OCAML(REG) \
         SWITCH_C_TO_OCAML_NO_CTXT(REG,24); \
-    /* Pop the caml_context from the bottom of stack updating %r14 */ \
+    /* Pop the caml_context from the bottom of stack */ \
         POP_EXN_HANDLER(REG); \
         popq    REG; CFI_ADJUST(-8); \
 
-/* Load [caml_stack_high - %r14] into %rsp. %r14 is an offset. Clobbers %r11. */
+/* Load Caml_state->exn_handler into %rsp and restores prior exn_handler. Clobbers %r11. */
 #define RESTORE_EXN_HANDLER_OCAML \
         LOAD_TL_VAR(caml_exn_handler, %rsp); \
         .cfi_def_cfa_offset 16; \
@@ -898,8 +899,8 @@ FUNCTION(G(caml_start_program))
 CFI_STARTPROC
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
-    /* Load caml_young_ptr into r15 (was passed as an argument from C) */
-        movq    C_ARG_1, %r15
+    /* Load Caml_state into r14 (was passed as an argument from C) */
+        movq    C_ARG_1, %r14
     /* Initial entry point is G(caml_program) */
         LEA_VAR(caml_program, %r12)
         movq    $0, %rax  /* dummy */
@@ -909,6 +910,8 @@ CFI_STARTPROC
     /* Common code for caml_start_program and caml_callback* */
 LBL(caml_start_program):
         pushq   $0   ; CFI_ADJUST(8) // alignment word
+    /* Load young_ptr into %r15 */
+        movq    Caml_state(young_ptr), %r15
     /* Build context on system stack for DWARF CFI */
         ADDR_TL_VAR(caml_current_stack, %r13)
         pushq   %r13; CFI_ADJUST(8)
@@ -1003,8 +1006,10 @@ CFI_ENDPROC
 
 FUNCTION(G(caml_raise_exception))
 CFI_STARTPROC
-        movq    C_ARG_1, %r15                /* young_ptr */
+        movq    C_ARG_1, %r14                /* Caml_state */
         movq    C_ARG_2, %rax
+    /* Load young_ptr into %r15 */
+        movq    Caml_state(young_ptr), %r15
 LBL(caml_raise_exception):
     /* Load ocaml stack and restore global variables */
         SWITCH_C_TO_OCAML(%r10)
@@ -1031,7 +1036,7 @@ CFI_STARTPROC
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
     /* Initial loading of arguments */
-        movq    C_ARG_1, %r15      /* young_ptr */
+        movq    C_ARG_1, %r14      /* Caml_state */
         movq    C_ARG_2, %rbx      /* closure */
         movq    0(C_ARG_3), %rax   /* argument */
         movq    0(%rbx), %r12      /* code pointer */
@@ -1045,7 +1050,7 @@ CFI_STARTPROC
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
     /* Initial loading of arguments */
-        movq    C_ARG_1, %r15      /* young_ptr */
+        movq    C_ARG_1, %r14      /* Caml_state */
         movq    C_ARG_2, %rdi      /* closure */
         movq    0(C_ARG_3), %rax   /* first argument */
         movq    8(C_ARG_3), %rbx   /* second argument */
@@ -1059,7 +1064,7 @@ CFI_STARTPROC
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
     /* Initial loading of arguments */
-        movq    C_ARG_1, %r15      /* young_ptr */
+        movq    C_ARG_1, %r14      /* Caml_state */
         movq    0(C_ARG_3), %rax   /* first argument */
         movq    8(C_ARG_3), %rbx   /* second argument */
         movq    C_ARG_2, %rsi      /* closure */

--- a/asmrun/amd64.S
+++ b/asmrun/amd64.S
@@ -152,6 +152,18 @@
         leaq    G(label)(%rip), dst
 #endif
 
+/* Push the current exception handler.
+   (Stored as an offset, to survive stack reallocations). Clobbers REG */
+#define PUSH_EXN_HANDLER(REG) \
+        LOAD_TL_VAR(caml_exn_handler, REG); \
+        pushq   REG; CFI_ADJUST(8); \
+        subq    %rsp, 0(%rsp)
+
+/* Pop the current exception handler. Undoes PUSH_EXN_HANDLER. Clobbers REG. */
+#define POP_EXN_HANDLER(REG) \
+        ADDR_TL_VAR(caml_exn_handler, REG); \
+        addq    %rsp, 0(%rsp); \
+        popq    (REG); CFI_ADJUST(-8)
 
 /******************************************************************************/
 /* Stack switching operations */
@@ -173,7 +185,7 @@
 #define SWITCH_OCAML_TO_C(REG) \
     /* Build caml_context at the bottom of the stack */ \
         pushq   $0 ; CFI_ADJUST(8); \
-        pushq   %r14; CFI_ADJUST(8); \
+        PUSH_EXN_HANDLER(REG); \
         SWITCH_OCAML_TO_C_NO_CTXT(REG)
 
 /* Switch from C to OCaml stack.  Clobbers REG. */
@@ -189,16 +201,14 @@
 #define SWITCH_C_TO_OCAML(REG) \
         SWITCH_C_TO_OCAML_NO_CTXT(REG,24); \
     /* Pop the caml_context from the bottom of stack updating %r14 */ \
-        popq    %r14; CFI_ADJUST(-8); \
+        POP_EXN_HANDLER(REG); \
         popq    REG; CFI_ADJUST(-8); \
 
 /* Load [caml_stack_high - %r14] into %rsp. %r14 is an offset. Clobbers %r11. */
 #define RESTORE_EXN_HANDLER_OCAML \
-        LOAD_TL_VAR(caml_stack_high, %r11); \
-        sub     %r14, %r11; \
-        movq    %r11, %rsp; \
+        LOAD_TL_VAR(caml_exn_handler, %rsp); \
         .cfi_def_cfa_offset 16; \
-        popq    %r14; CFI_ADJUST(-8)
+        POP_EXN_HANDLER(%r11)
 
 /* Switch between OCaml stacks.
  * arguments : target stack (%rdi)
@@ -916,8 +926,7 @@ LBL(caml_start_program):
     /* dummy prev trap. Important that this is 0 for indicating CFI last frame.
      * See OCAMLCFAXXX. */
         pushq   $0 ; CFI_ADJUST(8)
-        LOAD_TL_VAR(caml_stack_high, %r14); \
-        sub     %rsp, %r14
+        STORE_TL_VAR(%rsp, caml_exn_handler)
     /* Call the OCaml code */
         .cfi_remember_state
         LOAD_TL_VAR(caml_system_sp, %r13)
@@ -927,7 +936,7 @@ LBL(108):
         nop
         .cfi_restore_state
     /* Pop the OCaml exception handler */
-        popq    %r14; CFI_ADJUST(-8)
+        POP_EXN_HANDLER(%r11)
         popq    %r12; CFI_ADJUST(-8)   /* dummy register */
 LBL(110):
     /* Update alloc ptr */
@@ -970,7 +979,8 @@ LBL(117):
         movq    %rax, C_ARG_1     /* arg 1: exception bucket */
         movq    (%r10), C_ARG_2   /* arg 2: pc of raise */
         leaq    8(%r10), C_ARG_3  /* arg 3: sp at raise */
-        movq    %r14, C_ARG_4     /* arg 4: sp offset of handler */
+        LOAD_TL_VAR(caml_exn_handler, C_ARG_4)
+                                  /* arg 4: sp of handler */
         ENTER_FUNCTION
         PREPARE_FOR_C_CALL
         call    GCALL(caml_stash_backtrace)

--- a/asmrun/backtrace_prim.c
+++ b/asmrun/backtrace_prim.c
@@ -75,10 +75,9 @@ int caml_alloc_backtrace_buffer(void){
    preserved the global, statically bounded buffer of the old
    implementation -- before the more flexible
    [caml_get_current_callstack] was implemented. */
-void caml_stash_backtrace(value exn, uintnat pc, char * sp, uintnat trapsp_off)
+void caml_stash_backtrace(value exn, uintnat pc, char * sp, char* trapsp)
 {
   caml_domain_state* domain_state = Caml_state;
-  char* stack_high = (char*)domain_state->stack_high;
   caml_frame_descrs fds;
 
   if (exn != caml_read_root(domain_state->backtrace_last_exn)) {
@@ -101,7 +100,7 @@ void caml_stash_backtrace(value exn, uintnat pc, char * sp, uintnat trapsp_off)
       (backtrace_slot) descr;
 
     /* Stop when we reach the current exception handler */
-    if (sp > stack_high - trapsp_off) return;
+    if (sp > trapsp) return;
   }
 }
 

--- a/asmrun/fail.c
+++ b/asmrun/fail.c
@@ -52,7 +52,7 @@ extern caml_generated_constant
 
 /* Exception raising */
 
-extern void caml_raise_exception (char* young_ptr, value bucket) Noreturn;
+extern void caml_raise_exception (caml_domain_state* state, value bucket) Noreturn;
 
 void caml_raise(value v)
 {
@@ -72,7 +72,7 @@ void caml_raise(value v)
     CAML_LOCAL_ROOTS = CAML_LOCAL_ROOTS->next;
   }
 
-  caml_raise_exception(Caml_state->young_ptr, v);
+  caml_raise_exception(Caml_state, v);
 }
 
 void caml_raise_constant(value tag)

--- a/asmrun/startup.c
+++ b/asmrun/startup.c
@@ -77,7 +77,7 @@ static void init_segments(void)
 struct longjmp_buffer caml_termination_jmpbuf;
 void (*caml_termination_hook)(void *) = NULL;
 
-extern value caml_start_program (char*);
+extern value caml_start_program (caml_domain_state*);
 extern void caml_init_ieee_floats (void);
 extern void caml_init_signals (void);
 #ifdef _WIN32
@@ -139,7 +139,7 @@ value caml_startup_common(char_os **argv, int pooling)
     return Val_unit;
   }
   caml_init_main_stack();
-  return caml_start_program(Caml_state->young_ptr);
+  return caml_start_program(Caml_state);
 }
 
 value caml_startup_exn(char_os **argv)

--- a/byterun/callback.c
+++ b/byterun/callback.c
@@ -108,7 +108,7 @@ static void init_callback_code(void)
 {
 }
 
-typedef value (callback_stub)(char* young, value closure, value* args);
+typedef value (callback_stub)(caml_domain_state* state, value closure, value* args);
 
 callback_stub caml_callback_asm, caml_callback2_asm, caml_callback3_asm;
 
@@ -135,7 +135,7 @@ static value do_callback(callback_stub* cbstub, value closure,
   Stack_parent(Caml_state->current_stack) = NULL;
 
   check_stack(nargs, args);
-  ret = cbstub(Caml_state->young_ptr, closure, args);
+  ret = cbstub(Caml_state, closure, args);
 
   Caml_state->system_sp = saved_system_sp;
   Stack_parent(Caml_state->current_stack) = saved_parent;

--- a/byterun/caml/domain_state.tbl
+++ b/byterun/caml/domain_state.tbl
@@ -3,6 +3,7 @@ DOMAIN_STATE(char*, young_ptr)
 DOMAIN_STATE(char*, young_start)
 DOMAIN_STATE(char*, young_end)
 DOMAIN_STATE(struct stack_info*, current_stack)
+DOMAIN_STATE(void*, exn_handler) /* points into current stack */
 DOMAIN_STATE(value*, stack_high)
 DOMAIN_STATE(char*, system_sp)
 DOMAIN_STATE(value**, gc_regs_slot)


### PR DESCRIPTION
This patch uses %r14 on amd64 to access globals, simplifying the assembly stubs and shortening the code needed for making allocations and C calls.

For reviewing: the first commit makes a nontrivial change, moving the current exception handler from %r14 to a field in Caml_state, and changing how the offsets are computed. The other commits are mechanical.