### PR TITLE
Turn on -Werror by default

### DIFF
--- a/configure
+++ b/configure
@@ -909,6 +909,7 @@ enable_flambda_invariants
 with_target_bindir
 enable_reserved_header_bits
 enable_stdlib_manpages
+enable_warn_error
 enable_force_safe_string
 enable_flat_float_array
 enable_function_sections
@@ -1587,6 +1588,7 @@ Optional Features:
                           headers for profiling info
   --disable-stdlib-manpages
                           do not build or install the library man pages
+  --enable-warn-error     treat C compiler warnings as errors
   --disable-force-safe-string
                           do not force strings to be safe
   --disable-flat-float-array
@@ -3232,6 +3234,12 @@ fi
 # Check whether --enable-stdlib-manpages was given.
 if test "${enable_stdlib_manpages+set}" = set; then :
   enableval=$enable_stdlib_manpages;
+fi
+
+
+# Check whether --enable-warn-error was given.
+if test "${enable_warn_error+set}" = set; then :
+  enableval=$enable_warn_error;
 fi
 
 
@@ -12469,19 +12477,25 @@ fi
 
 case $ocaml_cv_cc_vendor in #(
   xlc-*) :
-    outputobj='-o $(EMPTY)'; gcc_warnings="-qflag=i:i" ;; #(
+    outputobj='-o $(EMPTY)'
+    warn_error_flag=''
+    gcc_warnings='-qflag=i:i' ;; #(
   # all warnings enabled
   msvc-*) :
-    outputobj=-Fo; gcc_warnings="" ;; #(
+    outputobj='-Fo'
+    warn_error_flag='-WX'
+    gcc_warnings='' ;; #(
   *) :
-    outputobj='-o $(EMPTY)'; case 4.10.0+multicore in #(
-  *+dev*) :
-    gcc_warnings="-Wall -Werror" ;; #(
-  *) :
-    gcc_warnings="-Wall"
-   ;;
+    outputobj='-o $(EMPTY)'
+  warn_error_flag='-Werror'
+  gcc_warnings='-Wall -Wdeclaration-after-statement' ;;
 esac
- ;;
+
+case $enable_warn_error,4.10.0+multicore in #(
+  yes,*|,*+dev*) :
+    gcc_warnings="$gcc_warnings $warn_error_flag" ;; #(
+  *) :
+     ;;
 esac
 
 # We select high optimization levels, provided we can turn off:
@@ -12536,7 +12550,7 @@ $as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
     common_cflags="-O2 -fno-strict-aliasing -fwrapv";
       internal_cflags="$gcc_warnings -fno-common" ;; #(
   msvc-*) :
-    common_cflags="-nologo -O2 -Gy- -MD"
+    common_cflags="-nologo -O2 -Gy- -MD $gcc_warnings"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
       internal_cppflags='-DUNICODE -D_UNICODE'
       internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="

--- a/configure
+++ b/configure
@@ -12492,7 +12492,7 @@ case $ocaml_cv_cc_vendor in #(
 esac
 
 case $enable_warn_error,4.10.0+multicore in #(
-  yes,*|,*+dev*) :
+  yes,*|,*+dev*|,*+multicore*) :
     cc_warnings="$cc_warnings $warn_error_flag" ;; #(
   *) :
      ;;

--- a/configure
+++ b/configure
@@ -12487,8 +12487,9 @@ case $ocaml_cv_cc_vendor in #(
     cc_warnings='' ;; #(
   *) :
     outputobj='-o $(EMPTY)'
+  # FIXME Should also be -Wdeclaration-after-statement here
   warn_error_flag='-Werror'
-  cc_warnings='-Wall -Wdeclaration-after-statement' ;;
+  cc_warnings='-Wall' ;;
 esac
 
 case $enable_warn_error,4.10.0+multicore in #(

--- a/configure
+++ b/configure
@@ -12479,21 +12479,21 @@ case $ocaml_cv_cc_vendor in #(
   xlc-*) :
     outputobj='-o $(EMPTY)'
     warn_error_flag=''
