### PR TITLE
Use Word_val for pointers with Patomic_load

### DIFF
--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -841,8 +841,10 @@ and transl_prim_1 env p arg dbg =
           dbg)
   | Ppoll ->
       Cop(Cpoll, [transl env arg], dbg)
-  | Patomic_load _ ->
+  | Patomic_load {immediate_or_pointer = Immediate} ->
       Cop(mk_load_mut Word_int, [transl env arg], dbg)
+  | Patomic_load {immediate_or_pointer = Pointer} ->
+      Cop(mk_load_mut Word_val, [transl env arg], dbg)
   | (Pfield_computed | Psequand | Psequor
     | Prunstack | Presume | Preperform
     | Patomic_exchange | Patomic_cas | Patomic_fetch_add


### PR DESCRIPTION
This PR fixes a bug found by @kayceesrk where we were not treating `Patomic_load` correctly in the case of loaded pointers. 