### PR TITLE
fix get_header_val to use acquire to match release

### DIFF
--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -179,7 +179,7 @@ static void spin_on_header(value v) {
 }
 
 static inline header_t get_header_val(value v) {
-  header_t hd = atomic_load_explicit(Hp_atomic_val(v), memory_order_relaxed);
+  header_t hd = atomic_load_explicit(Hp_atomic_val(v), memory_order_acquire);
   if (!Is_update_in_progress(hd))
     return hd;
 


### PR DESCRIPTION
This is a second stab at #364 to fix the `get_header_val` load.

It needs to work with this code in `olidfy_one`:
```c
    hd = get_header_val(v);
    if (hd == 0) {
      /* already forwarded, another domain is likely working on this. */
      *p = Op_val(v)[0] + infix_offset;
      return;
    }
```

which without the acquire we could end up reading garbage for the forwarding pointer. 