### PR TITLE
Demux eventlog for backup thread

### DIFF
--- a/runtime/caml/eventlog.h
+++ b/runtime/caml/eventlog.h
@@ -10,6 +10,7 @@ void caml_ev_counter(const char* name, uint64_t val);
 void caml_ev_begin_flow(const char* name, uintnat id);
 void caml_ev_end_flow(const char* name, uintnat id);
 void caml_ev_global_sync(void);
+void caml_ev_tag_self_as_backup_thread(void);
 
 
 /* FIXME: blocking/resuming not currently traced */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -249,7 +249,6 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
     domain_state->unique_id = d->interruptor.unique_id;
     d->state.state = domain_state;
     domain_state->critical_section_nesting = 0;
-    domain_state->handling_gc_interrupt = 0;
 
     if (caml_init_signal_stack() < 0) {
       goto init_signal_stack_failure;

--- a/runtime/eventlog.c
+++ b/runtime/eventlog.c
@@ -54,7 +54,14 @@ struct event_buffer {
 };
 
 static __thread struct event_buffer* evbuf;
+static __thread int is_backup_thread = 0;
+
 static pthread_key_t evbuf_pkey; // same as evbuf, used for destructor
+
+void caml_ev_tag_self_as_backup_thread ()
+{
+  is_backup_thread = 1;
+}
 
 static void thread_setup_evbuf()
 {
@@ -65,7 +72,7 @@ static void thread_setup_evbuf()
 
   evbuf->ev_flushed = 0;
   atomic_store_rel(&evbuf->ev_generated, 0);
-  evbuf->domain_unique_id = Caml_state->unique_id;
+  evbuf->domain_unique_id = 2 * Caml_state->unique_id + is_backup_thread;
 
   /* add to global list */
   caml_plat_lock(&lock);


### PR DESCRIPTION
With this change, in the eventlog, every even-numbered process is the domain's main thread and the subsequent odd-numbered process is the backup thread. Earlier the events from the backup thread were emitted with the same process id as the main thread and this lead to incomprehensible logs. 

Here is a sample run with this change:

![image](https://user-images.githubusercontent.com/410484/93755338-ba1f7c00-fc20-11ea-85ee-25a77b4af2c9.png)

In the above, the backup threads are active when the main thread is waiting on a condition variable.