### PR TITLE
Do not handle interrupts recursively

### DIFF
--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -91,6 +91,8 @@ DOMAIN_STATE(uintnat, requested_minor_gc)
 
 DOMAIN_STATE(intnat, critical_section_nesting)
 
+DOMAIN_STATE(intnat, handling_interrupt)
+
 DOMAIN_STATE(struct interrupt*, pending_interrupts)
 
 DOMAIN_STATE(int, parser_trace)

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -885,10 +885,11 @@ void caml_handle_gc_interrupt() {
   atomic_uintnat* young_limit = domain_self->interrupt_word_address;
   CAMLalloc_point_here;
 
-  if (atomic_load_acq(young_limit) == INTERRUPT_MAGIC) {
+  if (!Caml_state->handling_interrupt &&
+      atomic_load_acq(young_limit) == INTERRUPT_MAGIC) {
+
     /* interrupt */
     caml_ev_begin("handle_interrupt");
-    if (Caml_state->handling_interrupt) return;
     Caml_state->handling_interrupt = 1;
 
     while (atomic_load_acq(young_limit) == INTERRUPT_MAGIC) {


### PR DESCRIPTION
Introduces a domain local variable to prevent handling interrupts recursively. 