### PR TITLE
Rework Domain.DLS.get search function such that it no longer allocates

### DIFF
--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -149,10 +149,9 @@ module DLS = struct
       match l with
       | [] ->
         begin
-          let r = Obj.repr (init ()) in
-          let e = {key_id = key_id; slot = r } in
-          set_dls_list (e::dls_list);
-          r
+          let slot = Obj.repr (init ()) in
+          set_dls_list ({key_id; slot}::dls_list);
+          slot
         end
       | hd::tl ->
         if hd.key_id == key_id then hd.slot else search key_id init dls_list tl

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -145,19 +145,20 @@ module DLS = struct
     | Some e -> set_dls_list (e::vals)
 
   let get k =
-    let vals = get_dls_list () in
-    let (key, init) = k in
-    let rec search k l =
+    let rec search key_id init dls_list l =
       match l with
       | [] ->
         begin
           let r = Obj.repr (init ()) in
-          let e = {key_id = k; slot = r } in
-          set_dls_list (e::vals);
+          let e = {key_id = key_id; slot = r } in
+          set_dls_list (e::dls_list);
           r
         end
-      | hd::tl -> if hd.key_id == k then hd.slot else search k tl
+      | hd::tl ->
+        if hd.key_id == key_id then hd.slot else search key_id init dls_list tl
     in
-    Obj.obj @@ search key vals
+    let dls_list = get_dls_list () in
+    let (key_id, init) = k in
+    Obj.obj @@ search key_id init dls_list dls_list
 
 end


### PR DESCRIPTION
This PR tweaks `Domain.DLS.get` to remove memory allocation in the case that the key exists in the domain local storage.

This could be important for stuff like this:
```ocaml
let dls_key = Domain.DLS.new_key Random.State.make_self_init

let do_work n =
  let x = ref 0 in
  for i = 0 to n do
     x := !x + (Random.State.int (Domain.DLS.get dls_key) 2)
  done;
  !x

let () =
  let n = try int_of_string Sys.argv.(1) with _ -> 1_000_000 in
  let x = do_work n in
  Printf.printf "n=%i x=%i\n" n x
```
where the user might expect the `do_work` function to have no memory allocation. 

The change alters the `search` function within `Domain.DLS.get` to take all inputs as variables rather than capturing things from the environment in a closure. 

_Updated to improve the testcase code_