### PR TITLE
Fix Atomic.exchange in concurrent_minor_gc 

### DIFF
--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -2,12 +2,22 @@ type 'a t
 
 external make : 'a -> 'a t = "%makemutable"
 external get : 'a t -> 'a = "%atomic_load"
-external exchange : 'a t -> 'a -> 'a = "%atomic_exchange"
+(* currently can not exchange if the contents are a block that could be in a foreign minor heap *)
+external exchange_unsafe : 'a t -> 'a -> 'a = "%atomic_exchange"
 external compare_and_set : 'a t -> 'a -> 'a -> bool = "%atomic_cas"
 external fetch_and_add : int t -> int -> int = "%atomic_fetch_add"
 
 let set r x =
-  exchange r x |> ignore
+  exchange_unsafe r x |> ignore
+let rec exchange r x =
+  (* this is a workaround driven by:
+       https://github.com/ocaml-multicore/ocaml-multicore/issues/257
+  *)
+  (* we need the read barrier induced by the get to make the exchange safe *)
+  let y = get r in
+  if compare_and_set r y x
+  then y
+  else exchange r x
 let incr r =
   fetch_and_add r 1 |> ignore
 let decr r =

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -2,10 +2,10 @@ type 'a t
 
 external make : 'a -> 'a t = "%makemutable"
 external get : 'a t -> 'a = "%atomic_load"
-external exchange : 'a t -> 'a -> 'a = "%atomic_exchange"
 external compare_and_set : 'a t -> 'a -> 'a -> bool = "%atomic_cas"
 external fetch_and_add : int t -> int -> int = "%atomic_fetch_add"
 
 val set : 'a t -> 'a -> unit
+val exchange : 'a t -> 'a -> 'a
 val incr : int t -> unit
 val decr : int t -> unit

--- a/testsuite/tests/parallel/atomics.reference
+++ b/testsuite/tests/parallel/atomics.reference
@@ -1,2 +1,4 @@
+pushed ok
+popped ok
 ok
 ok


### PR DESCRIPTION
Issue #257 gives an example using `Atomic.exchange` which causes crashes with the concurrent minor gc (`master` branch). 

The bug we have is that `caml_atomic_exchange` in `memory.c`:
```
CAMLprim value caml_atomic_exchange (value ref, value v)
{
  value ret;
  if (Is_young(ref) || caml_domain_alone()) {
    ret = Op_val(ref)[0];
    Op_val(ref)[0] = v;
  } else {
    /* See Note [MM] above */
    atomic_thread_fence(memory_order_acquire);
    ret = atomic_exchange(Op_atomic_val(ref), v);
  }
  write_barrier(ref, 0, ret, v);
  return ret;
}
```
is allowing a reference to a foreign minor heap to escape through `ret`. I couldn't figure a working way to insert a `caml_read_barrier` to fix the issue (you can't use `ref` as a location argument because it has been exchanged). 

I took an alternative approach that implements `Atomic.exchange` using `Atomic.get` (which induces the correct read barrier) and `Atomic.compare_and_set` to get the correct exchange semantics. It's possibly not efficient, but I think it is correct and the sample code in #257 now works without crashing. 

I'm open to better fixes or suggestions, but right now this is the best fix I could come up with. 