### PR TITLE
Introduce Atomic.create and deprecate Atomic.make (as per #393)

### DIFF
--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -1,6 +1,7 @@
 type 'a t
 
 external make : 'a -> 'a t = "%makemutable"
+external create : 'a -> 'a t = "%makemutable"
 external get : 'a t -> 'a = "%atomic_load"
 external exchange : 'a t -> 'a -> 'a = "%atomic_exchange"
 external compare_and_set : 'a t -> 'a -> 'a -> bool = "%atomic_cas"

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -1,6 +1,8 @@
 type 'a t
 
 external make : 'a -> 'a t = "%makemutable"
+  [@@ocaml.deprecated "Use Atomic.create instead."]
+external create : 'a -> 'a t = "%makemutable"
 external get : 'a t -> 'a = "%atomic_load"
 external exchange : 'a t -> 'a -> 'a = "%atomic_exchange"
 external compare_and_set : 'a t -> 'a -> 'a -> bool = "%atomic_cas"

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -63,7 +63,7 @@ let cas r vold vnew =
   if not (Atomic.compare_and_set r vold vnew) then raise Retry
 
 let spawn f =
-  let state = Atomic.make Running in
+  let state = Atomic.create Running in
   let body () =
     let result = match f () with
       | x -> Ok x

--- a/testsuite/tests/parallel/atomics.ml
+++ b/testsuite/tests/parallel/atomics.ml
@@ -9,7 +9,7 @@ type u = U of unit
 let () =
   (* See https://github.com/ocaml-multicore/ocaml-multicore/issues/252 *)
   let make_cell (x : unit) : u Atomic.t =
-    let cell = Atomic.make (U x) in
+    let cell = Atomic.create (U x) in
     Atomic.set cell (U x) ;
     cell in
   (* the error shows up with an array of length 256 or larger *)
@@ -22,7 +22,7 @@ let test_fetch_add () =
   let count = 10000 in
   let arr = Array.make (ndoms * count) (-1) in
   let step = 1493 in
-  let r = Atomic.make 0 in
+  let r = Atomic.create 0 in
   (* step is relatively prime to Array.length arr *)
   let loop () =
     let self = (Domain.self () :> int) in
@@ -56,7 +56,7 @@ let test v =
   assert (get v = 20)
 
 let () =
-  let r = Atomic.make 42 in
+  let r = Atomic.create 42 in
   test r;
   Atomic.set r 42;
   Gc.full_major ();

--- a/testsuite/tests/parallel/domain_id.ml
+++ b/testsuite/tests/parallel/domain_id.ml
@@ -48,7 +48,7 @@ let test_interrupt_routing () =
      even if they reuse the same internal domain *)
   let d1 = Domain.spawn id in
   join d1;
-  let r = Atomic.make false in
+  let r = Atomic.create false in
   let d2 = Domain.spawn (fun () ->
     Sync.(critical_section (fun () ->
       Atomic.set r true; wait (); Atomic.set r false))) in

--- a/testsuite/tests/parallel/mctest.ml
+++ b/testsuite/tests/parallel/mctest.ml
@@ -77,8 +77,8 @@ module Q : QS = struct
       tail : 'a node Atomic.t }
 
   let create () =
-    let head = (Next (Obj.magic (), Atomic.make Nil)) in
-    { head = Atomic.make head ; tail = Atomic.make head }
+    let head = (Next (Obj.magic (), Atomic.create Nil)) in
+    { head = Atomic.create head ; tail = Atomic.create head }
 
   let is_empty q =
     match Atomic.get q.head with
@@ -108,7 +108,7 @@ module Q : QS = struct
            | Nil -> find_tail_and_enq curr_end node
            | Next (_, n) -> find_tail_and_enq n node
     in
-    let newnode = Next (v, Atomic.make Nil) in
+    let newnode = Next (v, Atomic.create Nil) in
     let tail = Atomic.get q.tail in
     match tail with
     | Nil         -> failwith "HW_MSQueue.push: impossible"
@@ -212,7 +212,7 @@ end
 
 let _ =
   let procs = 4 in
-  let counter = Atomic.make 0 in
+  let counter = Atomic.create 0 in
   let rec finish () =
     let v = Atomic.get counter in
     if not (Atomic.compare_and_set counter v (v+1)) then finish ();

--- a/testsuite/tests/parallel/timing.ml
+++ b/testsuite/tests/parallel/timing.ml
@@ -53,7 +53,7 @@ let () =
 (* Test that notifications interrupt waits *)
 let () =
   let start = timer_ticks () in
-  let flag = Atomic.make false in
+  let flag = Atomic.create false in
   let d1 = spawn (fun () ->
     critical_section (fun () ->
       let r = wait_until Int64.(add start (of_int 1000_000_000)) in

--- a/testsuite/tests/parallel/wait.ml
+++ b/testsuite/tests/parallel/wait.ml
@@ -15,7 +15,7 @@ external critical_adjust : int -> unit
   = "caml_ml_domain_critical_section"
 
 let go () =
-  let in_crit = Atomic.make false in
+  let in_crit = Atomic.create false in
   (* notify does actually notify *)
   let d = spawn (fun () ->
     critical_section (fun () ->
@@ -28,8 +28,8 @@ let go () =
   assert (not (Atomic.get in_crit));
   join d;
   (* notify works even if it arrives before wait *)
-  let entered_crit = Atomic.make false in
-  let woken = Atomic.make false in
+  let entered_crit = Atomic.create false in
+  let woken = Atomic.create false in
   let d = spawn (fun () ->
     critical_section (fun () ->
       Atomic.set entered_crit true;
@@ -40,8 +40,8 @@ let go () =
   notify (get_id d);
   join d;
   (* a single notification wakes all waits in a single crit sec *)
-  let entered_crit = Atomic.make false in
-  let in_second_crit = Atomic.make false in
+  let entered_crit = Atomic.create false in
+  let in_second_crit = Atomic.create false in
   let d = spawn (fun () ->
     critical_section (fun () ->
       Atomic.set entered_crit true;
@@ -61,7 +61,7 @@ let go () =
   assert (not (Atomic.get in_second_crit));
   join d;
   (* critical sections end at termination *)
-  let in_crit = Atomic.make false in
+  let in_crit = Atomic.create false in
   let d = Domain.spawn (fun () ->
      critical_adjust (+1);
      Atomic.set in_crit true;

--- a/testsuite/tests/weak-ephe-final/ephetest5.ml
+++ b/testsuite/tests/weak-ephe-final/ephetest5.ml
@@ -3,7 +3,7 @@
 module E = Ephemeron.K1
 
 module S = struct
-  let make () = Atomic.make false
+  let make () = Atomic.create false
 
   let rec wait s =
     let success =


### PR DESCRIPTION
This PR deprecates `Atomic.make` and introduces `Atomic.create` as suggested in #393 to match up with other stdlib modules. 