### PR TITLE
Split caml_urge_major_slice into caml_request_minor_gc and caml_request_major_slice

### DIFF
--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -46,7 +46,9 @@ void caml_handle_gc_interrupt(void);
 
 void caml_handle_incoming_interrupts(void);
 
-void caml_urge_major_slice (void);
+void caml_request_major_slice (void);
+
+void caml_request_minor_gc (void);
 
 void caml_interrupt_self(void);
 

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -78,7 +78,9 @@ DOMAIN_STATE(intnat, compare_unordered)
 
 DOMAIN_STATE(uintnat, oo_next_id_local)
 
-DOMAIN_STATE(uintnat, force_major_slice)
+DOMAIN_STATE(uintnat, requested_major_slice)
+
+DOMAIN_STATE(uintnat, requested_minor_gc)
 
 DOMAIN_STATE(caml_root, read_fault_ret_val)
 /* Global root for return value of a read fault */

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -38,12 +38,6 @@ void caml_init_signal_handling(void);
 CAMLextern void caml_enter_blocking_section (void);
 CAMLextern void caml_leave_blocking_section (void);
 
-/* <private> */
-extern int volatile caml_requested_major_slice;
-extern int volatile caml_requested_minor_gc;
-
-void caml_request_major_slice (void);
-void caml_request_minor_gc (void);
 CAMLextern int caml_convert_signal_number (int);
 CAMLextern int caml_rev_convert_signal_number (int);
 void caml_record_signal(int signal_number);

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -347,43 +347,19 @@ CAMLexport void caml_blit_fields (value src, int srcoff, value dst, int dstoff, 
   CAMLreturn0;
 }
 
-CAMLexport value caml_alloc_shr (mlsize_t wosize, tag_t tag)
+static inline value alloc_shr(mlsize_t wosize, tag_t tag, int noexc)
 {
-  caml_domain_state* dom_st = Caml_state;
-  value* v = caml_shared_try_alloc(dom_st->shared_heap, wosize, tag, 0);
-  if (v == NULL) {
-    caml_raise_out_of_memory ();
-  }
-  dom_st->allocated_words += Whsize_wosize (wosize);
-  if (dom_st->allocated_words > dom_st->minor_heap_wsz) {
-    caml_urge_major_slice();
-  }
-
-  if (tag < No_scan_tag) {
-    mlsize_t i;
-    for (i = 0; i < wosize; i++) {
-      value init_val = Val_unit;
-      #ifdef DEBUG
-      init_val = Debug_uninit_major;
-      #endif
-      Op_hp(v)[i] = init_val;
-    }
-  }
-#if defined(COLLECT_STATS) && defined(NATIVE_CODE)
-  dom_st->allocations++;
-#endif
-  return Val_hp(v);
-}
-
-CAMLexport value caml_alloc_shr_noexc(mlsize_t wosize, tag_t tag) {
   caml_domain_state *dom_st = Caml_state;
   value *v = caml_shared_try_alloc(dom_st->shared_heap, wosize, tag, 0);
   if (v == NULL) {
-    return (value)NULL;
+    if (!noexc)
+      caml_raise_out_of_memory();
+    else
+      return (value)NULL;
   }
   dom_st->allocated_words += Whsize_wosize(wosize);
   if (dom_st->allocated_words > dom_st->minor_heap_wsz) {
-    caml_urge_major_slice();
+    caml_request_major_slice();
   }
 
   if (tag < No_scan_tag) {
@@ -400,6 +376,15 @@ CAMLexport value caml_alloc_shr_noexc(mlsize_t wosize, tag_t tag) {
   dom_st->allocations++;
 #endif
   return Val_hp(v);
+}
+
+CAMLexport value caml_alloc_shr(mlsize_t wosize, tag_t tag)
+{
+  return alloc_shr(wosize, tag, 0);
+}
+
+CAMLexport value caml_alloc_shr_noexc(mlsize_t wosize, tag_t tag) {
+  return alloc_shr(wosize, tag, 1);
 }
 
 CAMLexport value caml_read_barrier(value obj, intnat field)

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -829,7 +829,7 @@ static void realloc_generic_table
     CAML_INSTR_INT (msg_intr_int, 1);
     caml_gc_message (0x08, msg_threshold, 0);
     tbl->limit = tbl->end;
-    caml_urge_major_slice ();
+    caml_request_minor_gc ();
   }else{
     asize_t sz;
     asize_t cur_ptr = tbl->ptr - tbl->base;


### PR DESCRIPTION
This PR splits `caml_urge_major_slice` into `caml_request_minor_gc` and `caml_request_major_slice`

There are a couple of reasons to do this:
 - the old code was confusing: `caml_urge_major_slice` used to result in a minor collection and not a major slice as suggested.
 - the new code matches stock OCaml behaviour and naming. This will make upstreaming easier.
 - it reduces minor collections in some workloads allocating directly to the heap which don't touch the minor allocator and are actually wanting a major slice; minor collections can be expensive as they force a stop-the-world section.

The change doesn't alter runtime metrics in a meaningful way for sequential code with this change, but you can see that the total number of minor garbage collections is reduced and brought more closely into line with stock OCaml.
<img width="800" alt="Screenshot 2020-07-10 at 13 25 51" src="https://user-images.githubusercontent.com/1682628/87154512-46243780-c2b1-11ea-8503-1ef696b3e252.png">
