### PR TITLE
Absolute exception stack

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -986,11 +986,9 @@ let emit_instr fallthrough i =
       I.push r11;
       cfi_adjust_cfa_offset 8;
       I.push (domain_field Domainstate.Domain_exn_handler);
-      I.sub rsp (mem64 NONE 0 RSP);
       I.mov rsp (domain_field Domainstate.Domain_exn_handler);
       stack_offset := !stack_offset + 16
   | Lpoptrap ->
-      I.add rsp (mem64 NONE 0 RSP);
       I.pop (domain_field Domainstate.Domain_exn_handler);
       cfi_adjust_cfa_offset (-8);
       I.add (int 8) rsp;
@@ -1009,7 +1007,6 @@ let emit_instr fallthrough i =
           record_frame Reg.Set.empty true i.dbg
       | Lambda.Raise_notrace ->
           I.mov (domain_field Domainstate.Domain_exn_handler) rsp;
-          I.add rsp (mem64 NONE 0 RSP);
           I.pop (domain_field Domainstate.Domain_exn_handler);
           I.pop r11;
           I.jmp r11

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -131,21 +131,15 @@
         leaq    G(label)(%rip), dst
 #endif
 
-/* Push the current exception handler.
-   (Stored as an offset, to survive stack reallocations). Clobbers %r11 */
+/* Push the current exception handler. Clobbers %r11 */
 #define PUSH_EXN_HANDLER \
         movq    Caml_state(exn_handler), %r11; \
-        subq    %rsp, %r11; \
-        addq    $0x8, %r11; \
         pushq   %r11; CFI_ADJUST(8);
 
-/* Pop the current exception handler. Undoes PUSH_EXN_HANDLER. Clobbers %r11 and %r10. */
+/* Pop the current exception handler. Undoes PUSH_EXN_HANDLER. Clobbers %r11 */
 #define POP_EXN_HANDLER \
         leaq    Caml_state(exn_handler), %r11; \
-        popq    %r10; CFI_ADJUST(-8); \
-        subq    $0x8, %r10; \
-        addq    %rsp, %r10; \
-        movq    %r10, (%r11)
+        popq    (%r11); CFI_ADJUST(-8)
 
 /******************************************************************************/
 /* Stack switching operations */
@@ -730,13 +724,14 @@ LBL(caml_start_program):
     /* Load the OCaml stack. */
         movq    Caml_state(current_stack), %r11
         movq    Stack_sp(%r11), %r10
-    /* Build a handler for exceptions raised in OCaml on the OCaml stack.
-       There is no previous exception handler. Instead, we use the prev
-       slot to store the C stack pointer, to allow DWARF backtraces */
+    /* Build a handler for exceptions raised in OCaml on the OCaml stack. */
         subq    $16, %r10
         lea     LBL(109)(%rip), %r11
         movq    %r11, 8(%r10)
-        movq    %rsp, 0(%r10)
+        /* load the previous context exn_handler so that copying stacks works */
+        movq    Caml_state(current_stack), %r11
+        movq    (%r11), %r11
+        movq    %r11, 0(%r10)
         movq    %r10, Caml_state(exn_handler)
     /* Switch stacks and call the OCaml code */
         movq    %r10, %rsp
@@ -747,7 +742,10 @@ LBL(caml_start_program):
              24 /* struct c_stack_link */ + 6*8 /* callee save regs */ + 8 /* ret addr */
         call    *%r12
 LBL(108):
-        leaq    16(%rsp), %r10 /* pop exn handler */
+    /* pop exn handler */
+        movq    0(%rsp), %r11
+        movq    %r11, Caml_state(exn_handler)
+        leaq    16(%rsp), %r10
 1:  /* Update alloc ptr */
         movq    %r15, Caml_state(young_ptr)
     /* Return to C stack. */
@@ -967,7 +965,10 @@ CFI_STARTPROC
         subq    $16, %r11
         leaq    LBL(fiber_exn_handler)(%rip), %r10
         movq    %r10, 8(%r11)
