### PR TITLE
Fix extcall noalloc DWARF

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -67,8 +67,8 @@ let cfi_remember_state () =
 let cfi_restore_state () =
   if Config.asm_cfi_supported then D.cfi_restore_state ()
 
-let cfi_def_cfa_offset n =
-  if Config.asm_cfi_supported then D.cfi_def_cfa_offset n
+let cfi_def_cfa_register reg =
+  if Config.asm_cfi_supported then D.cfi_def_cfa_register reg
 
 let emit_debug_info dbg =
   emit_debug_info_gen dbg D.file D.loc
@@ -659,15 +659,11 @@ let emit_instr fallthrough i =
           I.inc (domain_field Domainstate.Domain_extcall_noalloc);
         end;
         cfi_remember_state ();
+        cfi_def_cfa_register "rbp";
+        (* NB: gdb has asserts on contiguous stacks that mean it
+           will not unwind through this unless we were to tag this
+           calling frame with cfi_signal_frame in it's definition. *)
         I.mov (domain_field Domainstate.Domain_c_stack) rsp;
-        cfi_def_cfa_offset 0;
-
-        (* Keep GDB happy. If the cfa_offset was left at 0, then GDB complains
-         * that the frame did not save the PC and truncates the backtrace.
-         * Subtract rsp by 16 (instead of 8) to keep the stack aligned to
-         * 16-byte boundary. *)
-        I.sub (int 16) rsp;
-        cfi_adjust_cfa_offset 16;
 
         emit_call func;
         I.mov rbp rsp;

--- a/asmcomp/x86_ast.mli
+++ b/asmcomp/x86_ast.mli
@@ -210,6 +210,7 @@ type asm_line =
   | Cfi_startproc
   | Cfi_remember_state
   | Cfi_restore_state
+  | Cfi_def_cfa_register of string
   | Cfi_def_cfa_offset of int
   | File of int * string (* (file_num, file_name) *)
   | Indirect_symbol of string

--- a/asmcomp/x86_dsl.ml
+++ b/asmcomp/x86_dsl.ml
@@ -88,6 +88,7 @@ module D = struct
   let cfi_startproc () = directive Cfi_startproc
   let cfi_remember_state () = directive Cfi_remember_state
   let cfi_restore_state () = directive Cfi_restore_state
+  let cfi_def_cfa_register reg = directive (Cfi_def_cfa_register reg)
   let cfi_def_cfa_offset n = directive (Cfi_def_cfa_offset n)
   let comment s = directive (Comment s)
   let data () = section [ ".data" ] None []

--- a/asmcomp/x86_dsl.mli
+++ b/asmcomp/x86_dsl.mli
@@ -78,6 +78,7 @@ module D : sig
   val cfi_startproc: unit -> unit
   val cfi_remember_state: unit -> unit
   val cfi_restore_state: unit -> unit
+  val cfi_def_cfa_register: string -> unit
   val cfi_def_cfa_offset: int -> unit
   val comment: string -> unit
   val data: unit -> unit

--- a/asmcomp/x86_gas.ml
+++ b/asmcomp/x86_gas.ml
@@ -281,6 +281,7 @@ let print_line b = function
   | Cfi_startproc -> bprintf b "\t.cfi_startproc"
   | Cfi_remember_state -> bprintf b "\t.cfi_remember_state"
   | Cfi_restore_state -> bprintf b "\t.cfi_restore_state"
+  | Cfi_def_cfa_register reg -> bprintf b "\t.cfi_def_cfa_register %%%s" reg
   | Cfi_def_cfa_offset n -> bprintf b "\t.cfi_def_cfa_offset %d" n
   | File (file_num, file_name) ->
       bprintf b "\t.file\t%d\t\"%s\""

--- a/asmcomp/x86_masm.ml
+++ b/asmcomp/x86_masm.ml
@@ -239,6 +239,7 @@ let print_line b = function
   | Cfi_adjust_cfa_offset _
   | Cfi_endproc
   | Cfi_startproc
+  | Cfi_def_cfa_register _
   | Cfi_def_cfa_offset _
   | Cfi_remember_state
   | Cfi_restore_state

--- a/testsuite/tests/unwind/check-linker-version.sh
+++ b/testsuite/tests/unwind/check-linker-version.sh
@@ -10,7 +10,7 @@ elif [[ $LDVER -lt 224 ]]; then
   echo "ld version is $LDVER, only 224 or above are supported";
   test_result=${TEST_SKIP};
 else
-  test_reslut=${TEST_PASS};
+  test_result=${TEST_PASS};
 fi
 
-exit ${TEST_RESULT}
+exit ${test_result}

--- a/testsuite/tests/unwind/driver.ml
+++ b/testsuite/tests/unwind/driver.ml
@@ -15,8 +15,11 @@ flags = "-cclib -Wl,-keep_dwarf_unwind"
 all_modules = "mylib.ml driver.ml stack_walker.c"
 program = "${test_build_directory}/unwind_test"
 ****** run
-stdout = "program-output"
-stderr = "program-output"
+output = "${test_build_directory}/program-output"
+stdout = "${output}"
+stderr = "${output}"
+******* check-program-output
+reference = "${test_source_directory}/unwind_test.reference"
 
 *)
 

