### PR TITLE
Group env vars for run in travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - >
     mkdir ~/inst && ./configure --prefix ~/inst --enable-debug-runtime &&
     make -j4 world.opt &&
-    OCAMLRUNPARAM=v=0,V=1 make -C testsuite all-enabled
+    make -C testsuite all-enabled
 
 # For speed, only run a few compiler/OS combinations
 matrix:
@@ -31,5 +31,6 @@ matrix:
     os: linux
     env:
     - USE_RUNTIME: d
+    - OCAMLRUNPARAM: v=0,V=1
   - compiler: clang
     os: osx


### PR DESCRIPTION
This PR groups the `OCAMLRUNPARAM=v=0,V=1` with the `USE_RUNTIME=d` command.

This is partly to prevent me (and possibly others) performing a user-error fault by copying the `OCAMLRUNPARAM=v=0,V=1 make -C testsuite all-enabled` which runs the heap verifications but without any asserts (not interesting). Easy to forget that you need both `OCAMLRUNPARAM=v=0,V=1` and the `USE_RUNTIME=d` as they are in different places in the file.

There is also a subtle point as well. We should have at least one CI run which uses a non-debug build and is not going through the heap verification codepath where `V=1`. 