-    gcc_warnings='-qflag=i:i' ;; #(
+    cc_warnings='-qflag=i:i' ;; #(
   # all warnings enabled
   msvc-*) :
     outputobj='-Fo'
     warn_error_flag='-WX'
-    gcc_warnings='' ;; #(
+    cc_warnings='' ;; #(
   *) :
     outputobj='-o $(EMPTY)'
   warn_error_flag='-Werror'
-  gcc_warnings='-Wall -Wdeclaration-after-statement' ;;
+  cc_warnings='-Wall -Wdeclaration-after-statement' ;;
 esac
 
 case $enable_warn_error,4.10.0+multicore in #(
   yes,*|,*+dev*) :
-    gcc_warnings="$gcc_warnings $warn_error_flag" ;; #(
+    cc_warnings="$cc_warnings $warn_error_flag" ;; #(
   *) :
      ;;
 esac
@@ -12515,7 +12515,7 @@ esac
 # in the macro itself, too
 case $host in #(
   *-*-mingw32) :
-    internal_cflags="-Wno-unused $gcc_warnings"
+    internal_cflags="-Wno-unused $cc_warnings"
     # TODO: see whether the code can be fixed to avoid -Wno-unused
     common_cflags="-O -mms-bitfields"
     internal_cppflags='-DUNICODE -D_UNICODE'
@@ -12525,7 +12525,7 @@ case $host in #(
     case $ocaml_cv_cc_vendor in #(
   clang-*) :
     common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-      internal_cflags="$gcc_warnings -fno-common" ;; #(
+      internal_cflags="$cc_warnings -fno-common" ;; #(
   gcc-012-*) :
     # Some versions known to miscompile OCaml, e,g, 2.7.2.1, some 2.96.
       # Plus: C99 support unknown.
@@ -12541,23 +12541,23 @@ $as_echo "$as_me: WARNING: This version of GCC is rather old.
       { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Consider using GCC version 4.2 or above." >&5
 $as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
       common_cflags="-std=gnu99 -O";
-      internal_cflags="$gcc_warnings" ;; #(
+      internal_cflags="$cc_warnings" ;; #(
   gcc-4-*) :
     common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
 -fno-builtin-memcmp";
-      internal_cflags="$gcc_warnings" ;; #(
+      internal_cflags="$cc_warnings" ;; #(
   gcc-*) :
     common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-      internal_cflags="$gcc_warnings -fno-common" ;; #(
+      internal_cflags="$cc_warnings -fno-common" ;; #(
   msvc-*) :
-    common_cflags="-nologo -O2 -Gy- -MD $gcc_warnings"
+    common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
       internal_cppflags='-DUNICODE -D_UNICODE'
       internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
       internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
   xlc-*) :
     common_cflags="-O5 -qtune=balanced -qnoipa -qinline $CFLAGS";
-      internal_cflags="$gcc_warnings" ;; #(
+      internal_cflags="$cc_warnings" ;; #(
   *) :
     common_cflags="-O" ;;
 esac ;;

--- a/configure.ac
+++ b/configure.ac
@@ -536,18 +536,18 @@ AS_CASE([$ocaml_cv_cc_vendor],
   [xlc-*],
     [outputobj='-o $(EMPTY)'
     warn_error_flag=''
-    gcc_warnings='-qflag=i:i'], # all warnings enabled
+    cc_warnings='-qflag=i:i'], # all warnings enabled
   [msvc-*],
     [outputobj='-Fo'
     warn_error_flag='-WX'
-    gcc_warnings=''],
+    cc_warnings=''],
   [outputobj='-o $(EMPTY)'
   warn_error_flag='-Werror'
-  gcc_warnings='-Wall -Wdeclaration-after-statement'])
+  cc_warnings='-Wall -Wdeclaration-after-statement'])
 
 AS_CASE([$enable_warn_error,AC_PACKAGE_VERSION],
   [yes,*|,*+dev*],
-    [gcc_warnings="$gcc_warnings $warn_error_flag"])
+    [cc_warnings="$cc_warnings $warn_error_flag"])
 
 # We select high optimization levels, provided we can turn off:
 # - strict type-based aliasing analysis (too risky for the OCaml runtime)