--- a/testsuite/tests/unwind/driver.ml
+++ b/testsuite/tests/unwind/driver.ml
@@ -26,3 +26,7 @@ reference = "${test_source_directory}/unwind_test.reference"
 let () =
   Mylib.foo1 Mylib.bar 1 2 3 4 5 6 7 8 9 10;
   Mylib.foo2 Mylib.baz 1 2 3 4 5 6 7 8 9 10
+
+(* https://github.com/ocaml-multicore/ocaml-multicore/issues/274 *)
+let () =
+  Mylib.foo1 Mylib.bob 1 2 3 4 5 6 7 8 9 10

--- a/testsuite/tests/unwind/mylib.ml
+++ b/testsuite/tests/unwind/mylib.ml
@@ -18,3 +18,10 @@ let baz x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 =
   func_with_10_params x1 x2 x3 x4 x5 x6 x7 x8 x9 x10;
   func_with_10_params x1 x2 x3 x4 x5 x6 x7 x8 x9 x10;
   perform_stack_walk ()
+
+(* https://github.com/ocaml-multicore/ocaml-multicore/issues/274 *)
+external do_no_alloc: unit -> unit = "ml_do_no_alloc" [@@noalloc]
+
+let bob x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 =
+   func_with_10_params x1 x2 x3 x4 x5 x6 x7 x8 x9 x10;
+   do_no_alloc ()

--- a/testsuite/tests/unwind/mylib.mli
+++ b/testsuite/tests/unwind/mylib.mli
@@ -8,3 +8,5 @@ val bar:
   int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> unit
 val baz:
   int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> unit
+val bob:
+  int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> unit

--- a/testsuite/tests/unwind/stack_walker.c
+++ b/testsuite/tests/unwind/stack_walker.c
@@ -60,3 +60,7 @@ value ml_perform_stack_walk(value unused) {
 
     return Val_unit;
 }
+
+value ml_do_no_alloc(value unused) {
+    return ml_perform_stack_walk(unused);
+}

--- a/testsuite/tests/unwind/unwind_test.reference
+++ b/testsuite/tests/unwind/unwind_test.reference
@@ -10,3 +10,15 @@ caml_start_program
 caml_startup_common
 caml_main
 main
+ml_perform_stack_walk
+ml_do_no_alloc
+Mylib.bob
+caml_apply10
+Mylib.foo1
+caml_apply11
+Driver.entry
+caml_program
+caml_start_program
+caml_startup_common
+caml_main
+main


### PR DESCRIPTION
This PR fixes the DWARF information emitted for extcall noalloc which fixes broken callstacks as seen in issue #274. It also makes the unwind test check the program output to the reference  and adds a extcall noalloc testcase for issue #274 to tests/unwind. 

There is one rough edge to this fix: gdb is unable to unwind beyond the caller of an extcall noalloc. Using this example:
```ocaml
let foo () =
  classify_float 1.0;
  print_string "Hello, world!"

let _ = foo ()
```
Setting a breakpoint at `caml_classify_float_unboxed` gives the following gdb backtrace:
```
(gdb) bt
#0  caml_classify_float_unboxed (vd=1) at floats.c:1009
#1  0x000055555556a1d8 in camlFoo__foo_82 ()
Backtrace stopped: previous frame inner to this frame (corrupt stack?)
```

We could try to tag every OCaml function containing a extcall noalloc as `.cfi_signal_frame` which would allow gdb to unwind. It would have a detrimental impact on the gdb output because every function tagged with `.cfi_signal_frame` is (by default at least) presented in gdb backtraces as `<signal handler called>` instead of with their function name. 

lldb does not have this rough edge and unwinds correctly:
```
(lldb) bt
* thread #1, name = 'foo.exe', stop reason = breakpoint 1.1
  * frame #0: 0x0000555555576f00 foo.exe`caml_classify_float_unboxed(vd=1) at floats.c:1009
    frame #1: 0x000055555556a1d8 foo.exe`camlFoo__foo_82 + 24
    frame #2: 0x000055555556a260 foo.exe`camlFoo__entry + 64
    frame #3: 0x0000555555569c6c foo.exe`caml_program + 60
    frame #4: 0x000055555558af35 foo.exe`caml_start_program + 121
    frame #5: 0x000055555558b427 foo.exe`caml_startup_common(argv=0x00007fffffffe438, pooling=<unavailable>) at startup_nat.c:138
    frame #6: 0x000055555558b478 foo.exe`caml_main [inlined] caml_startup_exn(argv=<unavailable>) at startup_nat.c:143
    frame #7: 0x000055555558b471 foo.exe`caml_main(argv=<unavailable>) at startup_nat.c:148
    frame #8: 0x0000555555569afc foo.exe`main(argc=<unavailable>, argv=<unavailable>) at main.c:44
    frame #9: 0x00007ffff7244b97 libc.so.6`__libc_start_main(main=(foo.exe`main at main.c:44), argc=1, argv=0x00007fffffffe438, init=<unavailable>, fini=<unavailable>, rtld_fini=<unavailable>, stack_end=0x00007fffffffe428) at libc-start.c:310
    frame #10: 0x0000555555569b3a foo.exe`_start + 42
```