### PR TITLE
Fix the opam pin command in case the current directory name has spaces

### DIFF
--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -5,7 +5,7 @@
 
    Initial build:
 
-      opam pin add --inplace-build ocaml-variants.4.10.0+multicore file://`pwd`
+      opam pin add -k path --inplace-build ocaml-variants.4.10.0+multicore .
 
    This installs the compiler for the new opam switch. Subsequent builds can be
    done locally with:


### PR DESCRIPTION
One of your user came up with this issue. Their current directory had spaces and too many argument would be given to `opam pin`.