### PR TITLE
Interruptible mark & sweep

### DIFF
--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -42,6 +42,8 @@ struct domain {
 asize_t caml_norm_minor_heap_size (intnat);
 int caml_reallocate_minor_heap(asize_t);
 
+int caml_incoming_interrupts_queued(void);
+
 void caml_handle_gc_interrupt(void);
 
 void caml_handle_incoming_interrupts(void);

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -52,13 +52,20 @@ DOMAIN_STATE(uintnat, marking_done)
 DOMAIN_STATE(uintnat, sweeping_done)
 /* Is sweeping done for the current major cycle. */
 
-DOMAIN_STATE(uintnat, stealing)
-
 DOMAIN_STATE(uintnat, allocated_words)
 
 DOMAIN_STATE(uintnat, swept_words)
 
-DOMAIN_STATE(uintnat, opportunistic_work)
+DOMAIN_STATE(intnat, major_work_computed)
+/* total work accumulated in this GC clock cycle (in words) */
+
+DOMAIN_STATE(intnat, major_work_todo)
+/* balance of work to do in this GC clock cycle (in words)
+ *  positive: we need to do this amount of work to finish the slice
+ *  negative: we have done more than we need and this is credit
+ */
+
+DOMAIN_STATE(double, major_gc_clock)
 
 DOMAIN_STATE(struct caml__roots_block*, local_roots)
 

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -40,6 +40,10 @@ static inline char caml_gc_phase_char(gc_phase_t phase) {
 
 intnat caml_opportunistic_major_work_available ();
 intnat caml_opportunistic_major_collection_slice (intnat);
+/* auto-triggered slice from within the GC */
+#define AUTO_TRIGGERED_MAJOR_SLICE -1
+/* external triggered slice, but GC will compute the amount of work */
+#define GC_CALCULATE_MAJOR_SLICE 0
 intnat caml_major_collection_slice (intnat);
 void caml_finish_sweeping(void);
 void caml_finish_marking (void);
@@ -98,6 +102,6 @@ extern uintnat caml_major_cycles_completed;
 
 double caml_mean_space_overhead(void);
 
-#endif /* CAML_INTERNALiS */
+#endif /* CAML_INTERNALS */
 
 #endif /* CAML_MAJOR_GC_H */

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -26,8 +26,8 @@ typedef enum {
 extern gc_phase_t caml_gc_phase;
 
 intnat caml_opportunistic_major_work_available ();
-intnat caml_opportunistic_major_collection_slice (intnat, intnat* left /* out */);
-intnat caml_major_collection_slice (intnat, intnat* left /* out */);
+intnat caml_opportunistic_major_collection_slice (intnat);
+intnat caml_major_collection_slice (intnat);
 void caml_finish_sweeping(void);
 void caml_finish_marking (void);
 uintnat caml_get_num_domains_to_mark(void);

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -25,6 +25,19 @@ typedef enum {
 } gc_phase_t;
 extern gc_phase_t caml_gc_phase;
 
+static inline char caml_gc_phase_char(gc_phase_t phase) {
+  switch (phase) {
+    case Phase_sweep_and_mark_main:
+      return 'M';
+    case Phase_mark_final:
+      return 'F';
+    case Phase_sweep_ephe:
+      return 'E';
+    default:
+      return 'U';
+  }
+}
+
 intnat caml_opportunistic_major_work_available ();
 intnat caml_opportunistic_major_collection_slice (intnat);
 intnat caml_major_collection_slice (intnat);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -901,7 +901,7 @@ void caml_handle_gc_interrupt() {
   if (Caml_state->requested_major_slice) {
     caml_ev_begin("dispatch_major_slice");
     Caml_state->requested_major_slice = 0;
-    caml_major_collection_slice (0, 0);
+    caml_major_collection_slice(0);
     caml_ev_end("dispatch_major_slice");
   }
 }
@@ -1343,7 +1343,7 @@ CAMLprim value caml_ml_domain_yield(value unused)
       caml_ev_end("domain/idle_wait");
     } else {
       caml_plat_unlock(&s->lock);
-      caml_opportunistic_major_collection_slice(Chunk_size, &left);
+      left = caml_opportunistic_major_collection_slice(Chunk_size);
       if (left == Chunk_size)
         found_work = 0;
       caml_plat_lock(&s->lock);
@@ -1425,7 +1425,7 @@ CAMLprim value caml_ml_domain_yield_until(value t)
       }
     } else {
       caml_plat_unlock(&s->lock);
-      caml_opportunistic_major_collection_slice(Chunk_size, &left);
+      left = caml_opportunistic_major_collection_slice(Chunk_size);
       if (left == Chunk_size)
         found_work = 0;
       caml_plat_lock(&s->lock);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1219,6 +1219,11 @@ static void domain_terminate()
   atomic_fetch_add(&caml_num_domains_running, -1);
 }
 
+int caml_incoming_interrupts_queued()
+{
+  return domain_self->interruptor.qhead != NULL;
+}
+
 static inline void handle_incoming_interrupts(struct interruptor* s, int otherwise_relax)
 {
   if (s->qhead != NULL) {

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -901,7 +901,7 @@ void caml_handle_gc_interrupt() {
   if (Caml_state->requested_major_slice) {
     caml_ev_begin("dispatch_major_slice");
     Caml_state->requested_major_slice = 0;
-    caml_major_collection_slice(0);
+    caml_major_collection_slice(-1);
     caml_ev_end("dispatch_major_slice");
   }
 }

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -901,7 +901,7 @@ void caml_handle_gc_interrupt() {
   if (Caml_state->requested_major_slice) {
     caml_ev_begin("dispatch_major_slice");
     Caml_state->requested_major_slice = 0;
-    caml_major_collection_slice(-1);
+    caml_major_collection_slice(AUTO_TRIGGERED_MAJOR_SLICE);
     caml_ev_end("dispatch_major_slice");
   }
 }

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -255,14 +255,11 @@ CAMLprim value caml_gc_full_major(value v)
 
 CAMLprim value caml_gc_major_slice (value v)
 {
-  intnat res;
   CAMLassert (Is_long (v));
   caml_ev_pause(EV_PAUSE_GC);
-  caml_empty_minor_heaps_once();
-  res = caml_major_collection_slice(Long_val(v), 0);
-  caml_ev_resume();
+  caml_major_collection_slice(Long_val(v));
   caml_handle_gc_interrupt();
-  return Val_long (res);
+  return Val_long (0);
 }
 
 CAMLprim value caml_gc_compaction(value v)

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -397,20 +397,14 @@ static intnat get_major_slice_work(intnat howmuch) {
   intnat computed_work;
 
   /* calculate how much work to do now */
-  if (howmuch == -1) {
-    /* auto-triggered GC slice */
+  if (howmuch == AUTO_TRIGGERED_MAJOR_SLICE ||
+      howmuch == GC_CALCULATE_MAJOR_SLICE) {
     computed_work = (dom_st->major_work_todo > 0)
       ? dom_st->major_work_todo
       : 0;
   } else {
-    /* forced or opportunistic GC slice */
-    if (howmuch == 0) {
-      computed_work = (dom_st->major_work_todo > 0)
-        ? dom_st->major_work_todo
-        : 0;
-    } else {
-      computed_work = howmuch;
-    }
+    /* forced or opportunistic GC slice with explicit quantity */
+    computed_work = howmuch;
   }
 
   /* TODO: do we want to do anything more complex or simplify the above? */
@@ -1259,9 +1253,9 @@ intnat caml_major_collection_slice(intnat howmuch)
   intnat work_left;
 
   /* if this is an auto-triggered GC slice, make it interruptible */
-  if (howmuch == -1) {
-    work_left = major_collection_slice(-1, 0, 0, Slice_interruptible);
-    if (get_major_slice_work(-1) > 0) {
+  if (howmuch == AUTO_TRIGGERED_MAJOR_SLICE) {
+    work_left = major_collection_slice(AUTO_TRIGGERED_MAJOR_SLICE, 0, 0, Slice_interruptible);
+    if (get_major_slice_work(AUTO_TRIGGERED_MAJOR_SLICE) > 0) {
       caml_gc_log("Major slice interrupted, rescheduling major slice");
       caml_request_major_slice();
     }

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -675,10 +675,21 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
                (unsigned)(minor_allocated_bytes + 512)/1024, rewrite_successes, rewrite_failures);
 }
 
+void caml_do_opportunistic_major_slice(struct domain* domain, void* unused)
+{
+  /* NB: need to put guard around the ev logs to prevent
+    spam when we poll */
+  if (caml_opportunistic_major_work_available()) {
+    int log_events = caml_params->verb_gc & 0x40;
+    if (log_events) caml_ev_begin("minor_gc/opportunistic_major_slice");
+    caml_opportunistic_major_collection_slice(0x200);
+    if (log_events) caml_ev_end("minor_gc/opportunistic_major_slice");
+  }
+}
+
 /* Make sure the minor heap is empty by performing a minor collection
    if needed.
 */
-
 void caml_empty_minor_heap_setup(struct domain* domain) {
   atomic_store_explicit(&domains_finished_minor_gc, 0, memory_order_release);
 }
@@ -711,6 +722,8 @@ static void caml_stw_empty_minor_heap_no_major_slice (struct domain* domain, voi
       if( atomic_load_explicit(&domains_finished_minor_gc, memory_order_acquire) == participating_count ) {
         break;
       }
+
+      caml_do_opportunistic_major_slice(domain, 0);
     }
     caml_ev_end("minor_gc/leave_barrier");
   }
@@ -745,18 +758,6 @@ void caml_empty_minor_heap_no_major_slice_from_stw (struct domain* domain, void*
   /* if we are entering from within a major GC STW section then
      we do not schedule another major collection slice */
   caml_stw_empty_minor_heap_no_major_slice(domain, (void*)0, participating_count, participating);
-}
-
-void caml_do_opportunistic_major_slice(struct domain* domain, void* unused)
-{
-  /* NB: need to put guard around the ev logs to prevent
-    spam when we poll */
-  if (caml_opportunistic_major_work_available()) {
-    int log_events = caml_params->verb_gc & 0x40;
-    if (log_events) caml_ev_begin("minor_gc/opportunistic_major_slice");
-    caml_opportunistic_major_collection_slice(0x200);
-    if (log_events) caml_ev_end("minor_gc/opportunistic_major_slice");
-  }
 }
 
 /* must be called outside a STW section */

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -728,6 +728,9 @@ static void caml_stw_empty_minor_heap (struct domain* domain, void* unused, int 
 
   /* schedule a major collection slice for this domain */
   caml_request_major_slice();
+
+  /* can change how we account clock in future, here just do raw count */
+  domain->state->major_gc_clock += 1.0;
 }
 
 /* must be called within a STW section  */

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -751,7 +751,7 @@ void caml_do_opportunistic_major_slice(struct domain* domain, void* unused)
   if (caml_opportunistic_major_work_available()) {
     int log_events = caml_params->verb_gc & 0x40;
     if (log_events) caml_ev_begin("minor_gc/opportunistic_major_slice");
-    caml_opportunistic_major_collection_slice(0x200, 0);
+    caml_opportunistic_major_collection_slice(0x200);
     if (log_events) caml_ev_end("minor_gc/opportunistic_major_slice");
   }
 }

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -298,7 +298,7 @@ static pool* pool_global_adopt(struct caml_heap_state* local, sizeclass sz)
   caml_plat_unlock(&pool_freelist.lock);
 
   if( !r && adopted_pool ) {
-    Caml_state->opportunistic_work +=
+    Caml_state->major_work_todo -=
       pool_sweep(local, &local->full_pools[sz], sz, 0);
     r = local->avail_pools[sz];
   }
@@ -315,7 +315,7 @@ static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
 
   /* Otherwise, try to sweep until we find one */
   while (!local->avail_pools[sz] && local->unswept_avail_pools[sz]) {
-    Caml_state->opportunistic_work +=
+    Caml_state->major_work_todo -=
       pool_sweep(local, &local->unswept_avail_pools[sz], sz, 0);
   }
 


### PR DESCRIPTION
This PR makes mark and sweep work interruptible. We want to make mark and sweep work interruptible so that all domains can enter STW minor collections even when one domain is doing a large amount of mark and sweep work. 

Along the way this PR also restructures how we account for mark and sweep work to fix issues with opportunistic slices potentially clobbering `allocated_bytes` which can break the mark & sweep work accounting. It also adds opportunistic mark & sweep work to the leave barrier which is very beneficial for a domain that has its mark & sweep interrupted by a minor GC. 

This PR is best reviewed commit by commit:
- The first refactors `caml_gc_major_slice` to simplify the API of `major_collection_slice` and bring `caml_gc_major_slice` in line with stock. 
- The second changes the way in which we account for mark and sweep work. We move to a state consisting of (`work_todo`, `work_computed`, `gc_clock`) and functions (`update_major_slice_work`, `get_major_slice_work`, `commit_major_slice_work`) for altering these. This fixes the potential clobbering of `allocated_bytes` and hopefully makes a bit clearer how to interact with the state. In particular we have three things we want to do: calculate work todo, get the amount to be done now and commit any work done back to the state. 
- The third introduces interruptible major collections. We operate in chunks and check for pending work in the interrupt queue. If any work is pending in the interrupt queue, we complete the major slice in an orderly fashion and request deferred major slice work for this domain. This prevents nested calls, nested event logs and also subtle errors we have had in the past where major gc state is changed inside the interrupt while we are inside a slice. 
- The forth puts opportunistic mark/sweep work into the minor GC leave barrier; particularly beneficial for the domain that gets interrupted and likely has hardly any minor GC work but some mark/sweep to finish up. 

Overall the aim is to introduce functionality that improves scalability and allow future research or proposals for how the major GC accounting should be done to be more easily implemented. In particular, I don't think we should sweat the exact details of the chunk sizes, work capping and the GC clock advancement in this PR (aside obvious gotchas or design issues); further studies could tune these up.

Using multicore binarytrees in sandmark with 4 domains, this is an eventlog with what we had before:
<img width="785" alt="Screenshot 2020-07-29 at 15 12 24" src="https://user-images.githubusercontent.com/1682628/88811024-f8af3200-d1ad-11ea-8e15-226a8d6f8dab.png">
notice major work (pink) in domain 3 is preventing the other domains from entering a minor collection and so stalls their progress. 

After this change:
<img width="997" alt="Screenshot 2020-07-29 at 15 00 25" src="https://user-images.githubusercontent.com/1682628/88809644-46c33600-d1ac-11ea-8767-8641899c607f.png">
notice major work (pink) in domains 2 and 4 does not prevent progress in other domains. 