-        movq    $0, 0(%r11) /* dummy previous trap frame */
+    /* load the previous context exn_handler so that copying stacks works */
+        movq    Caml_state(current_stack), %r10
+        movq    (%r10), %r10
+        movq    %r10, 0(%r11)
         movq    %r11, Caml_state(exn_handler)
     /* Switch to the new stack */
         movq    %r11, %rsp

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -724,6 +724,9 @@ LBL(caml_start_program):
     /* Load the OCaml stack. */
         movq    Caml_state(current_stack), %r11
         movq    Stack_sp(%r11), %r10
+    /* Store the stack pointer to allow DWARF unwind */
+        subq    $16, %r10
+        movq    %rsp, 0(%r10)
     /* Build a handler for exceptions raised in OCaml on the OCaml stack. */
         subq    $16, %r10
         lea     LBL(109)(%rip), %r11
@@ -737,7 +740,7 @@ LBL(caml_start_program):
         movq    %r10, %rsp
         .cfi_remember_state
         .cfi_escape DW_CFA_def_cfa_expression, 3 + 2, \
-          DW_OP_breg + DW_REG_rsp, 0, DW_OP_deref,\
+          DW_OP_breg + DW_REG_rsp, 16, DW_OP_deref,\
           DW_OP_plus_uconst, \
              24 /* struct c_stack_link */ + 6*8 /* callee save regs */ + 8 /* ret addr */
         call    *%r12
@@ -745,7 +748,7 @@ LBL(108):
     /* pop exn handler */
         movq    0(%rsp), %r11
         movq    %r11, Caml_state(exn_handler)
-        leaq    16(%rsp), %r10
+        leaq    32(%rsp), %r10
 1:  /* Update alloc ptr */
         movq    %r15, Caml_state(young_ptr)
     /* Return to C stack. */
@@ -765,7 +768,8 @@ LBL(109):
     /* Exception handler*/
     /* Mark the bucket as an exception result and return it */
         orq     $2, %rax
-        movq    %rsp, %r10 /* exn handler already popped here */
+        /* exn handler already popped here */
+        leaq    16(%rsp), %r10
         jmp     1b
 CFI_ENDPROC
 ENDFUNCTION(G(caml_start_program))
@@ -961,8 +965,9 @@ CFI_STARTPROC
         movq    %rax, Handler_parent(%rcx)
         movq    %rdi, Caml_state(current_stack)
         movq    Stack_sp(%rdi), %rax
-    /* Create an exception handler on the target stack */
-        leaq    -16(%rax), %r11
+    /* Create an exception handler on the target stack
+       after 16byte DWARF block (which is unused here) */
+        leaq    -32(%rax), %r11
         leaq    LBL(fiber_exn_handler)(%rip), %r10
         movq    %r10, 8(%r11)
     /* load the previous context exn_handler so that copying stacks works */
@@ -972,13 +977,13 @@ CFI_STARTPROC
         movq    %r11, %rsp
         .cfi_remember_state
         .cfi_escape DW_CFA_def_cfa_expression, 3+3+2, \
-          DW_OP_breg + DW_REG_rsp, 16 /* exn */ + Handler_parent, DW_OP_deref,\
+          DW_OP_breg + DW_REG_rsp, 32 /* exn */ + Handler_parent, DW_OP_deref,\
           DW_OP_plus_uconst, Stack_sp, DW_OP_deref,\
           DW_OP_plus_uconst, 16 /* sizeof caml_context */ + 8 /* ret addr */
         movq    %r12, %rax /* first argument */
         callq   *(%rbx) /* closure in %rbx (second argument) */
 LBL(frame_runstack):
-        leaq    16(%rsp), %r11 /* SP with exn handler popped */
+        leaq    32(%rsp), %r11 /* SP with exn handler popped */
         movq    Handler_value(%r11), %rbx
 1:  /* Switch back to parent stack and free current */
         movq    Handler_parent(%r11), %r10
