### PR TITLE
Remove stack_high and cleanup

### DIFF
--- a/asmrun/startup.c
+++ b/asmrun/startup.c
@@ -138,7 +138,6 @@ value caml_startup_common(char_os **argv, int pooling)
     if (caml_termination_hook != NULL) caml_termination_hook(NULL);
     return Val_unit;
   }
-  caml_init_main_stack();
   return caml_start_program(Caml_state);
 }
 

--- a/byterun/backtrace_prim.c
+++ b/byterun/backtrace_prim.c
@@ -245,7 +245,7 @@ void caml_stash_backtrace(value exn, code_t pc, value * sp, int reraise)
 
   /* Traverse the stack and put all values pointing into bytecode
      into the backtrace buffer. */
-  value *trap_sp = Caml_state->stack_high + Caml_state->trap_sp_off;
+  value *trap_sp = Stack_high(Caml_state->current_stack) + Caml_state->trap_sp_off;
   for (/*nothing*/; sp < trap_sp; sp++) {
     if (Is_long(*sp)) {
       code_t p = Pc_val(*sp);

--- a/byterun/caml/compatibility.h
+++ b/byterun/caml/compatibility.h
@@ -253,10 +253,6 @@
 /* **** asmrun/signals.c */
 #define garbage_collection caml_garbage_collection
 
-/* **** stacks.c */
-#define stack_low caml_stack_low
-#define stack_high caml_stack_high
-
 /* **** asmrun/startup.c */
 #define static_data_start caml_static_data_start
 #define static_data_end caml_static_data_end

--- a/byterun/caml/domain_state.tbl
+++ b/byterun/caml/domain_state.tbl
@@ -4,7 +4,6 @@ DOMAIN_STATE(char*, young_start)
 DOMAIN_STATE(char*, young_end)
 DOMAIN_STATE(struct stack_info*, current_stack)
 DOMAIN_STATE(void*, exn_handler) /* points into current stack */
-DOMAIN_STATE(value*, stack_high)
 DOMAIN_STATE(char*, system_sp)
 DOMAIN_STATE(value**, gc_regs_slot)
 DOMAIN_STATE(struct caml_minor_tables*, minor_tables)

--- a/byterun/caml/fiber.h
+++ b/byterun/caml/fiber.h
@@ -26,7 +26,7 @@ CAML_STATIC_ASSERT(sizeof(struct stack_info) == Stack_ctx_words * sizeof(value))
 #define Stack_base(stk) ((value*)(stk + 1))
 #define Stack_threshold_ptr(stk) (Stack_base(stk) + Stack_threshold / sizeof(value))
 
-/* 16-byte align-down caml_stack_high for certain architectures like arm64
+/* 16-byte align-down Stack_high because certain architectures like arm64
  * demand 16-byte alignment. Leaves a word unused at the bottom of the stack if
  * the Op_val(stk) + Wosize_val(stk) is not 16-byte aligned. */
 #define Stack_high(stk) ((value*)(((uintnat)stk + sizeof(value) * stk->wosize) & (-1uLL << 4)))
@@ -100,7 +100,6 @@ int caml_try_realloc_stack (asize_t required_size);
 void caml_change_max_stack_size (uintnat new_max_size);
 void caml_maybe_expand_stack();
 void caml_free_stack(struct stack_info* stk);
-int  caml_on_current_stack(value*);
 #ifdef NATIVE_CODE
 int caml_switch_stack(struct stack_info* stk, int should_free);
 #else

--- a/byterun/caml/fiber.h
+++ b/byterun/caml/fiber.h
@@ -91,9 +91,7 @@ extern caml_root caml_global_data;
 #define Trap_link(tp) ((tp)[1])
 
 struct stack_info* caml_alloc_main_stack (uintnat init_size);
-void caml_init_main_stack(void);
 void caml_scan_stack(scanning_action f, void* fdata, struct stack_info* stack);
-void caml_restore_stack();
 /* try to grow the stack until at least required_size words are available.
    returns nonzero on success */
 int caml_try_realloc_stack (asize_t required_size);

--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -225,7 +225,7 @@ static void create_domain(uintnat initial_minor_heap_size) {
     d->state.state->shared_heap = caml_init_shared_heap();
     caml_init_major_gc(domain_state);
     caml_reallocate_minor_heap(initial_minor_heap_size);
-    caml_init_main_stack();
+    Caml_state->current_stack = caml_alloc_main_stack (Stack_size/sizeof(value));
 
     domain_state->backtrace_buffer = NULL;
 #ifndef NATIVE_CODE

--- a/byterun/fiber.c
+++ b/byterun/fiber.c
@@ -20,19 +20,8 @@
 #include "frame_descriptors.h"
 #endif
 
+
 #ifdef NATIVE_CODE
-
-static struct stack_info* save_stack ()
-{
-  return Caml_state->current_stack;
-}
-
-static void load_stack (struct stack_info* stack) {
-  caml_domain_state* domain_state = Caml_state;
-  domain_state->current_stack = stack;
-  CAMLassert(Stack_base(stack) < (value*)stack->sp &&
-             (value*)stack->sp <= Stack_high(stack));
-}
 
 extern void caml_fiber_exn_handler (value) Noreturn;
 extern void caml_fiber_val_handler (value) Noreturn;
@@ -179,8 +168,9 @@ void caml_update_gc_regs_slot (value* gc_regs)
 int caml_switch_stack(struct stack_info* stk, int should_free)
 {
   struct stack_info* old = Caml_state->current_stack;
-  save_stack();
-  load_stack(stk);
+  Caml_state->current_stack = stk;
+  CAMLassert(Stack_base(stk) < (value*)stk->sp &&
+             stk->sp <= Stack_high(stk));
   if (should_free)
     caml_free_stack(old);
   if (stk->sp == Stack_high(stk) - INIT_FIBER_USED)
@@ -191,19 +181,6 @@ int caml_switch_stack(struct stack_info* stk, int should_free)
 #else /* End NATIVE_CODE, begin BYTE_CODE */
 
 caml_root caml_global_data;
-
-static struct stack_info* save_stack ()
-{
-  caml_domain_state* domain_state = Caml_state;
-  struct stack_info* old_stack = domain_state->current_stack;
-  return old_stack;
-}
-
-static void load_stack(struct stack_info* new_stack)
-{
-  caml_domain_state* domain_state = Caml_state;
-  domain_state->current_stack = new_stack;
-}
 
 CAMLprim value caml_alloc_stack(value hval, value hexn, value heff)
 {
@@ -277,9 +254,11 @@ void caml_scan_stack(scanning_action f, void* fdata, struct stack_info* stack)
 
 struct stack_info* caml_switch_stack(struct stack_info* stk)
 {
-  struct stack_info* s = save_stack();
-  load_stack(stk);
-  return s;
+  struct stack_info* old = Caml_state->current_stack;
+  Caml_state->current_stack = stk;
+  CAMLassert(Stack_base(stk) < (value*)stk->sp &&
+             stk->sp <= Stack_high(stk));
+  return old;
 }
 
 #endif /* end BYTE_CODE */
@@ -297,8 +276,7 @@ int caml_try_realloc_stack(asize_t required_space)
   int stack_used;
   CAMLnoalloc;
 
-  old_stack = save_stack();
-
+  old_stack = Caml_state->current_stack;
   stack_used = Stack_high(old_stack) - (value*)old_stack->sp;
 #ifdef DEBUG
   size = stack_used + stack_used / 16 + required_space;
@@ -343,7 +321,7 @@ int caml_try_realloc_stack(asize_t required_space)
 #endif
 
   caml_free_stack(old_stack);
-  load_stack(new_stack);
+  Caml_state->current_stack = new_stack;
   return 1;
 }
 
@@ -360,22 +338,13 @@ struct stack_info* caml_alloc_main_stack (uintnat init_size)
 {
   struct stack_info* stk;
 
-  /* Create a stack for the main program.
-     The GC is not initialised yet, so we use caml_alloc_shr
-     which cannot trigger it */
+  /* Create a stack for the main program. */
   stk = caml_stat_alloc(sizeof(value) * init_size);
   stk->wosize = init_size;
   stk->magic = 42;
   caml_init_stack (stk);
 
   return stk;
-}
-
-void caml_init_main_stack ()
-{
-  struct stack_info* stack;
-  stack = caml_alloc_main_stack (Stack_size/sizeof(value));
-  load_stack(stack);
 }
 
 void caml_free_stack (struct stack_info* stack)
@@ -412,11 +381,6 @@ CAMLprim value caml_clone_continuation (value cont)
   caml_continuation_replace(cont, orig_source);
   caml_continuation_replace(new_cont, ret_stack);
   CAMLreturn (new_cont);
-}
-
-void caml_restore_stack()
-{
-  load_stack(Caml_state->current_stack);
 }
 
 CAMLprim value caml_continuation_use (value cont)

--- a/byterun/fiber.c
+++ b/byterun/fiber.c
@@ -29,7 +29,6 @@ static struct stack_info* save_stack ()
 
 static void load_stack (struct stack_info* stack) {
   caml_domain_state* domain_state = Caml_state;
-  domain_state->stack_high = Stack_high(stack);
   domain_state->current_stack = stack;
   CAMLassert(Stack_base(stack) < (value*)stack->sp &&
              (value*)stack->sp <= Stack_high(stack));
@@ -197,14 +196,12 @@ static struct stack_info* save_stack ()
 {
   caml_domain_state* domain_state = Caml_state;
   struct stack_info* old_stack = domain_state->current_stack;
-  Assert(domain_state->stack_high == Stack_high(old_stack));
   return old_stack;
 }
 
 static void load_stack(struct stack_info* new_stack)
 {
   caml_domain_state* domain_state = Caml_state;
-  domain_state->stack_high = Stack_high(new_stack);
   domain_state->current_stack = new_stack;
 }
 
@@ -243,7 +240,7 @@ CAMLprim value caml_ensure_stack_capacity(value required_space)
 
 void caml_change_max_stack_size (uintnat new_max_size)
 {
-  asize_t size = Caml_state->stack_high - Caml_state->current_stack->sp
+  asize_t size = Stack_high(Caml_state->current_stack) - Caml_state->current_stack->sp
                  + Stack_threshold / sizeof (value);
 
   if (new_max_size < size) new_max_size = size;
@@ -292,11 +289,6 @@ struct stack_info* caml_switch_stack(struct stack_info* stk)
 
   Used by the interpreter to allocate stack space.
 */
-
-int caml_on_current_stack(value* p)
-{
-  return Stack_base(Caml_state->current_stack) <= p && p < Caml_state->stack_high;
-}
 
 int caml_try_realloc_stack(asize_t required_space)
 {

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -199,7 +199,6 @@ static inline void caml_thread_restore_runtime_state(void)
   curr_thread = st_tls_get(thread_descriptor_key);
   /* Restore the stack-related global variables */
   Caml_state->current_stack = curr_thread->current_stack;
-  caml_restore_stack();
   CAML_LOCAL_ROOTS = curr_thread->local_roots;
 #ifdef NATIVE_CODE
   Caml_state->system_sp = curr_thread->system_sp;


### PR DESCRIPTION
stack_high is now redundant (after #215), so it's removed. That makes `load_stack`, `save_stack`, `caml_restore_stack` and `caml_init_main_stack` trivial, so they're inlined & removed.