### PR TITLE
Fix up Ppoll semantics_of_primitives entry

### DIFF
--- a/middle_end/semantics_of_primitives.ml
+++ b/middle_end/semantics_of_primitives.ml
@@ -21,7 +21,7 @@ type coeffects = No_coeffects | Has_coeffects
 
 let for_primitive (prim : Clambda_primitives.primitive) =
   match prim with
-  | Pmakeblock _ | Ppoll
+  | Pmakeblock _
   | Pmakearray (_, Mutable) -> Only_generative_effects, No_coeffects
   | Pmakearray (_, Immutable) -> No_effects, No_coeffects
   | Pduparray (_, Immutable) ->
@@ -36,6 +36,7 @@ let for_primitive (prim : Clambda_primitives.primitive) =
   | Pccall _ -> Arbitrary_effects, Has_coeffects
   | Praise _ -> Arbitrary_effects, No_coeffects
   | Prunstack | Pperform | Presume | Preperform -> Arbitrary_effects, Has_coeffects
+  | Ppoll -> Arbitrary_effects, Has_coeffects
   | Pnot
   | Pnegint
   | Paddint


### PR DESCRIPTION
This PR fixes up the semantics_of_primitives entry for `Ppoll` which was causing flambda builds to remove poll points (this fixes #412).

Thanks to @lthls for pointing me in the right direction. 