@@ -998,8 +1003,8 @@ LBL(frame_runstack):
     /* Invoke handle_value (or handle_exn) */
         jmp     *(%rbx)
 LBL(fiber_exn_handler):
-        movq    %rsp, %r11
-        movq    Handler_exception(%rsp), %rbx
+        leaq    16(%rsp), %r11
+        movq    Handler_exception(%r11), %rbx
         jmp     1b
 CFI_ENDPROC
 ENDFUNCTION(G(caml_runstack))

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -728,9 +728,9 @@ LBL(caml_start_program):
         subq    $16, %r10
         lea     LBL(109)(%rip), %r11
         movq    %r11, 8(%r10)
-        /* load the previous context exn_handler so that copying stacks works */
+    /* load the previous context exn_handler so that copying stacks works */
         movq    Caml_state(current_stack), %r11
-        movq    (%r11), %r11
+        movq    Stack_sp(%r11), %r11
         movq    %r11, 0(%r10)
         movq    %r10, Caml_state(exn_handler)
     /* Switch stacks and call the OCaml code */
@@ -960,15 +960,13 @@ CFI_STARTPROC
         movq    Stack_handler(%rdi), %rcx
         movq    %rax, Handler_parent(%rcx)
         movq    %rdi, Caml_state(current_stack)
-        movq    Stack_sp(%rdi), %r11
+        movq    Stack_sp(%rdi), %rax
     /* Create an exception handler on the target stack */
-        subq    $16, %r11
+        leaq    -16(%rax), %r11
         leaq    LBL(fiber_exn_handler)(%rip), %r10
         movq    %r10, 8(%r11)
     /* load the previous context exn_handler so that copying stacks works */
