### PR TITLE
Iloadmut doesn't clobber rax and rdx when we don't have a read barrier

### DIFF
--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -331,7 +331,6 @@ let destroyed_at_oper = function
   | Iop (Iintop_imm(Icheckbound _, _)) when Config.spacetime ->
       [| loc_spacetime_node_hole |]
   | Iswitch(_, _) -> [| rax; rdx |]
-  | Iop Iloadmut -> [| rax; rdx |]
   | Itrywith _ -> [| r11 |]
   | _ ->
     if fp then


### PR DESCRIPTION
This PR cleans up an oversight when we implemented the parallel minor collector for multicore. With the removal of the read barrier we can also free up the registers `rax` and `rdx` for OCaml code when `Iloadmut` is used. 

Performance is improved baseline [blue] and this PR [orange]:
<img width="994" alt="Screenshot 2020-06-23 at 17 27 18" src="https://user-images.githubusercontent.com/1682628/85429603-e02c7600-b576-11ea-809d-6c6304f98dce.png">
