### PR TITLE
Parallel minor gc inline mask rework

### DIFF
--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -59,7 +59,7 @@ extern int caml_try_stw_empty_minor_heap_on_all_domains(); /* out STW */
 extern void caml_empty_minor_heaps_once(); /* out STW */
 CAMLextern void caml_minor_collection (void);
 CAMLextern void garbage_collection (void); /* def in asmrun/signals.c */
-int get_header_val(value v);
+header_t caml_get_header_val(value v);
 void caml_alloc_table (struct caml_ref_table *tbl, asize_t sz, asize_t rsv);
 extern void caml_realloc_ref_table (struct caml_ref_table *);
 extern void caml_realloc_ephe_ref_table (struct caml_ephe_ref_table *);

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -228,7 +228,7 @@ static void generic_final_minor_update (struct domain* d, struct finalisable * f
   CAMLassert (final->old <= final->young);
   for (i = final->old; i < final->young; i++){
     CAMLassert (Is_block (final->table[i].val));
-    if (Is_minor(final->table[i].val) && get_header_val(final->table[i].val) != 0){
+    if (Is_minor(final->table[i].val) && caml_get_header_val(final->table[i].val) != 0){
       ++ todo_count;
     }
   }
@@ -248,7 +248,7 @@ static void generic_final_minor_update (struct domain* d, struct finalisable * f
     for (i = final->old; i < final->young; i++) {
       CAMLassert (Is_block (final->table[i].val));
       CAMLassert (Tag_val (final->table[i].val) != Forward_tag);
-      if (Is_minor(final->table[j].val) && get_header_val(final->table[i].val) != 0) {
+      if (Is_minor(final->table[j].val) && caml_get_header_val(final->table[i].val) != 0) {
         /** dead */
         fi->todo_tail->item[k] = final->table[i];
         /* The finalisation function is called with unit not with the value */
@@ -270,7 +270,7 @@ static void generic_final_minor_update (struct domain* d, struct finalisable * f
   for (i = final->old; i < final->young; i++) {
     CAMLassert (Is_block (final->table[i].val));
     if (Is_minor(final->table[i].val)) {
-      CAMLassert (get_header_val(final->table[i].val) == 0);
+      CAMLassert (caml_get_header_val(final->table[i].val) == 0);
       final->table[i].val = Op_val(final->table[i].val)[0];
     }
   }

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -166,7 +166,8 @@ static inline void log_gc_value(const char* prefix, value v)
 }
 #endif
 
-/* in progress updates are zeros except for the lowest color bit set to 1 */
+/* in progress updates are zeros except for the lowest color bit set to 1
+   that is a header with: wosize == 0 && color == 1 && tag == 0 */
 #define In_progress_update_val ((header_t)0x100)
 #define Is_update_in_progress(hd) ((hd) == In_progress_update_val)
 


### PR DESCRIPTION
This PR reworks the promotion path of the parallel_minor_gc. Couple of things:
 - cleans up the mask code used for the CAS when parallel promotion is occurring to a tighter sequence
 - inlines the `get_header_val` function and gives the externally visible non-inline function the `caml_` prefix
 - puts in a `cpu_relax` if we end up spinning on the header

These changes in addition to #359 are giving 3-5% improvements on `test_decompress` sandmark benchmark which does a lot of minor collections. It is giving an executed instruction decrease across all benchmarks even if a significant change of performance is harder to see on less minor collection heavy benchmarks. 
