### PR TITLE
Fix callback effect bug 211

### DIFF
--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -36,14 +36,20 @@ static __thread int callback_depth = 0;
  * is executing to ensure that the garbage collector follows the
  * stack parent
  */
-#define SAVE_AND_CLEAR_STACK_PARENT(cont, domain_state) \
-  struct stack_info* parent_stack = Stack_parent(domain_state->current_stack); \
-  cont = caml_alloc_1(Cont_tag, Val_ptr(parent_stack)); \
-  Stack_parent(domain_state->current_stack) = NULL
+static inline value save_and_clear_stack_parent(caml_domain_state* domain_state) {
+  struct stack_info* parent_stack = Stack_parent(domain_state->current_stack);
+  value cont = caml_alloc_1(Cont_tag, Val_ptr(parent_stack));
+  Stack_parent(domain_state->current_stack) = NULL;
+  return cont;
+}
+
+static inline void restore_stack_parent(caml_domain_state* domain_state, value cont) {
+  struct stack_info* parent_stack = Ptr_val(Op_val(cont)[0]);
+  Assert(Stack_parent(domain_state->current_stack) == NULL);
+  Stack_parent(domain_state->current_stack) = parent_stack;
+}
 
 #define RESTORE_STACK_PARENT(domain_state) \
-  Assert(Stack_parent(domain_state->current_stack) == NULL); \
-  Stack_parent(domain_state->current_stack) = parent_stack
 
 
 #ifndef NATIVE_CODE
@@ -68,7 +74,8 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[])
 {
   CAMLparam1(closure);
   CAMLxparamN(args, narg);
-  CAMLlocal2(res, cont);
+  CAMLlocal1(cont);
+  value res;
   int i;
   caml_domain_state* domain_state = Caml_state;
 
@@ -87,12 +94,12 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[])
   domain_state->current_stack->sp[narg + 2] = Val_long(0); /* extra args */
   domain_state->current_stack->sp[narg + 3] = closure;
 
-  SAVE_AND_CLEAR_STACK_PARENT(cont, domain_state);
+  cont = save_and_clear_stack_parent(domain_state);
 
   res = caml_interprete(code, sizeof(code));
   if (Is_exception_result(res)) domain_state->current_stack->sp += narg + 4; /* PR#3419 */
 
-  RESTORE_STACK_PARENT(domain_state);
+  restore_stack_parent(domain_state, cont);
 
   CAMLreturn (res);
 }
@@ -139,11 +146,12 @@ CAMLexport value caml_callback_exn(value closure, value arg)
   caml_domain_state* domain_state = Caml_state;
   if (Stack_parent(domain_state->current_stack)) {
     CAMLparam2 (closure, arg);
-    CAMLlocal2 (res, cont);
+    CAMLlocal1 (cont);
+    value res;
 
-    SAVE_AND_CLEAR_STACK_PARENT(cont, domain_state);
+    cont = save_and_clear_stack_parent(domain_state);
     res = caml_callback_asm(domain_state, closure, &arg);
-    RESTORE_STACK_PARENT(domain_state);
+    restore_stack_parent(domain_state, cont);
 
     CAMLreturn (res);
   }
@@ -158,11 +166,12 @@ CAMLexport value caml_callback2_exn(value closure, value arg1, value arg2)
   caml_domain_state* domain_state = Caml_state;
   if (Stack_parent(domain_state->current_stack)) {
     CAMLparam3 (closure, arg1, arg2);
-    CAMLlocal2 (res, cont);
+    CAMLlocal1 (cont);
+    value res;
 
-    SAVE_AND_CLEAR_STACK_PARENT(cont, domain_state);
+    cont = save_and_clear_stack_parent(domain_state);
     res = caml_callback2_asm(domain_state, closure, args);
-    RESTORE_STACK_PARENT(domain_state);
+    restore_stack_parent(domain_state, cont);
 
     CAMLreturn (res);
   }
@@ -178,11 +187,12 @@ CAMLexport value caml_callback3_exn(value closure,
   caml_domain_state* domain_state = Caml_state;
   if (Stack_parent(domain_state->current_stack))  {
     CAMLparam4 (closure, arg1, arg2, arg3);
-    CAMLlocal2 (res, cont);
+    CAMLlocal1 (cont);
+    value res;
 
-    SAVE_AND_CLEAR_STACK_PARENT(cont, domain_state);
+    cont = save_and_clear_stack_parent(domain_state);
     res = caml_callback3_asm(domain_state, closure, args);
-    RESTORE_STACK_PARENT(domain_state);
+    restore_stack_parent(domain_state, cont);
 
     CAMLreturn (res);
   }

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -62,9 +62,5 @@ lib-obj
 # Uses caml_page_table_lookup() (<- Is_in_static_data ()) which is not available on multicore
 tests/asmcomp/'is_static.ml' with 1 (native)
 
-# GC bug in callbacks (#211)
-tests/callback/'nested_fiber.ml' with 1.1 (bytecode)
-tests/callback/'test7.ml' with 1.2 (native)
-
 # since promotion is based on minor heap size now, this test can no longer be correct
 tests/promotion/bigrecmod.ml

--- a/testsuite/tests/callback/nested_fiber.ml
+++ b/testsuite/tests/callback/nested_fiber.ml
@@ -10,19 +10,35 @@ external caml_to_c : (unit -> 'a) -> 'a = "caml_to_c"
 
 effect E : unit
 
+type 'a tree = Empty | Node of 'a tree * 'a tree
+
+let rec make d =
+  match d with
+  | 0 -> Node(Empty, Empty)
+  | _ -> let d = d - 1 in Node(make d, make d)
+
+let rec check = function Empty -> 0 | Node(l, r) -> 1 + check l + check r
+
 let g () =
   caml_to_c (fun () ->
       Gc.full_major ();
-      Printf.printf "%d\n%!" 1)
+      let x = make 10 in
+      Printf.printf "g() check %d\n%!" (check x))
 
 let f () =
-  let x = ref 2 in
-  match g () with
+  let x = make 3 in
+  let z = ref 1 in
+  (match g () with
   | effect E k -> assert false
   | () ->
-     Printf.printf "%d\n" !x
+     Printf.printf "g() returned: %d\n%!" !z);
+  Printf.printf "f() check: %d\n%!" (check x)
 
 let () =
-  match f () with
+  let x = make 3 in
+  let z = ref 2 in
+  (match f () with
   | effect E k -> assert false
-  | () -> ()
+  | () ->
+     Printf.printf "f() returned: %d\n%!" !z);
+  Printf.printf "() check: %d\n%!" (check x)

--- a/testsuite/tests/callback/nested_fiber.reference
+++ b/testsuite/tests/callback/nested_fiber.reference
@@ -1,2 +1,5 @@
-1
-2
+g() check 2047
+g() returned: 1
+f() check: 15
+f() returned: 2
+() check: 15


### PR DESCRIPTION
This PR fixes #211 and also a bug in native that caused `tests/callback/test7` to fail. 

The PR does a couple of things:
 - ensures that the nested_fiber test is more taxing and so picks up the GC issue as in #211
 - we clear the stack parent before a callback and restore it after a callback (as was done in bytecode but not native)
 - makes the stack parent a local root, so that the GC will see the stack parent when inside the callback

I'm not wedded to the macros used here, but I couldn't see an elegant way to avoid code duplication and still get what we need. 