@@ -566,7 +566,7 @@ AS_CASE([$enable_warn_error,AC_PACKAGE_VERSION],
 # in the macro itself, too
 AS_CASE([$host],
   [*-*-mingw32],
-    [internal_cflags="-Wno-unused $gcc_warnings"
+    [internal_cflags="-Wno-unused $cc_warnings"
     # TODO: see whether the code can be fixed to avoid -Wno-unused
     common_cflags="-O -mms-bitfields"
     internal_cppflags='-DUNICODE -D_UNICODE'
@@ -575,7 +575,7 @@ AS_CASE([$host],
   [AS_CASE([$ocaml_cv_cc_vendor],
     [clang-*],
       [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-      internal_cflags="$gcc_warnings -fno-common"],
+      internal_cflags="$cc_warnings -fno-common"],
     [gcc-[012]-*],
       # Some versions known to miscompile OCaml, e,g, 2.7.2.1, some 2.96.
       # Plus: C99 support unknown.
@@ -588,23 +588,23 @@ AS_CASE([$host],
         Reducing optimization level."]);
       AC_MSG_WARN([Consider using GCC version 4.2 or above.]);
       common_cflags="-std=gnu99 -O";
-      internal_cflags="$gcc_warnings"],
+      internal_cflags="$cc_warnings"],
     [gcc-4-*],
       [common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
 -fno-builtin-memcmp";
-      internal_cflags="$gcc_warnings"],
+      internal_cflags="$cc_warnings"],
     [gcc-*],
       [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-      internal_cflags="$gcc_warnings -fno-common"],
+      internal_cflags="$cc_warnings -fno-common"],
     [msvc-*],
-      [common_cflags="-nologo -O2 -Gy- -MD $gcc_warnings"
+      [common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
       internal_cppflags='-DUNICODE -D_UNICODE'
       internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
       internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
     [xlc-*],
       [common_cflags="-O5 -qtune=balanced -qnoipa -qinline $CFLAGS";
-      internal_cflags="$gcc_warnings"],
+      internal_cflags="$cc_warnings"],
     [common_cflags="-O"])])
 
 internal_cppflags="-DCAML_NAME_SPACE $internal_cppflags"

--- a/configure.ac
+++ b/configure.ac
@@ -546,7 +546,7 @@ AS_CASE([$ocaml_cv_cc_vendor],
   cc_warnings='-Wall -Wdeclaration-after-statement'])
 
 AS_CASE([$enable_warn_error,AC_PACKAGE_VERSION],
-  [yes,*|,*+dev*],
+  [yes,*|,*+dev*|,*+multicore*],
     [cc_warnings="$cc_warnings $warn_error_flag"])
 
 # We select high optimization levels, provided we can turn off:

