### PR TITLE
Make DLS call to caml_domain_dls_get @@noalloc

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1453,5 +1453,6 @@ CAMLprim value caml_domain_dls_set(value t)
 
 CAMLprim value caml_domain_dls_get(value unused)
 {
+  CAMLnoalloc;
   return caml_read_root(Caml_state->dls_root);
 }

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1447,6 +1447,7 @@ CAMLprim value caml_ml_domain_cpu_relax(value t)
 
 CAMLprim value caml_domain_dls_set(value t)
 {
+  CAMLnoalloc;
   caml_modify_root(Caml_state->dls_root, t);
   return Val_unit;
 }

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -122,7 +122,7 @@ module DLS = struct
     = "caml_domain_dls_get" [@@noalloc]
 
   external set_dls_list : entry list  -> unit
-    = "caml_domain_dls_set"
+    = "caml_domain_dls_set" [@@noalloc]
 
   let new_key () = ref 0
 

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -119,7 +119,7 @@ module DLS = struct
   type entry = {key: int ref; slot: Obj.t ref}
 
   external get_dls_list : unit -> entry list
-    = "caml_domain_dls_get"
+    = "caml_domain_dls_get" [@@noalloc]
 
   external set_dls_list : entry list  -> unit
     = "caml_domain_dls_set"


### PR DESCRIPTION
This PR reduces the C call overhead for `Domain.DLS.get` by tagging `caml_dls_get` as  `@@noalloc`.

