### PR TITLE
Implement fiber stack cache

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -190,7 +190,7 @@ typedef uint64_t uintnat;
 
 /* Number of words used in the control structure at the start of a stack
    (see fiber.h) */
-#define Stack_ctx_words 3
+#define Stack_ctx_words 4
 
 /* Default maximum size of the stack (words). */
 #define Max_stack_def (1024 * 1024)

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -41,6 +41,8 @@ DOMAIN_STATE(struct c_stack_link*, c_stack)
 
 DOMAIN_STATE(value**, gc_regs_slot)
 
+DOMAIN_STATE(struct stack_cache*, stack_cache)
+
 DOMAIN_STATE(struct caml_minor_tables*, minor_tables)
 
 DOMAIN_STATE(struct mark_stack*, mark_stack)

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -24,6 +24,14 @@ struct stack_info {
   value* sp;
 #endif
   struct stack_handler* handler;
+
+  /* [size_class] is a multiple of [caml_fiber_wsz] if pooled. If unpooled, it
+   * is [-1].
+   *
+   * Stacks may be unpooled if either the stack size is not a multiple of
+   * [caml_fiber_wsz] (may be the case in debug mode) or the stack is bigger
+   * than pooled sizes. */
+  intnat size_class;
   uintnat magic;
 };
 
@@ -64,12 +72,19 @@ struct c_stack_link {
   struct c_stack_link* prev;
 };
 
+#define NUM_STACK_SIZE_CLASSES 5
+
+struct stack_cache {
+  struct stack_info* pool[NUM_STACK_SIZE_CLASSES];
+};
+
 /* The table of global identifiers */
 extern caml_root caml_global_data;
 
 #define Trap_pc(tp) ((tp)[0])
 #define Trap_link(tp) ((tp)[1])
 
