### PR TITLE
Remove Cloadmut and Iloadmut

### DIFF
--- a/asmcomp/CSEgen.ml
+++ b/asmcomp/CSEgen.ml
@@ -226,7 +226,6 @@ method class_of_operation op =
   | Iextcall _ -> assert false                 (* treated specially *)
   | Istackoffset _ -> Op_other
   | Iload(_,_) -> Op_load
-  | Iloadmut -> assert false                   (* treated speacially *)
   | Istore(_,_,asg) -> Op_store asg
   | Ialloc _ -> assert false                   (* treated specially *)
   | Iintop(Icheckbound _) -> Op_checkbound
@@ -290,13 +289,9 @@ method private cse n i =
          of arbitrary Caml code (finalizer, signal handler, context
          switch), which can contain non-initializing stores.
          Hence, all equations over loads must be removed. *)
-      let n1 = kill_addr_regs (self#kill_loads n) in
-      let n2 = set_unknown_regs n1 i.res in
-      {i with next = self#cse n2 i.next}
-  | Iop Iloadmut ->
-      let n1 = set_unknown_regs n (Proc.destroyed_at_oper i.desc) in
-      let n2 = set_unknown_regs n1 i.res in
-      {i with next = self#cse n2 i.next}
+       let n1 = kill_addr_regs (self#kill_loads n) in
+       let n2 = set_unknown_regs n1 i.res in
+       {i with next = self#cse n2 i.next}
   | Iop op ->
       begin match self#class_of_operation op with
       | (Op_pure | Op_checkbound | Op_load) as op_class ->

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -679,9 +679,6 @@ let emit_instr fallthrough i =
       stack_offset := !stack_offset + n
   | Lop(Iload(chunk, addr)) ->
       let dest = res i 0 in
-      if Config.stats then begin
-        I.inc (domain_field Domainstate.Domain_immutable_loads);
-      end;
       begin match chunk with
       | Word_int | Word_val ->
           I.mov (addressing addr QWORD i 0) dest
@@ -702,11 +699,6 @@ let emit_instr fallthrough i =
       | Double | Double_u ->
           I.movsd (addressing addr REAL8 i 0) dest
       end
-  | Lop Iloadmut ->
-      if Config.stats then begin
-        I.inc (domain_field Domainstate.Domain_mutable_loads);
-      end;
-      I.mov (mem64 QWORD 0 ~base:(arg64 i 0) (arg64 i 1) ~scale:8) (reg i.res.(0))
   | Lop(Istore(chunk, addr, is_assignment)) ->
       if Config.stats && is_assignment then begin
         I.inc (domain_field Domainstate.Domain_immutable_stores);

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -373,7 +373,7 @@ let max_register_pressure = function
 
 let op_is_pure = function
   | Icall_ind _ | Icall_imm _ | Itailcall_ind _ | Itailcall_imm _
-  | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _ | Ipoll | Iloadmut
+  | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _ | Ipoll
   | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _) -> false
   | Ispecific(Ilea _|Isextend32|Izextend32) -> true
   | Ispecific _ -> false

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -483,7 +483,6 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Iload (size, addr)) | Lop (Istore (size, addr, _)) ->
       let based = match addr with Iindexed _ -> 0 | Ibased _ -> 1 in
       based + begin match size with Single -> 2 | _ -> 1 end
-    | Lop Iloadmut -> 6
     | Lop (Ialloc {bytes = num_bytes}) when !fastcode_flag ->
       if num_bytes <= 0xFFF then 4 else 5
     | Lop (Ispecific (Ifar_alloc {bytes = num_bytes})) when !fastcode_flag ->
@@ -727,27 +726,6 @@ let emit_instr i =
         | Word_int | Word_val | Double | Double_u ->
             `	ldr	{emit_reg dst}, {emit_addressing addr base}\n`
         end
-    | Lop Iloadmut ->
-        `	ldr	{emit_reg i.res.(0)}, [{emit_reg i.arg.(0)},{emit_reg i.arg.(1)}, lsl 3]\n`;
-        `	eor {emit_reg reg_x0}, {emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}\n`;
-        let s = Nativeint.(shift_left one Domainstate.minor_heap_align_bits) in
-        `	mov {emit_reg reg_x1}, #{emit_nativeint s}\n`;
-        `	sub	{emit_reg reg_x0}, {emit_reg reg_x0}, {emit_reg reg_x1}\n`;
-        let bits = Domainstate.minor_heap_align_bits + Domainstate.minor_heap_sel_bits in
-        let minor_val_bitmask = Nativeint.(logor one (shift_left minus_one bits)) in
-        `	tst	{emit_reg reg_x0}, #{emit_nativeint minor_val_bitmask}\n`;
-        let lbl_call_read_barrier = new_label () in
-        let lbl_return = new_label () in
-        let lbl_frame = record_frame_label i.live Debuginfo.none in
-        `	b.eq	{emit_label lbl_call_read_barrier}\n`;
-        `{emit_label lbl_return}:\n`;
-        read_barrier_call_sites :=
-          { rb_base = i.arg.(0);
-            rb_off = i.arg.(1);
-            rb_dest = i.res.(0);
-            rb_lbl = lbl_call_read_barrier;
-            rb_return_lbl = lbl_return;
-            rb_frame = lbl_frame } :: !read_barrier_call_sites
     | Lop(Istore(size, addr, _)) ->
         let src = i.arg.(0) in
         let base =

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -224,7 +224,6 @@ let destroyed_at_oper = function
       else destroyed_at_c_call
   | Iop(Ialloc _) ->
       [| reg_x15 |]
-  | Iop Iloadmut -> [| reg_x0; reg_x1 |]
   | Iop(Iintoffloat | Ifloatofint | Iload(Single, _) | Istore(Single, _, _)) ->
       [| reg_d7 |]            (* d7 / s7 destroyed *)
   | _ -> [||]
@@ -252,7 +251,7 @@ let max_register_pressure = function
 
 let op_is_pure = function
   | Icall_ind _ | Icall_imm _ | Itailcall_ind _ | Itailcall_imm _
-  | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _ | Iloadmut
+  | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
   | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _)
   | Ispecific(Ishiftcheckbound _) -> false
   | _ -> true

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -131,7 +131,6 @@ and operation =
       { memory_chunk: memory_chunk
       ; mutability: Asttypes.mutable_flag
       ; is_atomic: bool }
-  | Cloadmut of {is_atomic : bool}
   | Calloc
   | Cstore of memory_chunk * Lambda.initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -132,9 +132,6 @@ and operation =
       { memory_chunk: memory_chunk
       ; mutability: Asttypes.mutable_flag
       ; is_atomic: bool }
-  | Cloadmut of {is_atomic : bool}
-    (* Mutable loads = Cload {Word_val; Mutable; _}. It is a separate op since we
-     * need the address of the object for read barrier. *)
   | Calloc
   | Cstore of memory_chunk * Lambda.initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi

--- a/asmcomp/interf.ml
+++ b/asmcomp/interf.ml
@@ -61,17 +61,7 @@ let build_graph fundecl =
     for i = 0 to Array.length v - 1 do
       let r1 = v.(i) in
       Reg.Set.iter (add_interf r1) s
-    done
-  in
-
-  let add_interf_arr v a =
-    for i = 0 to Array.length v - 1 do
-      let ri = v.(i) in
-      for j = 0 to Array.length a - 1 do
-        add_interf ri a.(j)
-      done
-    done
-  in
+    done in
 
   (* Record interferences between elements of an array *)
   let add_interf_self v =
@@ -80,8 +70,7 @@ let build_graph fundecl =
       for j = i+1 to Array.length v - 1 do
         add_interf ri v.(j)
       done
-    done
-  in
+    done in
 
   (* Record interferences between the destination of a move and a set
      of live registers. Since the destination is equal to the source,
@@ -103,13 +92,7 @@ let build_graph fundecl =
         interf i.next
     | Iop(Itailcall_ind _) -> ()
     | Iop(Itailcall_imm _) -> ()
-    | Iop op ->
-        begin match op with
-        | Iloadmut ->
-            add_interf_arr i.arg i.res;
-            add_interf_arr destroyed (Array.concat [i.arg; i.res])
-        | _ -> ()
-        end;
+    | Iop _ ->
         add_interf_set i.res i.live;
         add_interf_self i.res;
         interf i.next

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -53,7 +53,6 @@ type operation =
   | Iextcall of { func : string; alloc : bool; label_after : label; stack_ofs : int; }
   | Istackoffset of int
   | Iload of Cmm.memory_chunk * Arch.addressing_mode
-  | Iloadmut
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool
   | Ialloc of { bytes : int; label_after_call_gc : label option;
         spacetime_index : int; }
@@ -193,7 +192,7 @@ let spacetime_node_hole_pointer_is_live_before insn =
     | Ispecific specific_op ->
       Arch.spacetime_node_hole_pointer_is_live_before specific_op
     | Imove | Ispill | Ireload | Iconst_int _ | Iconst_float _
-    | Iconst_symbol _ | Istackoffset _ | Iload _ | Iloadmut | Istore _
+    | Iconst_symbol _ | Istackoffset _ | Iload _ | Istore _
     | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
     | Ifloatofint | Iintoffloat
     | Iname_for_debugger _ | Ipoll -> false

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -61,7 +61,6 @@ type operation =
                   stack_ofs : int}
   | Istackoffset of int
   | Iload of Cmm.memory_chunk * Arch.addressing_mode
-  | Iloadmut
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool
                                  (* false = initialization, true = assignment *)
   | Ialloc of { bytes : int; label_after_call_gc : label option;

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -103,7 +103,6 @@ let operation d = function
     match mutability with
     | Asttypes.Immutable -> Printf.sprintf "load %s" (chunk memory_chunk)
     | Asttypes.Mutable   -> Printf.sprintf "load_mut_imm %s" (chunk memory_chunk) )
-  | Cloadmut {is_atomic=_} -> "load_mut_ptr"
   | Calloc -> "alloc" ^ Debuginfo.to_string d
   | Cstore (c, init) ->
     let init =

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -134,8 +134,6 @@ let operation op arg ppf res =
   | Iload(chunk, addr) ->
       fprintf ppf "%s[%a]"
        (Printcmm.chunk chunk) (Arch.print_addressing reg addr) arg
-  | Iloadmut ->
-      fprintf ppf "mut_load(%a + %a)" reg arg.(0) reg arg.(1)
   | Istore(chunk, addr, is_assign) ->
       fprintf ppf "%s[%a] := %a %s"
        (Printcmm.chunk chunk)

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -62,7 +62,6 @@ let oper_result_type = function
       | Single | Double | Double_u -> typ_float
       | _ -> typ_int
       end
-  | Cloadmut _ -> typ_val
   | Calloc -> typ_val
   | Cstore (_c, _) -> typ_void
   | Cpoll -> typ_void
@@ -316,7 +315,7 @@ method is_simple_expr = function
   | Cop(op, args, _) ->
       begin match op with
         (* The following may have side effects *)
-      | Capply _ | Cextcall _ | Cloadmut _ | Cpoll | Calloc | Cstore _ | Craise _ -> false
+      | Capply _ | Cextcall _ | Cpoll | Calloc | Cstore _ | Craise _ -> false
         (* The remaining operations are simple if their args are *)
       | Cload _ | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi | Cand | Cor
       | Cxor | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf
@@ -361,7 +360,7 @@ method effects_of exp =
       | Cstore _ -> EC.effect_only Effect.Arbitrary
       | Craise _ | Ccheckbound -> EC.effect_only Effect.Raise
       | Cload {mutability = Asttypes.Immutable} -> EC.none
-      | Cloadmut _ | Cload {mutability = Asttypes.Mutable} ->
+      | Cload {mutability = Asttypes.Mutable} ->
           EC.coeffect_only Coeffect.Read_mutable
       | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi | Cand | Cor | Cxor
       | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf | Cabsf
@@ -447,7 +446,6 @@ method select_operation op args _dbg =
   | (Cload {memory_chunk}, [arg]) ->
       let (addr, eloc) = self#select_addressing memory_chunk arg in
       (Iload(memory_chunk, addr), [eloc])
-  | (Cloadmut _, _) -> (Iloadmut, args)
   | (Cstore (chunk, init), [arg1; arg2]) ->
       let (addr, eloc) = self#select_addressing chunk arg1 in
       let is_assign =


### PR DESCRIPTION
This PR removes `Cloadmut` and `Iloadmut` which are used to load mutable data when it can need a read barrier in the concurrent minor GC. 

The motivations for removing loadmut are:
 - The parallel minor GC scheme does not need read barriers and so this simplifies the code to make things easier to upstream to and rebase against stock OCaml.
 - The use of loadmut is leading to some changes in the generated code. This can make it harder to attribute the source of any performance and code-generation differences we see vs stock OCaml. This brings us closer to stock OCaml.
