### PR TITLE
Domain.DLS.new_key takes an initialiser

### DIFF
--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -144,7 +144,7 @@ module DLS = struct
     | None -> ()
     | Some e -> set_dls_list (e::vals)
 
-    let get k =
+  let get k =
     let vals = get_dls_list () in
     let (key, init) = k in
     let rec search k l =

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -118,9 +118,8 @@ module DLS : sig
     (** Type of a DLS key *)
 
     val new_key : (unit -> 'a) -> 'a key
-    (** [new_key f] returns a new key for accessing domain-local variable and
-        initialises the key's associated value in the calling domain with
-        initialiser [f ()]. *)
+    (** [new_key f] returns a new key bound to initialiser [f] for accessing
+        domain-local variable. *)
 
     val set : 'a key -> 'a -> unit
     (** [set k v] updates the calling domain's domain-local state to associate

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -117,12 +117,10 @@ module DLS : sig
     type 'a key
     (** Type of a DLS key *)
 
-    val new_key : unit -> 'a key
-    (** Returns a new key for accessing domain-local variable. The type of the
-        variable associated with the key can be specified during invocation.
-        For example, to generate a key which is associated to an integer:
-
-        let k : int Domain.DLS.key = Domain.DLS.new_key () *)
+    val new_key : (unit -> 'a) -> 'a key
+    (** [new_key f] returns a new key for accessing domain-local variable and
+        initialises the key's associated value in the calling domain with
+        initialiser [f ()]. *)
 
     val set : 'a key -> 'a -> unit
     (** [set k v] updates the calling domain's domain-local state to associate
@@ -130,10 +128,10 @@ module DLS : sig
         to [k], which cannot be restored later. [set] is an [O(n)] operation
         where [n] is the number of keys set on the calling domain. *)
 
-    val get : 'a key -> 'a option
-    (** [get k] returns [Some v] if a value [v] is associated to the key [k] in
-        the calling domain's domain-local state. Returns [None] otherwise.
-        [get] is an [O(n)] operation where [n] is the number of keys set on the
-        calling domain *)
+    val get : 'a key -> 'a
+    (** [get k] returns [v] if a value [v] is associated to the key [k] on
+        the calling domain's domain-local state. Sets [k]'s value with its
+        initialiser and returns it otherwise. [get] is an [O(n)] operation
+        where [n] is the number of keys set on the calling domain *)
 
   end

--- a/testsuite/tests/parallel/domain_dls.ml
+++ b/testsuite/tests/parallel/domain_dls.ml
@@ -6,12 +6,12 @@ include unix
 *)
 
 let check () =
-  let k1 : int Domain.DLS.key = Domain.DLS.new_key () in
-  let k2 : float Domain.DLS.key = Domain.DLS.new_key () in
+  let k1 = Domain.DLS.new_key (fun () -> 10) in
+  let k2 = Domain.DLS.new_key (fun () -> 1.0) in
   Domain.DLS.set k1 100;
   Domain.DLS.set k2 200.0;
-  let v1 = Option.get (Domain.DLS.get k1) in
-  let v2 = Option.get (Domain.DLS.get k2) in
+  let v1 = Domain.DLS.get k1 in
+  let v2 = Domain.DLS.get k2 in
   assert (v1 = 100);
   assert (v2 = 200.0);
   Gc.major ()


### PR DESCRIPTION
This PR adds an initialiser argument to `Domain.DLS.new_key`. The initialiser used to set an associated value to that key in case no other value is explicitly set to it. `Domains.DLS.get` no longer returns an option value. For example:

```ocaml
# let k = Domain.DLS.new_key (fun () -> 42);;
val k : int Domain.DLS.key = <abstr>
# Domain.DLS.get k;;
- : int = 42
```
Due to changes in type signatures of `DLS.new_key` and `DLS.get` in this patch, any existing code using `DLS` module needs to be altered to use the modified API if this PR is merged.

Fixes #388 