### PR TITLE
Force major slice on minor collection

### DIFF
--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -54,7 +54,7 @@ struct caml_minor_tables {
 struct domain;
 
 extern void caml_set_minor_heap_size (asize_t); /* size in bytes */
-extern void caml_empty_minor_heap_from_stw (struct domain* domain, void* unused, int participating_count, struct domain** participating); /* in STW */
+extern void caml_empty_minor_heap_no_major_slice_from_stw (struct domain* domain, void* unused, int participating_count, struct domain** participating); /* in STW */
 extern int caml_try_stw_empty_minor_heap_on_all_domains(); /* out STW */
 extern void caml_empty_minor_heaps_once(); /* out STW */
 CAMLextern void caml_minor_collection (void);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1204,32 +1204,31 @@ static void domain_terminate()
   atomic_fetch_add(&caml_num_domains_running, -1);
 }
 
-void caml_handle_incoming_interrupts()
+static inline void handle_incoming_interrupts(struct interruptor* s, int otherwise_relax)
 {
-  struct interruptor* s = &domain_self->interruptor;
-  if (s->qhead == NULL) return;
-  caml_plat_lock(&s->lock);
-  handle_incoming(s);
-  caml_plat_unlock(&s->lock);
-}
-
-static void handle_incoming_otherwise_relax (caml_domain_state* domain_state,
-                                             struct interruptor* self)
-{
-  if (Caml_check_gc_interrupt(domain_state)) {
-    caml_plat_lock(&self->lock);
-    handle_incoming(self);
-    caml_plat_unlock(&self->lock);
-  } else {
+  if (s->qhead != NULL) {
+    caml_plat_lock(&s->lock);
+    handle_incoming(s);
+    caml_plat_unlock(&s->lock);
+  } else if (otherwise_relax) {
     cpu_relax();
   }
+}
+
+static void handle_incoming_otherwise_relax (struct interruptor* self)
+{
+  handle_incoming_interrupts(self, 1);
+}
+
+void caml_handle_incoming_interrupts()
+{
+  handle_incoming_interrupts(&domain_self->interruptor, 0);
 }
 
 static void caml_wait_interrupt_acknowledged (struct interruptor* self,
                                            struct interrupt* req)
 {
   int i;
-  caml_domain_state* domain_state = Caml_state;
 
   /* Often, interrupt handlers are fast, so spin for a bit before waiting */
   for (i=0; i<1000; i++) {
@@ -1240,7 +1239,7 @@ static void caml_wait_interrupt_acknowledged (struct interruptor* self,
   }
 
   while (!atomic_load_acq(&req->acknowledged))
-    handle_incoming_otherwise_relax(domain_state, self);
+    handle_incoming_otherwise_relax(self);
 
   return;
 }
@@ -1427,6 +1426,6 @@ CAMLprim value caml_ml_domain_yield_until(value t)
 CAMLprim value caml_ml_domain_cpu_relax(value t)
 {
   struct interruptor* self = &domain_self->interruptor;
-  handle_incoming_otherwise_relax (Caml_state, self);
+  handle_incoming_otherwise_relax (self);
   return Val_unit;
 }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -783,7 +783,7 @@ static void cycle_all_domains_callback(struct domain* domain, void* unused,
   CAMLassert(atomic_load(&num_domains_to_sweep) == 0);
   CAMLassert(atomic_load(&num_domains_to_ephe_sweep) == 0);
 
-  caml_empty_minor_heap_from_stw(domain, (void*)0, participating_count, participating);
+  caml_empty_minor_heap_no_major_slice_from_stw(domain, (void*)0, participating_count, participating);
 
   caml_ev_begin("major_gc/stw");
 
@@ -1185,7 +1185,7 @@ static void finish_major_cycle_callback (struct domain* domain, void* arg,
   uintnat saved_major_cycles = (uintnat)arg;
   CAMLassert (domain == caml_domain_self());
 
-  caml_empty_minor_heap_from_stw(domain, (void*)0, participating_count, participating);
+  caml_empty_minor_heap_no_major_slice_from_stw(domain, (void*)0, participating_count, participating);
 
   while (saved_major_cycles == caml_major_cycles_completed) {
     major_collection_slice(10000000, participating_count, participating, 0, 0);

--- a/testsuite/tests/parallel/major_gc_wait_backup.ml
+++ b/testsuite/tests/parallel/major_gc_wait_backup.ml
@@ -1,0 +1,40 @@
+(* TEST
+* hasunix
+include unix
+** native
+** bytecode
+*)
+
+type 'a tree = Empty | Node of 'a tree * 'a tree
+
+let rec make d =
+  if d = 0 then Node(Empty, Empty)
+  else let d = d - 1 in Node(make d, make d)
+
+(* you need to use Gc.quick_stat, because Gc.stat forces a major cycle *)
+let major_collections () =
+  (Gc.quick_stat ()).major_collections
+
+(* test to force domain to do a full GC while another is waiting *)
+let _ =
+  let d = Domain.spawn (fun _ ->
+  	Domain.Sync.critical_section (fun () -> Domain.Sync.wait());
+  ) in
+  Gc.full_major ();
+  let n = major_collections () in
+  ignore (make 22);
+  assert ((major_collections ()) > n);
+  Domain.Sync.notify (Domain.get_id d);
+  Domain.join d;
+  print_endline "wait OK"
+
+(* test to force domain to do a full GC while another is blocking *)
+let _ =
+  let _ = Domain.spawn (fun _ ->
+  	Unix.sleep 10000
+  ) in
+  Gc.full_major ();
+  let n = major_collections () in
+  ignore (make 22);
+  assert ((major_collections ()) > n);
+  print_endline "sleep OK"

--- a/testsuite/tests/parallel/major_gc_wait_backup.reference
+++ b/testsuite/tests/parallel/major_gc_wait_backup.reference
@@ -1,0 +1,2 @@
+wait OK
+sleep OK


### PR DESCRIPTION
A domain can block with `Domain.sync.wait` and through `caml_enter_blocking_section`. In both cases the interrupts for the blocked domain is serviced by signalling the interruptor's condition variable. This results in `handle_interrupt` being called and the interrupt being serviced.

This can prevent the completion of major GC cycles in the case that one domain is running normally and one is blocked because the blocked thread does not progress the major GC when servicing the minor collector through `handle_interrupt`. This can result in a program never doing a major collection and memory usage growing without bound.

This PR fixes the situation by:
 - adding a call to `caml_request_major_slice` from `caml_stw_empty_minor_heap`; this work must be deferred because in that context we are inside the minor GC STW section.  
 - adding a call to `caml_handle_gc_interrupt` after a STW interrupt is handled to poll for any deferred GC work.
 - adding a unit test which exercises the major GC while another domain is blocked (both with a `Domain.sync.wait` or a `caml_enter_blocking_section`).
- (refactoring the code for `caml_minor_collection` to align more closely with stock OCaml.)
- (a minor refactor of `handle_incoming_otherwise_relax` and `caml_handle_incoming_interrupts` to utilize a single guard condition and so remove any confusion for the future reader.)

There is a rough edge to this PR; I'm not convinced that finalizers will be called in a timely manner when there is an imbalance between allocation in domains - that is the finalizers are triggered only if a domain fills its own minor heap, not if an interrupt causes the collection. This behaviour is as it currently is before this PR. The difficulty was making sure that finalizers only run when reasonable: Is it reasonable for finalizers to run from the backup thread? Is it reasonable for the finalizers to run for a domain waiting in a critical section? 