### PR TITLE
Replace the non-standard PTHREAD_MUTEX_ERRORCHECK_NP and fix a leak

### DIFF
--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -2,9 +2,6 @@
 #define CAML_PLAT_THREADS_H
 /* Platform-specific concurrency and memory primitives */
 
-#ifdef __linux__
-#define _GNU_SOURCE /* for PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP */
-#endif
 #include <pthread.h>
 #include <errno.h>
 #include <string.h>


### PR DESCRIPTION
Adapting code from ocaml trunk, this does two things:
1) destroy the mutexattr
2) replace the older and non-standard `PTHREAD_MUTEX_ERRORCHECK_NP` with the standard `PTHREAD_MUTEX_ERRORCHECK`. This is reported as necessary for compiling multicore with musl (fixes #266). According to @stedolan [“This function was part of SUSv2 in 1997, and was included in POSIX.1-2001 as part of the XSI extension. The recent change is that it was made mandatory rather than part of an extension, but I'm not aware of any pthread implementations that lack it.”](https://github.com/ocaml/ocaml/pull/9757#issuecomment-658820515)