### PR TITLE
Remove locks in caml_shared_try_alloc critical path for all but large allocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ _ocamltest
 /asmrun/ints.c
 /asmrun/io.c
 /asmrun/lexing.c
+/asmrun/lockfree.c
 /asmrun/main.c
 /asmrun/major_gc.c
 /asmrun/md5.c

--- a/asmrun/Makefile
+++ b/asmrun/Makefile
@@ -21,7 +21,7 @@ LINKEDFILES=misc.c major_gc.c minor_gc.c memory.c alloc.c array.c \
   weak.c finalise.c meta.c custom.c main.c roots.c globroots.c \
   $(UNIX_OR_WIN32).c dynlink.c signals.c debugger.c addrmap.c \
   domain.c platform.c eventlog.c backtrace.c startup_aux.c \
-	afl.c bigarray.c fiber.c shared_heap.c
+	afl.c bigarray.c fiber.c shared_heap.c lockfree.c
 
 # The following variable stores the list of files for which dependencies
 # should be computed. It includes even the files that won't actually be
@@ -80,7 +80,7 @@ COBJS=startup_aux.$(O) startup.$(O) main.$(O) fail.$(O)		\
   clambda_checks.$(O) spacetime.$(O) spacetime_snapshot.$(O)		\
   spacetime_offline.$(O) afl.$(O) bigarray.$(O) addrmap.$(O) \
   domain.$(O) platform.$(O) eventlog.$(O) shared_heap.$(O) \
-	fiber.$(O) frame_descriptors.$(O)
+	fiber.$(O) frame_descriptors.$(O) lockfree.$(O)
 
 OBJS=$(COBJS) $(ASMOBJS)
 

--- a/byterun/Makefile
+++ b/byterun/Makefile
@@ -100,7 +100,7 @@ OBJS=$(addsuffix .$(O), \
   compare ints floats str array io extern intern \
   hash sys meta parsing gc_ctrl terminfo md5 obj \
   lexing callback debugger weak finalise custom \
-	domain platform eventlog fiber shared_heap addrmap \
+	domain platform eventlog fiber lockfree shared_heap addrmap \
   dynlink spacetime afl $(UNIX_OR_WIN32) bigarray main)
 
 DOBJS=$(OBJS:.$(O)=.$(DBGO)) instrtrace.$(DBGO)

--- a/byterun/caml/lockfree.h
+++ b/byterun/caml/lockfree.h
@@ -1,0 +1,18 @@
+#ifndef CAML_LOCKFREE_queue_H
+#define CAML_LOCKFREE_queue_H
+
+#ifdef CAML_INTERNALS
+
+#include "camlatomic.h"
+#include "platform.h"
+
+struct lockfree_queue {
+    atomic_intptr_t head;
+};
+
+void lockfree_queue_init(struct lockfree_queue* queue);
+void lockfree_queue_push(struct lockfree_queue* queue, void* queue_item);
+void* lockfree_queue_pop(struct lockfree_queue* queue);
+
+#endif /* CAML_INTERNALS */
+#endif /* CAML_SHARED_HEAP_H */

--- a/byterun/caml/major_gc.h
+++ b/byterun/caml/major_gc.h
@@ -48,18 +48,33 @@ void caml_add_orphaned_finalisers (struct caml_final_info*);
 void caml_final_domain_terminate (caml_domain_state *domain_state);
 void caml_adopt_orphaned_work (void);
 
