### PR TITLE
Move to SPIN_WAIT for all spins and usleep in SPIN_WAIT

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1277,8 +1277,11 @@ static void caml_wait_interrupt_acknowledged (struct interruptor* self,
     cpu_relax();
   }
 
-  while (!atomic_load_acq(&req->acknowledged))
+  SPIN_WAIT {
+    if (atomic_load_acq(&req->acknowledged))
+      return;
     handle_incoming_otherwise_relax(self);
+  }
 
   return;
 }

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -173,8 +173,9 @@ static inline void log_gc_value(const char* prefix, value v)
 
 /* TODO: Probably a better spinlock needed here though doesn't happen often */
 static void spin_on_header(value v) {
-  while (atomic_load(Hp_atomic_val(v)) != 0) {
-    cpu_relax();
+  SPIN_WAIT {
+    if (atomic_load(Hp_atomic_val(v)) == 0)
+      return;
   }
 }
 


### PR DESCRIPTION
This PR does two things:
 - it moves all busy spin wait loops to use the SPIN_WAIT macro
 - it reinstates the use of `caml_plat_spin_wait` when busy waiting. This causes the spins to be 1000 polls, then `usleep` calls of 10us, 12.5us, etc.

The reason for doing this is that we want to use the same busy spin strategy in all places in our code. Secondly in situations where we have more pthreads running than cores (hopefully rare but can occur with backup threads), it is important to deschedule during a busy spin to degrade gracefully. 