### PR TITLE
Introduce Lazy.try_force and Lazy.try_force_val

### DIFF
--- a/stdlib/camlinternalLazy.ml
+++ b/stdlib/camlinternalLazy.ml
@@ -18,7 +18,6 @@
 type 'a t = 'a lazy_t
 
 exception Undefined
-exception RacyLazy
 
 (* [update_tag blk old new] updates the tag [blk] from [old] to [new] using a
  * CAS loop (in order to handle concurrent conflicts with the GC marking).
@@ -31,8 +30,33 @@ external make_forward : Obj.t -> Obj.t -> unit = "caml_obj_make_forward"
 
 external domain_self : unit -> int = "caml_ml_domain_id"
 
-(* Assume [blk] is a block with tag lazy *)
-let force_lazy_block (blk : 'arg lazy_t) =
+(* Assumes [blk] is a block with tag forcing *)
+let do_force_block blk =
+  let b = Obj.repr blk in
+  let closure = (Obj.obj (Obj.field b 0) : unit -> 'arg) in
+  Obj.set_field b 0 (Obj.repr (domain_self ()));
+  try
+    let result = closure () in
+    make_forward b (Obj.repr result);
+    result
+  with e ->
+    Obj.set_field b 0 (Obj.repr (fun () -> raise e));
+    assert (update_tag b Obj.forcing_tag Obj.lazy_tag);
+    raise e
+
+(* Assumes [blk] is a block with tag forcing *)
+let do_force_val_block blk =
+  let b = Obj.repr blk in
+  let closure = (Obj.obj (Obj.field b 0) : unit -> 'arg) in
+  Obj.set_field b 0 (Obj.repr (domain_self ()));
+  let result = closure () in
+  make_forward b (Obj.repr result);
+  result
+
+type status = Racy | Forcing
+
+(* Assumes [blk] is a block with tag lazy *)
+let update_tag_forcing (blk : 'arg lazy_t) =
   let b = Obj.repr blk in
   if not (update_tag b Obj.lazy_tag Obj.forcing_tag) then
     (* blk has tag either
@@ -46,60 +70,38 @@ let force_lazy_block (blk : 'arg lazy_t) =
      * before reading the first field of [b] *)
     if Obj.tag b = Obj.forcing_tag && forcing_domain_id = my_domain_id then
       raise Undefined
-    else raise RacyLazy
-  else begin
-    let closure = (Obj.obj (Obj.field b 0) : unit -> 'arg) in
-    Obj.set_field b 0 (Obj.repr (domain_self ()));
-    try
-      let result = closure () in
-      make_forward b (Obj.repr result);
-      result
-    with e ->
-      Obj.set_field b 0 (Obj.repr (fun () -> raise e));
-      assert (update_tag b Obj.forcing_tag Obj.lazy_tag);
-      raise e
-  end
+    else Racy
+  else Forcing
 
+let force_gen_lazy_block ~only_val blk =
+  match update_tag_forcing blk with
+  | Racy -> raise Undefined
+  | Forcing when only_val -> do_force_val_block blk
+  | Forcing -> do_force_block blk
 
-(* Assume [blk] is a block with tag lazy *)
-let force_val_lazy_block (blk : 'arg lazy_t) =
-  let b = Obj.repr blk in
-  if not (update_tag b Obj.lazy_tag Obj.forcing_tag) then
-    (* blk has tag either
-        + Obj.forcing_tag -- currently being forced by this domain or
-                             another concurrent domain (or)
-        + Obj.forward_tag -- was being forced by another domain which has since
-                             completed the evaluation and updated the lazy. *)
-    let forcing_domain_id : int = Obj.obj (Obj.field b 0) in
-    let my_domain_id = (domain_self () :> int) in
-    (* XXX KC: Need a fence here to prevent the tag read from being reordered
-     * before reading the first field of [b] *)
-    if Obj.tag b = Obj.forcing_tag && forcing_domain_id = my_domain_id then
-      raise Undefined
-    else raise RacyLazy
-  else begin
-    let closure = (Obj.obj (Obj.field b 0) : unit -> 'arg) in
-    Obj.set_field b 0 (Obj.repr (domain_self ()));
-    let result = closure () in
-    make_forward b (Obj.repr result);
-    result
-  end
+(* used in the %lazy_force primitive *)
+let force_lazy_block blk = force_gen_lazy_block ~only_val:false blk
 
-(* [force] is not used, since [Lazy.force] is declared as a primitive
-   whose code inlines the tag tests of its argument.  This function is
-   here for the sake of completeness, and for debugging purpose. *)
+let try_force_gen_lazy_block ~only_val blk =
+  match update_tag_forcing blk with
+  | Racy -> None
+  | Forcing when only_val -> Some (do_force_val_block blk)
+  | Forcing -> Some (do_force_block blk)
 
-let force (lzv : 'arg lazy_t) =
+(* [force_gen ~only_val:false] is not used, since [Lazy.force] is
+   declared as a primitive whose code inlines the tag tests of its
+   argument. This function is here for the sake of completeness, and
+   for debugging purpose. *)
+let force_gen ~only_val (lzv : 'arg lazy_t) =
   let x = Obj.repr lzv in
   let t = Obj.tag x in
   if t = Obj.forward_tag then (Obj.obj (Obj.field x 0) : 'arg) else
   if t <> Obj.lazy_tag && t <> Obj.forcing_tag then (Obj.obj x : 'arg)
-  else force_lazy_block lzv
+  else force_gen_lazy_block ~only_val lzv
 
-
-let force_val (lzv : 'arg lazy_t) =
+let try_force_gen ~only_val (lzv : 'arg lazy_t) =
   let x = Obj.repr lzv in
   let t = Obj.tag x in
-  if t = Obj.forward_tag then (Obj.obj (Obj.field x 0) : 'arg) else
-  if t <> Obj.lazy_tag && t <> Obj.forcing_tag then (Obj.obj x : 'arg)
-  else force_val_lazy_block lzv
+  if t = Obj.forward_tag then Some (Obj.obj (Obj.field x 0) : 'arg) else
+  if t <> Obj.lazy_tag && t <> Obj.forcing_tag then Some (Obj.obj x : 'arg)
+  else try_force_gen_lazy_block ~only_val lzv

--- a/stdlib/camlinternalLazy.mli
+++ b/stdlib/camlinternalLazy.mli
@@ -20,11 +20,9 @@
 type 'a t = 'a lazy_t
 
 exception Undefined
-exception RacyLazy
 
 val force_lazy_block : 'a lazy_t -> 'a
 
-val force_val_lazy_block : 'a lazy_t -> 'a
+val force_gen : only_val:bool -> 'a lazy_t -> 'a
 
-val force : 'a lazy_t -> 'a
-val force_val : 'a lazy_t -> 'a
+val try_force_gen : only_val:bool -> 'a lazy_t -> 'a option

--- a/stdlib/lazy.ml
+++ b/stdlib/lazy.ml
@@ -51,15 +51,17 @@ type 'a t = 'a CamlinternalLazy.t
 
 exception Undefined = CamlinternalLazy.Undefined
 
-exception RacyLazy = CamlinternalLazy.RacyLazy
-
 external make_forward : 'a -> 'a lazy_t = "caml_lazy_make_forward"
 
 external force : 'a t -> 'a = "%lazy_force"
 
-(* let force = force *)
+(* let force l = CamlinternalLazy.force_gen ~only_val:false l *)
 
-let force_val = CamlinternalLazy.force_val
+let force_val l = CamlinternalLazy.force_gen ~only_val:true l
+
+let try_force l =  CamlinternalLazy.try_force_gen ~only_val:false l
+
+let try_force_val l = CamlinternalLazy.try_force_gen ~only_val:true l
 
 let from_fun (f : unit -> 'arg) =
   let x = Obj.new_block Obj.lazy_tag 1 in

--- a/stdlib/lazy.mli
+++ b/stdlib/lazy.mli
@@ -42,9 +42,11 @@ type 'a t = 'a CamlinternalLazy.t
    for the [lazy] keyword.  You should not use it directly.  Always use
    [Lazy.t] instead.
 
-   Note: [Lazy.force] is not thread-safe.  If you use this module in
-   a multi-threaded program, you will need to add some locks.  See also
-   [Lazy.try_force].
+   Note: [Lazy.force] (and therefore the [lazy] pattern-matching) are
+   thread-safe, but will raise the [Undefined] exception if forced
+   concurrently. If you need to share a lazy between threads, then you
+   need to use [Lazy.try_force] and implement your own synchronisation.
+   (@since XXX)
 
    Note: if the program is compiled with the [-rectypes] option,
    ill-founded recursive definitions of the form [let rec x = lazy x]
@@ -70,8 +72,8 @@ external force : 'a t -> 'a = "%lazy_force"
 
 val try_force : 'a t -> 'a option
 (** [try_force x] behaves similarly to [Some (force x)], except that
-    it returns immediately with [None] if [x] is concurrently forced by
-    another domain. *)
+    it returns immediately with [None] if [x] is already being forced
+    concurrently by another domain. *)
 
 val force_val : 'a t -> 'a
 (** [force_val x] forces the suspension [x] and returns its
@@ -80,13 +82,12 @@ val force_val : 'a t -> 'a
     Raise {!Undefined} if the forcing of [x] tries to force [x] itself
     recursively, or if [x] is concurrently forced by another domain.
     If the computation of [x] raises an exception, it is unspecified
-    whether [force_val x] raises the same exception or {!Undefined}.
-*)
+    whether [force_val x] raises the same exception or {!Undefined}. *)
 
 val try_force_val : 'a t -> 'a option
 (** [try_force_val x] behaves similarly to [Some (force_val x)],
-    except that it returns immediately with [None] if [x] is
-    concurrently forced by another domain. *)
+    except that it returns immediately with [None] if [x] is already
+    being forced concurrently by another domain. *)
 
 val from_fun : (unit -> 'a) -> 'a t
 (** [from_fun f] is the same as [lazy (f ())] but slightly more efficient.

--- a/testsuite/tests/backtrace/backtrace2.byte.reference
+++ b/testsuite/tests/backtrace/backtrace2.byte.reference
@@ -46,13 +46,13 @@ Called from file "backtrace2.ml", line 52, characters 43-52
 Called from file "backtrace2.ml", line 52, characters 43-52
 Called from file "backtrace2.ml", line 52, characters 43-52
 Called from file "backtrace2.ml", line 52, characters 43-52
-Called from file "camlinternalLazy.ml", line 54, characters 19-29
-Re-raised at file "camlinternalLazy.ml", line 60, characters 12-13
+Called from file "camlinternalLazy.ml", line 39, characters 17-27
+Re-raised at file "camlinternalLazy.ml", line 45, characters 10-11
 Called from file "backtrace2.ml", line 67, characters 11-23
 Uncaught exception Not_found
 Raised at file "hashtbl.ml", line 537, characters 19-28
 Called from file "backtrace2.ml", line 55, characters 8-41
-Re-raised at file "camlinternalLazy.ml", line 58, characters 51-52
-Called from file "camlinternalLazy.ml", line 54, characters 19-29
-Re-raised at file "camlinternalLazy.ml", line 60, characters 12-13
+Re-raised at file "camlinternalLazy.ml", line 43, characters 49-50
+Called from file "camlinternalLazy.ml", line 39, characters 17-27
+Re-raised at file "camlinternalLazy.ml", line 45, characters 10-11
 Called from file "backtrace2.ml", line 67, characters 11-23

--- a/testsuite/tests/backtrace/backtrace2.opt.reference
+++ b/testsuite/tests/backtrace/backtrace2.opt.reference
@@ -46,13 +46,13 @@ Called from file "backtrace2.ml", line 52, characters 43-52
 Called from file "backtrace2.ml", line 52, characters 43-52
 Called from file "backtrace2.ml", line 52, characters 43-52
 Called from file "backtrace2.ml", line 52, characters 43-52
-Called from file "camlinternalLazy.ml", line 54, characters 19-29
-Re-raised at file "camlinternalLazy.ml", line 60, characters 6-13
+Called from file "camlinternalLazy.ml", line 39, characters 17-27
+Re-raised at file "camlinternalLazy.ml", line 45, characters 4-11
 Called from file "backtrace2.ml", line 67, characters 11-23
 Uncaught exception Not_found
 Raised at file "hashtbl.ml", line 537, characters 13-28
 Called from file "backtrace2.ml", line 55, characters 8-41
-Re-raised at file "camlinternalLazy.ml", line 58, characters 45-52
-Called from file "camlinternalLazy.ml", line 54, characters 19-29
-Re-raised at file "camlinternalLazy.ml", line 60, characters 6-13
+Re-raised at file "camlinternalLazy.ml", line 43, characters 43-50
+Called from file "camlinternalLazy.ml", line 39, characters 17-27
+Re-raised at file "camlinternalLazy.ml", line 45, characters 4-11
 Called from file "backtrace2.ml", line 67, characters 11-23

--- a/testsuite/tests/lazy/lazy3.ml
+++ b/testsuite/tests/lazy/lazy3.ml
@@ -24,4 +24,4 @@ let main () =
 let _ =
   match main () with
   | (n1, n2) -> Printf.printf "n1=%d n2=%d\n" n1 n2
-  | exception Lazy.RacyLazy -> print_endline "RacyLazy"
+  | exception Lazy.Undefined -> print_endline "Undefined"

--- a/testsuite/tests/lazy/lazy3.reference
+++ b/testsuite/tests/lazy/lazy3.reference
@@ -1,1 +1,1 @@
-RacyLazy
+Undefined

--- a/testsuite/tests/lazy/lazy5.ml
+++ b/testsuite/tests/lazy/lazy5.ml
@@ -2,10 +2,12 @@
    ocamlopt_flags += " -O3 "
 *)
 let rec safe_force l =
-  try Lazy.force l with
-  | Lazy.RacyLazy ->
-      Domain.Sync.cpu_relax ();
+  match Lazy.try_force l with
+  | Some x -> x
+  | None -> (
+      Domain.Sync.cpu_relax () ;
       safe_force l
+    )
 
 let f count =
   let _n = (Domain.self ():> int) in


### PR DESCRIPTION
Hi @kayceesrk,

I though about it more and here is the fix I would like to propose for the `RacyLazy` exception.

From the commit log:

---

The `Lazy.RacyLazy` exception denotes a concurrency bug. As such, the following pattern:
```ocaml
  try Lazy.force x with Lazy.RacyLazy -> ...
```
does not do what one wants: we do not know whether it means that the evaluation of x ended with a bug, or if x itself is being concurrently forced.

The two new functions `Lazy.try_force` and `Lazy.try_force_val`, which return `None` if it is being concurrently forced, aims to replace the above pattern to implement concurrent lazy abstractions.

---

Here is the rationale:

- With @kayceesrk we agree that `Lazy.RacyLazy` can denote a bug.
- Catching the `RacyLazy` exception can otherwise be useful to implement concurrent lazy abstractions (e.g. lazy statics à la Rust); however doing so runs the risk of degrading an exception denoting a bug into a loop.
- Furthermore, as @kayceesrk explained, there is no obvious default behaviour replacing the RacyLazy exception for concurrent forcing of lazys in `Lazy.force`: implementing synchronisation at the level of domains by default might make sense in a vacuum (e.g. pay-as-you-go model à la C++/Rust: the user is free to not use it), but given the amount of legacy code that uses `Lazy.force`, this would threaten the cooperative concurrency story.

With this patch, concurrent lazy abstractions would call the `try_…` variants, while `RacyLazy` would always denote a bug.

Further notes:
- I needed to factor the code, but since the code looked optimised I tried to remain first-order.
- In the future, one can imagine that the `RacyLazy` exception could be eliminated via static control of interference.
- I saw interesting races for asynchronous exceptions in there... that is another story to look at in trunk for the future.

I believe this can also interest @stedolan.