-struct heap_stats {
-  intnat pool_words;
-  intnat pool_max_words;
-  intnat pool_live_words;
-  intnat pool_live_blocks;
-  intnat pool_frag_words;
-  intnat large_words;
-  intnat large_max_words;
-  intnat large_blocks;
+struct atomic_heap_stats {
+  atomic_uintnat pool_words;
+  atomic_uintnat pool_max_words;
+  atomic_uintnat pool_live_words;
+  atomic_uintnat pool_live_blocks;
+  atomic_uintnat pool_frag_words;
+  atomic_uintnat large_words;
+  atomic_uintnat large_max_words;
+  atomic_uintnat large_blocks;
 };
-void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* s);
-void caml_remove_heap_stats(struct heap_stats* acc, const struct heap_stats* s);
+
+struct heap_stats {
+  uintnat pool_words;
+  uintnat pool_max_words;
+  uintnat pool_live_words;
+  uintnat pool_live_blocks;
+  uintnat pool_frag_words;
+  uintnat large_words;
+  uintnat large_max_words;
+  uintnat large_blocks;
+};
+
+void caml_atomic_accum_heap_stats(struct atomic_heap_stats* acc, struct heap_stats* s);
+void caml_atomic_remove_heap_stats(struct atomic_heap_stats* acc, struct heap_stats* s);
+
+void caml_accum_heap_stats(struct heap_stats* acc, struct heap_stats* s);
+void caml_remove_heap_stats(struct heap_stats* acc, struct heap_stats* s);
 
 struct gc_stats {
   uint64_t minor_words;

--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -1031,7 +1031,6 @@ static void domain_terminate()
       finished = 1;
       s->terminating = 0;
       s->running = 0;
-      atomic_fetch_add(&num_domains_running, -1);
       s->unique_id += Max_domains;
     }
     caml_plat_unlock(&s->lock);
@@ -1057,6 +1056,7 @@ static void domain_terminate()
   }
   caml_plat_unlock(&domain_self->roots_lock);
   caml_plat_assert_all_locks_unlocked();
+  atomic_fetch_add(&num_domains_running, -1);
 }
 
 void caml_handle_incoming_interrupts()

--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -1056,6 +1056,9 @@ static void domain_terminate()
   }
   caml_plat_unlock(&domain_self->roots_lock);
   caml_plat_assert_all_locks_unlocked();
+  /* This is the last thing we do because we need to be able to rely
+     on caml_domain_alone (which uses num_domains_running) in at least
+     the shared_heap lockfree fast paths */
   atomic_fetch_add(&num_domains_running, -1);
 }
 

--- a/byterun/lockfree.c
+++ b/byterun/lockfree.c
@@ -1,0 +1,43 @@
+#define CAML_INTERNALS
+
+#include "caml/domain.h"
+#include "caml/lockfree.h"
+#include <stdint.h>
+
+/* Simple Treiber queue for now (a LIFO queue to match existing linked list semantics) */
+
+struct queue_item {
+  atomic_intptr_t next;
+};
+
+void lockfree_queue_init(struct lockfree_queue* queue) {
+    queue->head = NULL;
+}
+
+void lockfree_queue_push(struct lockfree_queue* queue, void* queue_item) {
+    struct queue_item* new_item = (struct queue_item*)queue_item;
+
+    intptr_t current_head;
+    do {
+        current_head = atomic_load(&queue->head);
+
+        atomic_store(&new_item->next, (intptr_t)current_head);
+    } while(!atomic_compare_exchange_strong(&queue->head, (intptr_t*)&current_head, (intptr_t)new_item));
+}
+
+void* lockfree_queue_pop(struct lockfree_queue* queue) {
+    intptr_t current_head;
+    intptr_t new_head;
+
+    do {
+        current_head = atomic_load(&queue->head);
+
+        if( current_head == 0 ) {
+            return 0;
+        }
+        
+        new_head = atomic_load(&(((struct queue_item*)current_head)->next));
+    } while(!atomic_compare_exchange_strong(&queue->head, (intptr_t*)&current_head, (intptr_t)new_head));
+
+    return (void*)current_head;
+}