+struct stack_cache* caml_init_stack_cache (void);
 struct stack_info* caml_alloc_main_stack (uintnat init_size);
 void caml_scan_stack(scanning_action f, void* fdata, struct stack_info* stack);
 /* try to grow the stack until at least required_size words are available.

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -274,15 +274,19 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
       goto reallocate_minor_heap_failure;
     }
 
-    Caml_state->current_stack =
+    domain_state->current_stack =
         caml_alloc_main_stack(Stack_size / sizeof(value));
-    if(Caml_state->current_stack == NULL) {
+    if(domain_state->current_stack == NULL) {
       goto alloc_main_stack_failure;
     }
 
     domain_state->dls_root = caml_create_root_noexc(Val_unit);
-    if(Caml_state->dls_root == NULL) {
+    if(domain_state->dls_root == NULL) {
       goto create_root_failure;
+    }
+    domain_state->stack_cache = caml_init_stack_cache();
+    if(Caml_state->stack_cache == NULL) {
+      goto create_stack_cache_failure;
     }
 
     domain_state->backtrace_buffer = NULL;
@@ -292,8 +296,10 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
 #endif
     goto domain_init_complete;
 
+create_stack_cache_failure:
+  caml_delete_root(domain_state->dls_root);
 create_root_failure:
-  caml_free_stack(Caml_state->current_stack);
+  caml_free_stack(domain_state->current_stack);
 alloc_main_stack_failure:
 reallocate_minor_heap_failure:
   caml_teardown_major_gc();

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -42,6 +42,21 @@ static inline struct stack_info* alloc_for_stack (mlsize_t wosize)
                                sizeof(struct stack_handler));
 }
 
+static inline intnat stack_size_class (mlsize_t wosize)
+{
+  intnat size_class = 0;
+
+  if (wosize % caml_fiber_wsz != 0)
+    return -1;
+  wosize = wosize / caml_fiber_wsz;
+  do {
+    if ((wosize = wosize >> 1) == 0)
+      return size_class;
+  } while(size_class++ < NUM_STACK_SIZE_CLASSES);
+
+  return -1;
+}
+
 /* allocate a stack with at least "wosize" usable words of stack */
 static struct stack_info* alloc_stack_noexc(mlsize_t wosize, value hval, value hexn, value heff)
 {
@@ -52,8 +67,8 @@ static struct stack_info* alloc_stack_noexc(mlsize_t wosize, value hval, value h
   CAML_STATIC_ASSERT(sizeof(struct stack_info) % sizeof(value) == 0);
   CAML_STATIC_ASSERT(sizeof(struct stack_handler) % sizeof(value) == 0);
 
-  if (wosize % caml_fiber_wsz == 0 &&
-      (size_class = wosize / caml_fiber_wsz - 1) < NUM_STACK_SIZE_CLASSES) {
+  size_class = stack_size_class (wosize);
+  if (size_class >= 0) {
     if (Caml_state->stack_cache->pool[size_class] == NULL) {
       stack = alloc_for_stack(wosize);
       stack->size_class = size_class;

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -20,19 +20,52 @@
 #include "frame_descriptors.h"
 #endif
 
+struct stack_cache* caml_init_stack_cache () {
+  int i;
+
+  struct stack_cache* stack_cache =
+    (struct stack_cache*)caml_stat_alloc_noexc(sizeof(struct stack_cache));
+  if (stack_cache == NULL)
+    return NULL;
+
+  for(i = 0; i < NUM_STACK_SIZE_CLASSES; i++)
+    stack_cache->pool[i] = NULL;
+
+  return stack_cache;
+}
+
+static inline struct stack_info* alloc_for_stack (mlsize_t wosize)
+{
+  return caml_stat_alloc_noexc(sizeof(struct stack_info) +
+                               sizeof(value) * wosize +
+                               8 /* for alignment */ +
+                               sizeof(struct stack_handler));
+}
+
 /* allocate a stack with at least "wosize" usable words of stack */
 static struct stack_info* alloc_stack_noexc(mlsize_t wosize, value hval, value hexn, value heff)
 {
   struct stack_info* stack;
   struct stack_handler* hand;
+  intnat size_class;
 
   CAML_STATIC_ASSERT(sizeof(struct stack_info) % sizeof(value) == 0);
   CAML_STATIC_ASSERT(sizeof(struct stack_handler) % sizeof(value) == 0);
 
-  stack = caml_stat_alloc_noexc(sizeof(struct stack_info) +
-                          sizeof(value) * wosize +
-                          8 /* for alignment */ +
-                          sizeof(struct stack_handler));
+  if (wosize % caml_fiber_wsz == 0 &&
+      (size_class = wosize / caml_fiber_wsz - 1) < NUM_STACK_SIZE_CLASSES) {
+    if (Caml_state->stack_cache->pool[size_class] == NULL) {
+      stack = alloc_for_stack(wosize);
+      stack->size_class = size_class;
+    } else {
+      stack = Caml_state->stack_cache->pool[size_class];
+      CAMLassert(stack->size_class == size_class);
+      Caml_state->stack_cache->pool[size_class] = stack->handler->parent;
+    }
+  } else {
+    stack = alloc_for_stack(wosize);
+    stack->size_class = -1;
+  }
   if (stack == NULL) {
     return NULL;
   }
@@ -351,7 +384,12 @@ void caml_free_stack (struct stack_info* stack)
 #ifdef DEBUG
   memset(stack, 0x42, (char*)stack->handler - (char*)stack);
 #endif
-  caml_stat_free(stack);
+  if (stack->size_class != -1) {
+    stack->handler->parent = Caml_state->stack_cache->pool[stack->size_class];
+    Caml_state->stack_cache->pool[stack->size_class] = stack;
+  } else {
+    caml_stat_free(stack);
+  }
 }
 
 CAMLprim value caml_clone_continuation (value cont)


### PR DESCRIPTION
This PR implements a stack cache for fibers. The cache initially starts out empty. When fibers are freed, they're returned to the pool rather than calling `free` on them. Such pooled fibers are reused for later allocations. We use a small number of allocation size classes; larger ones are returned to the OS eagerly. 

Here are some initial performance observations. The test program is:

```ocaml
effect E : unit

let n = try int_of_string Sys.argv.(1) with _ -> 10

let rec fib n =
  match
    if n < 2 then 1
    else fib (n-1) + fib (n-2)
  with
  | v -> v
  | effect E k -> failwith "impossible"

let main () = ignore @@ fib n

let _ = main ()
```

I have also benchmarked with `mimalloc` just to see if a difference `malloc` implementation makes a difference. Here are the results from 10 runs obtained using `hyperfine`. 

| Variant | Time | SD | Min | Max |
|-------|-----|------|------|-----|
| 4.10+mc | 1.053s | 0.033s | 1.017s | 1.112s |
| 4.10+mc+mimalloc | 0.914s | 0.041s | 0.850s | 0.969s |
| 4.10+mc+cache | 0.986s | 0.037s | 0.921s | 1.044s |
| 4.10+mc+cache+mimalloc | 0.963s | 0.035s | 0.912s | 1.031s |

Plain `4.10+mc+mimalloc` is the clear winner here. I'm surprised it does better than the stack cache.