### PR TITLE
Added Caml_state_field to domain_state.h

### DIFF
--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -79,6 +79,6 @@ CAML_STATIC_ASSERT(
   #define SET_Caml_state(x) (Caml_state = (x))
 #endif
 
-#define Caml_state_field(field) Caml_state->field
+#define Caml_state_field(field) (Caml_state->field)
 
 #endif /* CAML_STATE_H */

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -79,10 +79,6 @@ CAML_STATIC_ASSERT(
   #define SET_Caml_state(x) (Caml_state = (x))
 #endif
 
-#ifdef CAML_NAME_SPACE
 #define Caml_state_field(field) Caml_state->field
-#else
-#define Caml_state_field(field) Caml_state->_##field
-#endif
 
 #endif /* CAML_STATE_H */

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -29,7 +29,11 @@ typedef struct caml_root_private* caml_root;
 /* This structure sits in the TLS area and is also accessed efficiently
  * via native code, which is why the indices are important */
 typedef struct {
+#ifdef CAML_NAME_SPACE
 #define DOMAIN_STATE(type, name) CAMLalign(8) type name;
+#else
+#define DOMAIN_STATE(type, name) CAMLalign(8) type _##name;
+#endif
 #include "domain_state.tbl"
 #ifndef NATIVE_CODE
   /* Bytecode TLS vars, not used for native code */
@@ -77,6 +81,12 @@ CAML_STATIC_ASSERT(
   CAMLextern __thread caml_domain_state* Caml_state;
   #define CAML_INIT_DOMAIN_STATE
   #define SET_Caml_state(x) (Caml_state = (x))
+#endif
+
+#ifdef CAML_NAME_SPACE
+#define Caml_state_field(field) Caml_state->field
+#else
+#define Caml_state_field(field) Caml_state->_##field
 #endif
 
 #endif /* CAML_STATE_H */

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -29,11 +29,7 @@ typedef struct caml_root_private* caml_root;
 /* This structure sits in the TLS area and is also accessed efficiently
  * via native code, which is why the indices are important */
 typedef struct {
-#ifdef CAML_NAME_SPACE
 #define DOMAIN_STATE(type, name) CAMLalign(8) type name;
-#else
-#define DOMAIN_STATE(type, name) CAMLalign(8) type _##name;
-#endif
 #include "domain_state.tbl"
 #ifndef NATIVE_CODE
   /* Bytecode TLS vars, not used for native code */


### PR DESCRIPTION
Building base-v0.14.0 with 4.10.0-Multicore using dune.2.5.1 in Sandmark, we get:
```
      ocamlc src/exn_stubs.o (exit 2)
(cd _build/default/src && /home/guest/code/sandmark/_opam/4.10.0/bin/ocamlc.opt -g -I /home/guest/code/sandmark/_opam/4.10.0/lib/sexplib0 -I ../compiler-stdlib/src -I ../hash_types/src -I ../shadow-stdlib/src -ccopt -O2 -ccopt -fno-strict-aliasing -ccopt -fwrapv -ccopt -fPIC -ccopt -D_LARGEFILE64_SOURCE -ccopt -mpopcnt -ccopt -g -o exn_stubs.o exn_stubs.c)
In file included from exn_stubs.c:3:0:
exn_stubs.c: In function 'Base_clear_caml_backtrace_pos':
/home/guest/code/sandmark/_opam/4.10.0/lib/ocaml/caml/backtrace.h:75:29: warning: implicit declaration of function 'Caml_state_field'; did you mean 'caml_read_field'? [-Wimplicit-function-declaration] 
#define caml_backtrace_pos (Caml_state_field(backtrace_pos))                             
                            ^
exn_stubs.c:6:3: note: in expansion of macro 'caml_backtrace_pos'   
   caml_backtrace_pos = 0;   
   ^~~~~~~~~~~~~~~~~~
/home/guest/code/sandmark/_opam/4.10.0/lib/ocaml/caml/backtrace.h:75:46: error: 'backtrace_pos' undeclared (first use in this function); did you mean 'backtrace_slot'? 
#define caml_backtrace_pos (Caml_state_field(backtrace_pos))                                              
                                             ^
exn_stubs.c:6:3: note: in expansion of macro 'caml_backtrace_pos'   
   caml_backtrace_pos = 0;   
   ^~~~~~~~~~~~~~~~~~
```
The following patch adds Caml_state_field back in to domain_state.h. But, re-building fails for orun with the following message:
```
#=== ERROR while compiling orun.0.1 ===========================================#
# context     2.0.4 | linux/x86_64 | ocaml-base-compiler.4.10.0+multicore+caml+state | pinned(file:///home/guest/code/sandmark/orun)
# path        ~/code/sandmark/_opam/4.10.0+multicore+caml+state/.opam-switch/build/orun.0.1
# command     ~/code/sandmark/_opam/opam-init/hooks/sandbox.sh build dune build -p orun
# exit-code   1
# env-file    ~/code/sandmark/_opam/log/orun-29246-48b426.env
# output-file ~/code/sandmark/_opam/log/orun-29246-48b426.out
### output ###
# [...]
# /home/guest/code/sandmark/_opam/4.10.0+multicore+caml+state/lib/ocaml/caml/memory.h:259:39: error: ‘caml_domain_state {aka struct <anonymous>}’ has no member named ‘local_roots’; did you mean ‘_local_roots’?
#  #define CAML_LOCAL_ROOTS (Caml_state->local_roots)
#                                        ^
# /home/guest/code/sandmark/_opam/4.10.0+multicore+caml+state/lib/ocaml/caml/memory.h:293:54: note: in expansion of macro ‘CAML_LOCAL_ROOTS’
#    struct caml__roots_block** caml_local_roots_ptr = &CAML_LOCAL_ROOTS;\
#                                                       ^~~~~~~~~~~~~~~~
# /home/guest/code/sandmark/_opam/4.10.0+multicore+caml+state/lib/ocaml/caml/memory.h:305:3: note: in expansion of macro ‘CAMLparam0’
#    CAMLparam0 (); \
#    ^~~~~~~~~~
# profiler.c:278:5: note: in expansion of macro ‘CAMLparam3’
#      CAMLparam3(ml_pid, ml_pipe_fds, sample_callback);
```