### PR TITLE
Fixup loose memory order in minor_gc promote

### DIFF
--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -217,8 +217,8 @@ static int try_update_object_header(value v, value *p, value result, mlsize_t in
         // Success
         // Now we can write the forwarding pointer
         atomic_store_explicit(Op_atomic_val(v), result, memory_order_relaxed);
-        // And can update the header too
-        atomic_store_explicit(Hp_atomic_val(v), 0, memory_order_relaxed);
+        // And update header ('release' to ensure after update of fwd pointer)
+        atomic_store_explicit(Hp_atomic_val(v), 0, memory_order_release);
         // Let the caller know we were responsible for the update
         success = 1;
       } else {


### PR DESCRIPTION
Not currently an issue when I checked on the assembler produced for x86, but having found it we should fix where we update the header after the CAS on promote in the minor_gc. 

It should be `memory_order_release` to ensure that the previous write of the forwarding pointer will always be seen. I checked we generate the same assembler after the change on Linux GCC 7.5.0.