--- a/configure.ac
+++ b/configure.ac
@@ -542,8 +542,9 @@ AS_CASE([$ocaml_cv_cc_vendor],
     warn_error_flag='-WX'
     cc_warnings=''],
   [outputobj='-o $(EMPTY)'
+  # FIXME Should also be -Wdeclaration-after-statement here
   warn_error_flag='-Werror'
-  cc_warnings='-Wall -Wdeclaration-after-statement'])
+  cc_warnings='-Wall'])
 
 AS_CASE([$enable_warn_error,AC_PACKAGE_VERSION],
   [yes,*|,*+dev*|,*+multicore*],

--- a/configure.ac
+++ b/configure.ac
@@ -341,6 +341,10 @@ AC_ARG_ENABLE([stdlib-manpages],
   [AS_HELP_STRING([--disable-stdlib-manpages],
     [do not build or install the library man pages])])
 
+AC_ARG_ENABLE([warn-error],
+  [AS_HELP_STRING([--enable-warn-error],
+    [treat C compiler warnings as errors])])
+
 AC_ARG_VAR([WINDOWS_UNICODE_MODE],
   [how to handle Unicode under Windows: ansi, compatible])
 
@@ -530,15 +534,20 @@ AS_IF(
 
 AS_CASE([$ocaml_cv_cc_vendor],
   [xlc-*],
-    [outputobj='-o $(EMPTY)'; gcc_warnings="-qflag=i:i"], # all warnings enabled
+    [outputobj='-o $(EMPTY)'
+    warn_error_flag=''
+    gcc_warnings='-qflag=i:i'], # all warnings enabled
   [msvc-*],
-    [outputobj=-Fo; gcc_warnings=""],
-  [outputobj='-o $(EMPTY)'; AS_CASE([AC_PACKAGE_VERSION],
-    [*+dev*],
-      [gcc_warnings="-Wall -Werror"],
-    [gcc_warnings="-Wall"]
-  )]
-)
+    [outputobj='-Fo'
+    warn_error_flag='-WX'
+    gcc_warnings=''],
+  [outputobj='-o $(EMPTY)'
+  warn_error_flag='-Werror'
+  gcc_warnings='-Wall -Wdeclaration-after-statement'])
+
+AS_CASE([$enable_warn_error,AC_PACKAGE_VERSION],
+  [yes,*|,*+dev*],
+    [gcc_warnings="$gcc_warnings $warn_error_flag"])
 
 # We select high optimization levels, provided we can turn off:
 # - strict type-based aliasing analysis (too risky for the OCaml runtime)
@@ -588,7 +597,7 @@ AS_CASE([$host],
       [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
       internal_cflags="$gcc_warnings -fno-common"],
     [msvc-*],
-      [common_cflags="-nologo -O2 -Gy- -MD"
+      [common_cflags="-nologo -O2 -Gy- -MD $gcc_warnings"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
       internal_cppflags='-DUNICODE -D_UNICODE'
       internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -39,7 +39,6 @@ function run {
 # Takes 3 arguments
 # $1:the Windows port. Recognized values: mingw, msvc and msvc64
 # $2: the prefix to use to install
-# $3: C compiler flags to use to turn warnings into errors
 function set_configuration {
     case "$1" in
         mingw)
@@ -58,9 +57,7 @@ function set_configuration {
 
     ./configure $build $host --prefix="$2"
 
-    FILE=$(pwd | cygpath -f - -m)/Makefile.config
-    echo "Edit $FILE to turn C compiler warnings into errors"
-    sed -i -e '/^ *OC_CFLAGS *=/s/\r\?$/ '"$3"'\0/' "$FILE"
+#    FILE=$(pwd | cygpath -f - -m)/Makefile.config
 #    run "Content of $FILE" cat Makefile.config
 }
 
@@ -91,7 +88,7 @@ case "$1" in
   msvc32-only)
     cd "$APPVEYOR_BUILD_FOLDER/../$BUILD_PREFIX-msvc32"
 
-    set_configuration msvc "$OCAMLROOT-msvc32" -WX
+    set_configuration msvc "$OCAMLROOT-msvc32"
 
     run 'make world' make world
     run 'make runtimeopt' make runtimeopt
@@ -121,9 +118,9 @@ case "$1" in
     fi
 
     if [[ $PORT = 'msvc64' ]] ; then
-      set_configuration msvc64 "$OCAMLROOT" -WX
+      set_configuration msvc64 "$OCAMLROOT"
     else
-      set_configuration mingw "$OCAMLROOT-mingw32" -Werror
+      set_configuration mingw "$OCAMLROOT-mingw32"
     fi
 
     cd "$APPVEYOR_BUILD_FOLDER/../$BUILD_PREFIX-$PORT"


### PR DESCRIPTION
First two commits are ocaml/ocaml#9625. This extends the logic already in `configure` which turns on `-Werror` if `VERSION` contains `+dev` to also recognise `+multicore`. The new `--disable-warn-error` option can then be used in multicore-opam.