--- a/byterun/lockfree.c
+++ b/byterun/lockfree.c
@@ -17,27 +17,50 @@ void lockfree_queue_init(struct lockfree_queue* queue) {
 void lockfree_queue_push(struct lockfree_queue* queue, void* queue_item) {
     struct queue_item* new_item = (struct queue_item*)queue_item;
 
-    intptr_t current_head;
-    do {
-        current_head = atomic_load(&queue->head);
+    if( caml_domain_alone() ) 
+    {
+        new_item->next = queue->head;
+        queue->head = new_item;
+    }
+    else 
+    {
+        intptr_t current_head;
+        do {
+            current_head = atomic_load(&queue->head);
 
-        atomic_store(&new_item->next, (intptr_t)current_head);
-    } while(!atomic_compare_exchange_strong(&queue->head, (intptr_t*)&current_head, (intptr_t)new_item));
+            atomic_store(&new_item->next, (intptr_t)current_head);
+        } while(!atomic_compare_exchange_strong(&queue->head, (intptr_t*)&current_head, (intptr_t)new_item));
+    }
 }
 
 void* lockfree_queue_pop(struct lockfree_queue* queue) {
-    intptr_t current_head;
-    intptr_t new_head;
+    if( caml_domain_alone() )
+    {
+        struct queue_item* current_head = queue->head;
 
-    do {
-        current_head = atomic_load(&queue->head);
-
-        if( current_head == 0 ) {
+        if( current_head == NULL ) {
             return 0;
         }
-        
-        new_head = atomic_load(&(((struct queue_item*)current_head)->next));
-    } while(!atomic_compare_exchange_strong(&queue->head, (intptr_t*)&current_head, (intptr_t)new_head));
 
-    return (void*)current_head;
+        queue->head = current_head->next;
+
+        return current_head;
+    }
+    else
+    {
+        intptr_t current_head;
+        intptr_t new_head;
+
+        do {
+            current_head = atomic_load(&queue->head);
+
+            if( current_head == 0 ) {
+                return 0;
+            }
+            
+            new_head = atomic_load(&(((struct queue_item*)current_head)->next));
+        } while(!atomic_compare_exchange_strong(&queue->head, (intptr_t*)&current_head, (intptr_t)new_head));
+
+        return current_head;
+    }
 }

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -790,10 +790,10 @@ intnat ephe_sweep (struct domain* d, intnat budget)
    at the end of the most recently completed GC cycle */
 static struct gc_stats sampled_gc_stats[2][Max_domains];
 
-void set_max(atomic_uintnat* to, atomic_uintnat* from) {
+void set_max(atomic_uintnat* to, uintnat* from) {
   while(1) {
     uintnat to_val = atomic_load_acq(to);
-    uintnat from_val = atomic_load_acq(from);
+    uintnat from_val = *from;
 
     if( from_val <= to_val || atomic_compare_exchange_strong(to, &to_val, from_val) ) {
       break;

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -790,7 +790,43 @@ intnat ephe_sweep (struct domain* d, intnat budget)
    at the end of the most recently completed GC cycle */
 static struct gc_stats sampled_gc_stats[2][Max_domains];
 
-void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
+void set_max(atomic_uintnat* to, atomic_uintnat* from) {
+  while(1) {
+    uintnat to_val = atomic_load_acq(to);
+    uintnat from_val = atomic_load_acq(from);
+
+    if( from_val <= to_val || atomic_compare_exchange_strong(to, &to_val, from_val) ) {
+      break;
+    }
+  }
+}
+
+void caml_atomic_accum_heap_stats(struct atomic_heap_stats* acc, struct heap_stats* h)
+{
+  atomic_fetch_add_explicit(&acc->pool_words, h->pool_words, memory_order_release);
+  
+  set_max(&acc->pool_max_words, &h->pool_max_words);
+  
+  atomic_fetch_add_explicit(&acc->pool_live_words, h->pool_live_words, memory_order_release);
+  atomic_fetch_add_explicit(&acc->pool_live_blocks, h->pool_live_blocks, memory_order_release); 
+  atomic_fetch_add_explicit(&acc->pool_frag_words, h->pool_frag_words, memory_order_release); 
+  
+  atomic_fetch_add_explicit(&acc->large_words, h->large_words, memory_order_release);
+  set_max(&acc->large_max_words, &h->large_max_words);    
+  atomic_fetch_add_explicit(&acc->large_blocks, h->large_blocks, memory_order_release); 
+}
+
+void caml_atomic_remove_heap_stats(struct atomic_heap_stats* acc, struct heap_stats* h)
+{
+  atomic_fetch_sub_explicit(&acc->pool_words, h->pool_words, memory_order_release);
+  atomic_fetch_sub_explicit(&acc->pool_live_words, h->pool_live_words, memory_order_release);
+  atomic_fetch_sub_explicit(&acc->pool_live_blocks, h->pool_live_blocks, memory_order_release);
+  atomic_fetch_sub_explicit(&acc->pool_frag_words, h->pool_frag_words, memory_order_release);
+  atomic_fetch_sub_explicit(&acc->large_words, h->large_words, memory_order_release);
+  atomic_fetch_sub_explicit(&acc->large_blocks, h->large_blocks, memory_order_release);
+}
+
+void caml_accum_heap_stats(struct heap_stats* acc, struct heap_stats* h)
 {
   acc->pool_words += h->pool_words;
   if (acc->pool_max_words < h->pool_max_words)
@@ -804,7 +840,7 @@ void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
   acc->large_blocks += h->large_blocks;
 }
 
-void caml_remove_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
+void caml_remove_heap_stats(struct heap_stats* acc, struct heap_stats* h)
 {
   acc->pool_words -= h->pool_words;
   acc->pool_live_words -= h->pool_live_words;
@@ -813,7 +849,6 @@ void caml_remove_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
   acc->large_words -= h->large_words;
   acc->large_blocks -= h->large_blocks;
 }
-
 
 void caml_sample_gc_stats(struct gc_stats* buf)
 {

--- a/byterun/shared_heap.c
+++ b/byterun/shared_heap.c
@@ -80,12 +80,9 @@ struct caml_heap_state* caml_init_shared_heap() {
   // the queues
   if( caml_domain_alone() ) {
     for (i = 0; i<NUM_SIZECLASSES; i++) {
-      caml_gc_log("initializing pools for sz: %d", i);
       lockfree_queue_init(&pool_freelist.global_avail_pools[i]);
       lockfree_queue_init(&pool_freelist.global_full_pools[i]);
     }
-
-    caml_gc_log("initializing free pools\n");
     lockfree_queue_init(&pool_freelist.free);
   }
 

--- a/byterun/shared_heap.c
+++ b/byterun/shared_heap.c
@@ -9,6 +9,7 @@
 #include "caml/fiber.h" /* for verification */
 #include "caml/gc.h"
 #include "caml/globroots.h"
+#include "caml/lockfree.h"
 #include "caml/memory.h"
 #include "caml/mlvalues.h"
 #include "caml/platform.h"
@@ -37,20 +38,20 @@ CAML_STATIC_ASSERT(sizeof(large_alloc) % sizeof(value) == 0);
 #define LARGE_ALLOC_HEADER_SZ sizeof(large_alloc)
 
 struct {
-  caml_plat_mutex lock;
-  pool* free;
+  struct lockfree_queue free;
 
   /* these only contain swept memory of terminated domains*/
-  struct heap_stats stats;
-  pool* global_avail_pools[NUM_SIZECLASSES];
-  pool* global_full_pools[NUM_SIZECLASSES];
+  struct atomic_heap_stats stats;
+  struct lockfree_queue global_avail_pools[NUM_SIZECLASSES];
+  struct lockfree_queue global_full_pools[NUM_SIZECLASSES];
+  caml_plat_mutex large_mutex;
   large_alloc* global_large;
 } pool_freelist = {
+  { 0 },
+  { 0, },
+  { {0}, },
+  { {0}, },
   CAML_PLAT_MUTEX_INITIALIZER,
-  NULL,
-  { 0, },
-  { 0, },
-  { 0, },
   NULL
 };
 
@@ -75,6 +76,19 @@ struct caml_heap_state* caml_init_shared_heap() {
   int i;
   struct caml_heap_state* heap;
 
+  // This is the first time we've done this, so set up
+  // the queues
+  if( caml_domain_alone() ) {
+    for (i = 0; i<NUM_SIZECLASSES; i++) {
+      caml_gc_log("initializing pools for sz: %d", i);
+      lockfree_queue_init(&pool_freelist.global_avail_pools[i]);
+      lockfree_queue_init(&pool_freelist.global_full_pools[i]);
+    }
+
+    caml_gc_log("initializing free pools\n");
+    lockfree_queue_init(&pool_freelist.free);
+  }
+
   heap = caml_stat_alloc_noexc(sizeof(struct caml_heap_state));
   if(heap != NULL) {
     for (i = 0; i<NUM_SIZECLASSES; i++) {
@@ -90,33 +104,68 @@ struct caml_heap_state* caml_init_shared_heap() {
   return heap;
 }
 
-static int move_all_pools(pool** src, pool** dst, struct domain* new_owner) {
+static void calc_pool_stats(pool* a, sizeclass sz, struct heap_stats* s);
+
+static int move_all_pools_to_queue(pool** src, struct lockfree_queue* dst, struct domain* new_owner, struct heap_stats* s, sizeclass sz) {
   int count = 0;
-  while (*src) {
+  
+  while(*src) {
     pool* p = *src;
     *src = p->next;
     p->owner = new_owner;
-    p->next = *dst;
-    *dst = p;
+    p->next = 0;
+
+    calc_pool_stats(p, sz, s);
+
+    lockfree_queue_push(dst, p);
     count++;
   }
+
   return count;
 }
+
+static int move_all_queue_to_pools(struct lockfree_queue* src, pool** dst, struct domain* new_owner, struct heap_stats* s, sizeclass sz) {
+  int count = 0;
+  
+  while(1) {
+    pool* p = lockfree_queue_pop(src);
+
+    if( p == NULL ) {
+      break;
+    }
+
+    p->owner = new_owner;
+    p->next = *dst;
+
+    calc_pool_stats(p, sz, s);
+
+    *dst = p;
+    
+    count++;
+  }
+
+  return count;
+}
+
+
 
 void caml_teardown_shared_heap(struct caml_heap_state* heap) {
   int i;
   int released = 0, released_large = 0;
-  caml_plat_lock(&pool_freelist.lock);
+
+  struct heap_stats tmp_stats = {0};
+
   for (i = 0; i < NUM_SIZECLASSES; i++) {
     released +=
-      move_all_pools(&heap->avail_pools[i], &pool_freelist.global_avail_pools[i], NULL);
+      move_all_pools_to_queue(&heap->avail_pools[i], &pool_freelist.global_avail_pools[i], NULL, &tmp_stats, i);
     released +=
-      move_all_pools(&heap->full_pools[i], &pool_freelist.global_full_pools[i], NULL);
+      move_all_pools_to_queue(&heap->full_pools[i], &pool_freelist.global_full_pools[i], NULL, &tmp_stats, i);
     /* should be swept by now */
     Assert(!heap->unswept_avail_pools[i]);
     Assert(!heap->unswept_full_pools[i]);
   }
   Assert(!heap->unswept_large);
+  caml_plat_lock(&pool_freelist.large_mutex);
   while (heap->swept_large) {
     large_alloc* a = heap->swept_large;
     heap->swept_large = a->next;
@@ -124,8 +173,11 @@ void caml_teardown_shared_heap(struct caml_heap_state* heap) {
     pool_freelist.global_large = a;
     released_large++;
   }
-  caml_accum_heap_stats(&pool_freelist.stats, &heap->stats);
-  caml_plat_unlock(&pool_freelist.lock);
+  
+  tmp_stats.large_words = heap->stats.large_words;
+  tmp_stats.large_blocks = heap->stats.large_blocks;
+  caml_plat_unlock(&pool_freelist.large_mutex);
+  caml_atomic_accum_heap_stats(&pool_freelist.stats, &tmp_stats);
   caml_stat_free(heap);
   caml_gc_log("Shutdown shared heap. Released %d active pools, %d large",
               released, released_large);
@@ -143,25 +195,28 @@ void caml_sample_heap_stats(struct caml_heap_state* local, struct heap_stats* h)
 static pool* pool_acquire(struct caml_heap_state* local) {
   pool* r;
 
-  caml_plat_lock(&pool_freelist.lock);
-  if (!pool_freelist.free) {
-    void* mem = caml_mem_map(Bsize_wsize(POOL_WSIZE) * POOLS_PER_ALLOCATION,
+  do {
+    r = lockfree_queue_pop(&pool_freelist.free);
+
+    if (!r) {
+      void* mem = caml_mem_map(Bsize_wsize(POOL_WSIZE) * POOLS_PER_ALLOCATION,
                               Bsize_wsize(POOL_WSIZE), 0 /* allocate */);
-    int i;
-    if (mem) {
-      pool_freelist.free = mem;
-      for (i=1; i<POOLS_PER_ALLOCATION; i++) {
-        r = (pool*)(((uintnat)mem) + ((uintnat)i) * Bsize_wsize(POOL_WSIZE));
-        r->next = pool_freelist.free;
-        r->owner = 0;
-        pool_freelist.free = r;
+      int i;
+      if (mem) {
+        lockfree_queue_push(&pool_freelist.free, mem);
+        for (i=1; i<POOLS_PER_ALLOCATION; i++) {
+         r = (pool*)(((uintnat)mem) + ((uintnat)i) * Bsize_wsize(POOL_WSIZE));
+         r->owner = 0;
+         r->next = 0;
+         lockfree_queue_push(&pool_freelist.free, r);
+        }
+      } else {
+       return 0;
       }
+
+      r = lockfree_queue_pop(&pool_freelist.free);
     }
-  }
-  r = pool_freelist.free;
-  if (r)
-    pool_freelist.free = r->next;
-  caml_plat_unlock(&pool_freelist.lock);
+  } while( !r );
 
   if (r) Assert (r->owner == 0);
   return r;
@@ -173,10 +228,8 @@ static void pool_release(struct caml_heap_state* local, pool* pool, sizeclass sz
   local->stats.pool_words -= POOL_WSIZE;
   local->stats.pool_frag_words -= POOL_HEADER_WSIZE + wastage_sizeclass[sz];
   /* FIXME: give free pools back to the OS */
-  caml_plat_lock(&pool_freelist.lock);
-  pool->next = pool_freelist.free;
-  pool_freelist.free = pool;
-  caml_plat_unlock(&pool_freelist.lock);
+
+  lockfree_queue_push(&pool_freelist.free, pool);
 }
 
 static void calc_pool_stats(pool* a, sizeclass sz, struct heap_stats* s) {
@@ -221,34 +274,30 @@ static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
   if (r) return r;
 
   /* Haven't managed to find a pool locally, try the global ones */
-  caml_plat_lock(&pool_freelist.lock);
-  if( pool_freelist.global_avail_pools[sz] ) {
-    r = pool_freelist.global_avail_pools[sz];
+  r = lockfree_queue_pop(&pool_freelist.global_avail_pools[sz]);
 
-    if( r ) {
-      pool_freelist.global_avail_pools[sz] = r->next;
-      r->next = 0;
-      local->avail_pools[sz] = r;
+  if( r ) {
+    r->next = 0;
+    local->avail_pools[sz] = r;
 
-      #ifdef DEBUG
-      int free_objs = 0;
-      value* next_obj = r->next_obj;
-      while( next_obj ) {
-        free_objs++;
-        Assert(next_obj[0] == 0);
-        next_obj = (value*)next_obj[1];
-      }
-      #endif
-
-      struct heap_stats tmp_stats = { 0 };
-
-      calc_pool_stats(r, sz, &tmp_stats);
-      caml_accum_heap_stats(&local->stats, &tmp_stats);
-      caml_remove_heap_stats(&pool_freelist.stats, &tmp_stats);
-
-      if (local->stats.pool_words > local->stats.pool_max_words)
-        local->stats.pool_max_words = local->stats.pool_words;
+    #ifdef DEBUG
+    int free_objs = 0;
+    value* next_obj = r->next_obj;
+    while( next_obj ) {
+      free_objs++;
+      Assert(next_obj[0] == 0);
+      next_obj = (value*)next_obj[1];
     }
+    #endif
+
+    struct heap_stats tmp_stats = { 0 };
+
+    calc_pool_stats(r, sz, &tmp_stats);
+    caml_accum_heap_stats(&local->stats, &tmp_stats);
+    caml_atomic_remove_heap_stats(&pool_freelist.stats, &tmp_stats);
+
+    if (local->stats.pool_words > local->stats.pool_max_words)
+      local->stats.pool_max_words = local->stats.pool_words;
   }
 
   /* There were no global avail pools, so let's adopt one of the full ones and try
@@ -256,16 +305,15 @@ static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
   if( !r ) {
     struct heap_stats tmp_stats = { 0 };
 
-    r = pool_freelist.global_full_pools[sz];
+    r = lockfree_queue_pop(&pool_freelist.global_full_pools[sz]);
 
     if( r ) {
-      pool_freelist.global_full_pools[sz] = r->next;
       r->next = local->full_pools[sz];
       local->full_pools[sz] = r;
 
       calc_pool_stats(r, sz, &tmp_stats);
       caml_accum_heap_stats(&local->stats, &tmp_stats);
-      caml_remove_heap_stats(&pool_freelist.stats, &tmp_stats);
+      caml_atomic_remove_heap_stats(&pool_freelist.stats, &tmp_stats);
 
       adopted_pool = 1;
       r = 0; // this pool is full
@@ -275,8 +323,6 @@ static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
       }
     }
   }
-
-  caml_plat_unlock(&pool_freelist.lock);
 
   if( !r && adopted_pool ) {
     caml_domain_state* domain_state = caml_domain_self()->state;
@@ -305,7 +351,6 @@ static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
   mlsize_t wh = wsize_sizeclass[sz];
   value* p = (value*)((char*)r + POOL_HEADER_SZ);
   value* end = (value*)((char*)r + Bsize_wsize(POOL_WSIZE));
-  value* last_p = 0;
 
   p[0] = 0;
   p[1] = 0;
@@ -326,6 +371,19 @@ static void* pool_allocate(struct caml_heap_state* local, sizeclass sz) {
   pool* r = pool_find(local, sz);
 
   if (!r) return 0;
+
+  #ifdef DEBUG
+  {
+    value* s = r->next_obj;
+
+    do 
+    {
+      Assert(s[0] == 0);
+    }
+    while( (s = (value*)s[1]) != 0 );
+
+  }
+  #endif
 
   value* p = r->next_obj;
   value* next = (value*)p[1];
@@ -610,12 +668,6 @@ void verify_push(void* st_v, value v, value* p)
   struct heap_verify_state* st = st_v;
   if (!Is_block(v)) return;
 
-  if( Is_minor(v) ) {
-    caml_gc_log("minor in heap: 0x%lx, hd_val: %d, p: 0x%lx", v, Hd_val(v), p);
-    struct domain* domain = caml_owner_of_young_block(v);
-    caml_gc_log("owner: %d, young_start: 0x%lx, young_end: 0x%lx, young_ptr: 0x%lx, young_limit: 0x%lx", domain->state->id, domain->state->young_start, domain->state->young_end, domain->state->young_ptr, domain->state->young_limit);
-  }
-
   if (st->sp == st->stack_len) {
     st->stack_len = st->stack_len * 2 + 100;
     st->stack = caml_stat_resize(st->stack,
@@ -698,6 +750,7 @@ static void verify_pool(pool* a, sizeclass sz, struct mem_stats* s) {
 
   while (p + wh <= end) {
     header_t hd = (header_t)*p;
+    
     Assert(hd == 0 || !Has_status_hd(hd, global.GARBAGE));
     if (hd) {
       s->live += Whsize_hd(hd);
@@ -734,7 +787,9 @@ static void verify_swept (struct caml_heap_state* local) {
            local->unswept_full_pools[i] == 0);
     pool* p;
     for (p = local->avail_pools[i]; p; p = p->next)
+    {
       verify_pool(p, i, &pool_stats);
+    }
     for (p = local->full_pools[i]; p; p = p->next) {
       Assert(p->next_obj == 0);
       verify_pool(p, i, &pool_stats);
@@ -785,15 +840,18 @@ void caml_cycle_heap(struct caml_heap_state* local) {
   local->unswept_large = local->swept_large;
   local->swept_large = 0;
 
-  caml_plat_lock(&pool_freelist.lock);
+  struct heap_stats tmp_stats = {0};
+
   for (i = 0; i < NUM_SIZECLASSES; i++) {
-    received_p += move_all_pools(&pool_freelist.global_avail_pools[i],
+    received_p += move_all_queue_to_pools(&pool_freelist.global_avail_pools[i],
                                  &local->unswept_avail_pools[i],
-                                 local->owner);
-    received_p += move_all_pools(&pool_freelist.global_full_pools[i],
+                                 local->owner, &tmp_stats, i);
+    received_p += move_all_queue_to_pools(&pool_freelist.global_full_pools[i],
                                  &local->unswept_full_pools[i],
-                                 local->owner);
+                                 local->owner, &tmp_stats, i);
   }
+  
+  caml_plat_lock(&pool_freelist.large_mutex);
   while (pool_freelist.global_large) {
     large_alloc* a = pool_freelist.global_large;
     pool_freelist.global_large = a->next;
@@ -802,11 +860,19 @@ void caml_cycle_heap(struct caml_heap_state* local) {
     local->unswept_large = a;
     received_l++;
   }
-  if (received_p || received_l) {
-    caml_accum_heap_stats(&local->stats, &pool_freelist.stats);
-    memset(&pool_freelist.stats, 0, sizeof(pool_freelist.stats));
+
+  tmp_stats.large_words += pool_freelist.stats.large_words;
+  tmp_stats.large_blocks += pool_freelist.stats.large_blocks;
+  if( tmp_stats.large_words > tmp_stats.large_max_words ) {
+    tmp_stats.large_max_words = tmp_stats.large_words;
   }
-  caml_plat_unlock(&pool_freelist.lock);
+  caml_plat_unlock(&pool_freelist.large_mutex);
+
+  if (received_p || received_l) {
+    caml_accum_heap_stats(&local->stats, &tmp_stats);
+    caml_atomic_remove_heap_stats(&pool_freelist.stats, &tmp_stats);
+  }
+
   if (received_p || received_l)
     caml_gc_log("Received %d new pools, %d new large allocs", received_p, received_l);
 


### PR DESCRIPTION
The minor GC when promoting blocks to the major heap calls `caml_shared_try_alloc` which will try to find a space in a pool of the appropriate size for the blocks. If no pool can be found then `pool_find` is called which tries to grab one of the orphaned available pools or full pools of that size, if those aren't available then a new pool is allocated.

At the moment `pool_find` has a mutex around adopting orphaned pools and allocating a new pool. This lock ends up being contended reasonably heavily during minor collections especially with the parallel collector due to all minor GCs happening at the same time. We also do some slightly expensive bookkeeping while holding the lock which makes matters worse.

This PR removes locking from calls to `caml_shared_try_alloc` for all but large allocations (which are very infrequent). It does so by replacing the existing singly linked lists protected by a mutex with a set of lockfree stacks. The lockfree stack implementation is a simple Treiber Stack and we may want to look at something more performant later on. The implementation is kept separate from the shared heap code to allow for reuse elsewhere in the codebase.