-        movq    Caml_state(current_stack), %r10
-        movq    (%r10), %r10
-        movq    %r10, 0(%r11)
+        movq    %rax, 0(%r11)
         movq    %r11, Caml_state(exn_handler)
     /* Switch to the new stack */
         movq    %r11, %rsp

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -48,8 +48,8 @@ static frame_descr * caml_next_frame_descriptor(caml_frame_descrs fds, uintnat *
       return d;
     } else {
       /* This marks the top of an ML stack chunk. Move sp to the previous stack
-       * chunk. This includes skipping over the trap frame (2 words). */
-      *sp += 2 * sizeof(value);
+       * chunk. This includes skipping over the DWARF link & trap frame (4 words). */
+      *sp += 4 * sizeof(value);
       if (*sp == (char*)Stack_high(stack)) {
         /* We've reached the top of stack. No more frames. */
         *pc = 0;

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -74,7 +74,7 @@
 /* Structure of OCaml callback contexts */
 
 struct caml_context {
-  uintnat exception_ptr_offset; /* exception pointer offset from top of stack */
+  uintnat exception_ptr;        /* exception pointer */
   value * gc_regs;              /* pointer to register block */
 #ifdef Context_needs_padding
   value padding;

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -131,8 +131,8 @@ next_chunk:
       /* XXX KC: disabled already scanned optimization. */
     } else {
       /* This marks the top of an ML stack chunk. Move sp to the previous stack
-       * chunk. This includes skipping over the trap frame (2 words). */
-      sp += 2 * sizeof(value);
+       * chunk. This includes skipping over the DWARF link & trap frame (4 words). */
+      sp += 4 * sizeof(value);
       goto next_chunk;
     }
   }

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -235,6 +235,31 @@ void caml_scan_stack(scanning_action f, void* fdata, struct stack_info* stack)
   Used by the interpreter to allocate stack space.
 */
 
+/* Update absolute exception pointers for new stack*/
+static void rewrite_exception_stack(struct stack_info *old_stack, value* exn_ptr, struct stack_info *new_stack)
+{
+  caml_gc_log ("Old [%lu, %lu]", Stack_base(old_stack), Stack_high(old_stack));
+  caml_gc_log ("New [%lu, %lu]", Stack_base(new_stack), Stack_high(new_stack));
+  if(exn_ptr) {
+    caml_gc_log ("exn_ptr=%lu", *exn_ptr);
+
+    while (Stack_base(old_stack) < *exn_ptr && *exn_ptr <= Stack_high(old_stack)) {
+      value old_val = *exn_ptr;
+      *exn_ptr = Stack_high(new_stack) - (Stack_high(old_stack) - (value*)*exn_ptr);
+
+      caml_gc_log ("Rewriting %lu to %lu", old_val, *exn_ptr);
+
+      CAMLassert(Stack_base(new_stack) < (value*)*exn_ptr);
+      CAMLassert((value*)*exn_ptr <= Stack_high(new_stack));
+
+      exn_ptr = (char*)*exn_ptr;
+    }
+    caml_gc_log ("finished with exn_ptr=%lu", *exn_ptr);
+  } else {
+    caml_gc_log ("exn_ptr is null");
+  }
+}
+
 int caml_try_realloc_stack(asize_t required_space)
 {
   struct stack_info *old_stack, *new_stack;
@@ -275,10 +300,7 @@ int caml_try_realloc_stack(asize_t required_space)
   new_stack->sp = Stack_high(new_stack) - stack_used;
   Stack_parent(new_stack) = Stack_parent(old_stack);
 #ifdef NATIVE_CODE
-  CAMLassert(Stack_base(old_stack) < (value*)Caml_state->exn_handler &&
-             (value*)Caml_state->exn_handler <= Stack_high(old_stack));
-  Caml_state->exn_handler =
-    Stack_high(new_stack) - (Stack_high(old_stack) - (value*)Caml_state->exn_handler);
+  rewrite_exception_stack(old_stack, &Caml_state->exn_handler, new_stack);
 #endif
 
   /* Update stack pointers in Caml_state->c_stack */
@@ -334,6 +356,7 @@ CAMLprim value caml_clone_continuation (value cont)
 {
   CAMLparam1(cont);
   CAMLlocal1(new_cont);
+  value* exn_start;
   intnat stack_used;
   struct stack_info *source, *orig_source, *target, *ret_stack;
   struct stack_info **link = &ret_stack;
@@ -350,6 +373,11 @@ CAMLprim value caml_clone_continuation (value cont)
     if (!target) caml_raise_out_of_memory();
     memcpy(Stack_high(target) - stack_used, Stack_high(source) - stack_used,
            stack_used * sizeof(value));
+#ifdef NATIVE_CODE
+    /* pull out the exception pointer from the caml context on the stack */
+    exn_start = Stack_high(target) - (Stack_high(source) - (value*)source->sp);
+    rewrite_exception_stack(source, exn_start, target);
+#endif
     target->sp = Stack_high(target) - stack_used;
     *link = target;
     link = &Stack_parent(target);


### PR DESCRIPTION
This PR moves the representation of the exception stack from relative addressing to absolute addressing. (It is a rebase of #313 to 4.10)

This was prompted by benchmark analysis showing the exception push/pop for multicore can be expensive. For example the following code can have much more expensive exception handling overhead:
```ocaml
let get g x y =
  try g.(x).(y)
  with _ -> 0
```

The code is a bit fiddly as we need to:
 - rewrite the exception stack when stacks are copied in `fiber.c`
 - update the assembler to allow the stack to be visible through `ocaml stack` -> `c stack` -> `ocaml stack` calls (e.g. `callback/test4.ml`)
 - correctly handle the cloning of continuations in `fiber.c`

Sandmark serial benchmark results that I got with this change:
<img width="999" alt="4 10_absolute_exn" src="https://user-images.githubusercontent.com/1682628/82940519-e128b280-9f8c-11ea-9bf8-a26c0d6722aa.png">
(I was a bit taken aback by the difference for `game_of_life.256` and reran a couple of times, it seems to be an area where this patch is making a big difference)