### PR TITLE
Simplify minor heaps configuration logic and masking

### DIFF
--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -701,7 +701,7 @@ let float_array_ref arr ofs dbg =
   box_float dbg (unboxed_float_array_ref arr ofs dbg)
 
 let addr_array_set arr ofs newval dbg =
-  Cop(Cextcall("caml_modify_field_asm", typ_void, false, None),
+  Cop(Cextcall("caml_modify_field", typ_void, false, None),
       [arr; untag_int ofs dbg; newval], dbg)
 let addr_array_initialize arr ofs newval dbg =
   Cop(Cextcall("caml_initialize_field", typ_void, false, None),
@@ -2148,7 +2148,7 @@ let assignment_kind
 let setfield n ptr init arg1 arg2 dbg =
   match assignment_kind ptr init with
   | Caml_modify ->
-      return_unit dbg (Cop(Cextcall("caml_modify_field_asm",
+      return_unit dbg (Cop(Cextcall("caml_modify_field",
                                     typ_void, false, None),
                       [arg1; Cconst_int (n, dbg); arg2],
                       dbg))

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -110,8 +110,6 @@
 
 #define CAML_CONFIG_H_NO_TYPEDEFS
 #include "../runtime/caml/config.h"
-        .equ Minor_val_bitmask,\
-          (1 | ~((1 << (Minor_heap_align_bits + Minor_heap_sel_bits)) - 1))
 
         .set    domain_curr_field, 0
 #define DOMAIN_STATE(c_type, name) \
@@ -465,21 +463,6 @@ CFI_STARTPROC
         jmp     GCALL(caml_raise_exn)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_call_realloc_stack))
-
-/* runs on C stack with C calling convention.
-   optimisation: use ocaml calling convention and SAVE_ALL_REGS?
-   args: C_ARG_1: object, C_ARG_2: field idx, C_ARG_3: new value */
-FUNCTION(G(caml_modify_field_asm))
-CFI_STARTPROC
-        movq    C_ARG_1, %r11
-        xorq    %r14, %r11
-        testq   $Minor_val_bitmask, %r11
-        jz      1f
-        jmp     GCALL(caml_modify_field)
-1:      movq    C_ARG_3, 0(C_ARG_1,C_ARG_2,8)
-        ret
-CFI_ENDPROC
-ENDFUNCTION(G(caml_modify_field_asm))
 
 FUNCTION(G(caml_call_gc))
 CFI_STARTPROC

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -296,10 +296,10 @@ CAMLprim value caml_make_vect(value len, value init)
     else {
       /* make sure init is not young, to avoid creating
        very many ref table entries */
-      if (Is_block(init) && Is_minor(init))
+      if (Is_block(init) && Is_young(init))
         caml_minor_collection();
 
-      CAMLassert(!(Is_block(init) && Is_minor(init)));
+      CAMLassert(!(Is_block(init) && Is_young(init)));
       res = caml_alloc(size, 0);
       /* We now know that [init] is not in the minor heap, so there is
          no need to call [caml_initialize]. */

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -212,18 +212,10 @@ typedef uint64_t uintnat;
    This must be at least [Max_young_wosize + 1]. */
 #define Minor_heap_min (Max_young_wosize + 1)
 
-/* There may be at most 1<<Minor_heap_sel_bits minor
-   heaps allocated */
-#define Minor_heap_sel_bits 7
-
-/* An entire minor heap must fit inside one region
-   of size 1 << Minor_heap_align_bits, which determines
-   the maximum size of the heap */
-#if SIZEOF_PTR  <= 4
-#define Minor_heap_align_bits 20
-#else
-#define Minor_heap_align_bits 24
-#endif
+/* Maximum size of the minor zone (words).
+   Must be greater than or equal to [Minor_heap_min].
+*/
+#define Minor_heap_max (1 << 28)
 
 /* Default size of the minor zone. (words)  */
 #define Minor_heap_def 262144
@@ -264,7 +256,7 @@ typedef uint64_t uintnat;
 #define Percent_to_promote_with_GC 10
 
 /* Maximum number of domains */
-#define Max_domains (1 << Minor_heap_sel_bits)
+#define Max_domains 128
 
 /* Default setting for the major GC slice smoothing window: 1
    (i.e. no smoothing)

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -103,6 +103,8 @@ struct domain* caml_owner_of_young_block(value);
 struct domain* caml_domain_of_id(int);
 
 CAMLextern atomic_uintnat caml_num_domains_running;
+CAMLextern uintnat caml_minor_heaps_base;
+CAMLextern uintnat caml_minor_heaps_end;
 
 INLINE intnat caml_domain_alone()
 {

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -204,31 +204,14 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
 /* Fields are numbered from 0. */
 #define Field(x, i) (((value *)(x)) [i])           /* Also an l-value. */
 
-/* All values which are not blocks in the current domain's minor heap
-   differ from caml_domain_state in at least one of the bits set in
-   Young_val_bitmask */
-#define Young_val_bitmask \
-  ((uintnat)1 | ~(((uintnat)1 << Minor_heap_align_bits) - (uintnat)1))
+/* Is_young(val) is true iff val is in the reserved area for minor heaps */
 
-/* All values which are not blocks in any domain's minor heap differ
-   from caml_domain_state in at least one of the bits set in
-   Minor_val_bitmask */
-#define Minor_val_bitmask \
-  ((uintnat)1 | ~(((uintnat)1 << (Minor_heap_align_bits + Minor_heap_sel_bits)) - (uintnat)1))
-
-
-/* Is_young(val) is true iff val is a block in the current domain's minor heap.
-   Since the minor heap is allocated in one aligned block, this can be tested
-   via bitmasking. */
 #define Is_young(val) \
-  ((((uintnat)(val) ^ (uintnat)Caml_state) & Young_val_bitmask) == 0)
+  (CAMLassert (Is_block (val)),		   \
+   (char *)(val) < (char *)caml_minor_heaps_end && \
+   (char *)(val) > (char *)caml_minor_heaps_base)
 
-/* Is_minor(val) is true iff val is a block in any domain's minor heap. */
-#define Is_minor(val) \
-  ((((uintnat)(val) ^ (uintnat)Caml_state) & Minor_val_bitmask) == 0)
-
-#define Is_block_and_young(val) Is_young(val)
-#define Is_block_and_minor(val) Is_minor(val)
+#define Is_block_and_young(val) (Is_block(val) && Is_young(val))
 
 /* NOTE: [Forward_tag] and [Infix_tag] must be just under
    [No_scan_tag], with [Infix_tag] the lower one.

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -475,12 +475,12 @@ CAMLprim value caml_continuation_use_noexc (value cont)
   value v;
   value null_stk = Val_ptr(NULL);
 
-  fiber_debug_log("cont: is_block(%d) tag_val(%ul) is_minor(%d)", Is_block(cont), Tag_val(cont), Is_minor(cont));
+  fiber_debug_log("cont: is_block(%d) tag_val(%ul) is_young(%d)", Is_block(cont), Tag_val(cont), Is_young(cont));
   CAMLassert(Is_block(cont) && Tag_val(cont) == Cont_tag);
 
   /* this forms a barrier between execution and any other domains
      that might be marking this continuation */
-  if (!Is_minor(cont) ) caml_darken_cont(cont);
+  if (!Is_young(cont) ) caml_darken_cont(cont);
 
   /* at this stage the stack is assured to be marked */
   v = Op_val(cont)[0];

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -228,7 +228,7 @@ static void generic_final_minor_update (struct domain* d, struct finalisable * f
   CAMLassert (final->old <= final->young);
   for (i = final->old; i < final->young; i++){
     CAMLassert (Is_block (final->table[i].val));
-    if (Is_minor(final->table[i].val) && caml_get_header_val(final->table[i].val) != 0){
+    if (Is_young(final->table[i].val) && caml_get_header_val(final->table[i].val) != 0){
       ++ todo_count;
     }
   }
@@ -248,7 +248,7 @@ static void generic_final_minor_update (struct domain* d, struct finalisable * f
     for (i = final->old; i < final->young; i++) {
       CAMLassert (Is_block (final->table[i].val));
       CAMLassert (Tag_val (final->table[i].val) != Forward_tag);
-      if (Is_minor(final->table[j].val) && caml_get_header_val(final->table[i].val) != 0) {
+      if (Is_young(final->table[j].val) && caml_get_header_val(final->table[i].val) != 0) {
         /** dead */
         fi->todo_tail->item[k] = final->table[i];
         /* The finalisation function is called with unit not with the value */
@@ -269,7 +269,7 @@ static void generic_final_minor_update (struct domain* d, struct finalisable * f
   /** update the minor value to the copied major value */
   for (i = final->old; i < final->young; i++) {
     CAMLassert (Is_block (final->table[i].val));
-    if (Is_minor(final->table[i].val)) {
+    if (Is_young(final->table[i].val)) {
       CAMLassert (caml_get_header_val(final->table[i].val) == 0);
       final->table[i].val = Op_val(final->table[i].val)[0];
     }

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -29,7 +29,7 @@ static caml_plat_mutex roots_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 CAMLexport caml_root caml_create_root(value init)
 {
   CAMLparam1(init);
-  
+
   value* v = (value*)caml_stat_alloc(sizeof(value));
 
   *v = init;
@@ -42,7 +42,7 @@ CAMLexport caml_root caml_create_root(value init)
 CAMLexport caml_root caml_create_root_noexc(value init)
 {
   CAMLparam1(init);
-  
+
   value* v = (value*)caml_stat_alloc_noexc(sizeof(value));
 
   if( v == NULL ) {
@@ -95,7 +95,7 @@ struct skiplist caml_global_roots_old = SKIPLIST_STATIC_INITIALIZER;
    - Otherwise (the root contains a pointer outside of the heap or an integer),
      then neither [caml_global_roots_young] nor [caml_global_roots_old] contain
      it. */
-    
+
 /* Insertion and deletion */
 
 Caml_inline void caml_insert_global_root(struct skiplist * list, value * r)
@@ -307,4 +307,3 @@ void caml_scan_global_young_roots(scanning_action f, void* fdata)
 
   caml_skiplist_empty(&caml_global_roots_young);
 }
-  

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -473,9 +473,9 @@ static struct pool* find_pool_to_rescan();
 
 
 #ifdef DEBUG
-#define Is_markable(v) (Is_block(v) && !Is_minor(v) && v != Debug_free_major)
+#define Is_markable(v) (Is_block(v) && !Is_young(v) && v != Debug_free_major)
 #else
-#define Is_markable(v) (Is_block(v) && !Is_minor(v))
+#define Is_markable(v) (Is_block(v) && !Is_young(v))
 #endif
 
 static void realloc_mark_stack (struct mark_stack* stk)
@@ -509,7 +509,7 @@ static intnat mark_stack_push(struct mark_stack* stk, mark_entry e)
   value v;
   intnat work;
 
-  CAMLassert(Is_block(e.block) && !Is_minor(e.block));
+  CAMLassert(Is_block(e.block) && !Is_young(e.block));
   CAMLassert(Tag_val(e.block) != Infix_tag);
   CAMLassert(Tag_val(e.block) != Cont_tag);
   CAMLassert(Tag_val(e.block) < No_scan_tag);
@@ -629,7 +629,7 @@ static intnat mark(intnat budget) {
 
 void caml_darken_cont(value cont)
 {
-  CAMLassert(Is_block(cont) && !Is_minor(cont) && Tag_val(cont) == Cont_tag);
+  CAMLassert(Is_block(cont) && !Is_young(cont) && Tag_val(cont) == Cont_tag);
   SPIN_WAIT {
     header_t hd = atomic_load_explicit(Hp_atomic_val(cont), memory_order_relaxed);
     CAMLassert(!Has_status_hd(hd, global.GARBAGE));

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -133,16 +133,16 @@ static void write_barrier(value obj, intnat field, value old_val, value new_val)
   /* HACK: can't assert when get old C-api style pointers
     Assert (Is_block(obj)); */
 
-  if (!Is_minor(obj)) {
+  if (!Is_young(obj)) {
 
     if (Is_block(old_val)) {
        /* if old is in the minor heap, then this is in a remembered set already */
-       if (Is_minor(old_val)) return;
+       if (Is_young(old_val)) return;
        /* old is a block and in the major heap */
        caml_darken(0, old_val, 0);
      }
      /* this update is creating a new link from major to minor, remember it */
-     if (Is_block_and_minor(new_val)) {
+     if (Is_block_and_young(new_val)) {
        Ref_table_add(&Caml_state->minor_tables->major_ref, Op_val(obj) + field);
      }
    }
@@ -185,7 +185,7 @@ CAMLexport void caml_initialize_field (value obj, intnat field, value val)
   Assert(0 <= field && field < Wosize_val(obj));
 #ifdef DEBUG
   /* caml_initialize_field can only be used on just-allocated objects */
-  if (Is_minor(obj))
+  if (Is_young(obj))
     Assert(Op_val(obj)[field] == Debug_uninit_minor ||
            Op_val(obj)[field] == Val_unit);
   else
@@ -204,7 +204,7 @@ CAMLexport CAMLweakdef void caml_initialize (value *fp, value val)
 {
 #ifdef DEBUG
   /* caml_initialize_field can only be used on just-allocated objects */
-  if (Is_minor((value)fp))
+  if (Is_young((value)fp))
     Assert(*fp == Debug_uninit_minor ||
            *fp == Val_unit);
   else
@@ -390,10 +390,6 @@ CAMLexport value caml_alloc_shr_noexc(mlsize_t wosize, tag_t tag) {
 #ifdef DEBUG
 header_t hd_val (value v) {
   return (header_t)Hd_val(v);
-}
-
-int is_minor(value v) {
-  return Is_minor(v);
 }
 
 int is_young(value v) {

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -114,11 +114,11 @@ void caml_free_minor_tables(struct caml_minor_tables* r)
 
 #ifdef DEBUG
 extern int caml_debug_is_minor(value val) {
-  return Is_minor(val);
+  return Is_young(val);
 }
 
 extern int caml_debug_is_major(value val) {
-  return Is_block(val) && !Is_minor(val);
+  return Is_block(val) && !Is_young(val);
 }
 #endif
 
@@ -260,7 +260,7 @@ static void oldify_one (void* st_v, value v, value *p)
   tag_t tag;
 
   tail_call:
-  if (!(Is_block(v) && Is_minor(v))) {
+  if (!(Is_block(v) && Is_young(v))) {
     /* not a minor block */
     *p = v;
     return;
@@ -397,7 +397,7 @@ static inline int ephe_check_alive_data (struct caml_ephe_ref_elt *re)
   for (i = CAML_EPHE_FIRST_KEY; i < Wosize_val(re->ephe); i++) {
     child = Op_val(re->ephe)[i];
     if (child != caml_ephe_none
-        && Is_block (child) && Is_minor(child)) {
+        && Is_block (child) && Is_young(child)) {
       resolve_infix_val(&child);
       if (get_header_val(child) != 0) {
         /* value not copied to major heap */
@@ -435,13 +435,13 @@ static void oldify_mopup (struct oldify_state* st, int do_ephemerons)
 
     f = Op_val (new_v)[0];
     CAMLassert (!Is_debug_tag(f));
-    if (Is_block (f) && Is_minor(f)) {
+    if (Is_block (f) && Is_young(f)) {
       oldify_one (st, f, Op_val (new_v));
     }
     for (i = 1; i < Wosize_val (new_v); i++){
       f = Op_val (v)[i];
       CAMLassert (!Is_debug_tag(f));
-      if (Is_block (f) && Is_minor(f)) {
+      if (Is_block (f) && Is_young(f)) {
         oldify_one (st, f, Op_val (new_v) + i);
       } else {
         Op_val (new_v)[i] = f;
@@ -461,7 +461,7 @@ static void oldify_mopup (struct oldify_state* st, int do_ephemerons)
       value *data = re->offset == CAML_EPHE_DATA_OFFSET
               ? &Ephe_data(re->ephe)
               :  &Op_val(re->ephe)[re->offset];
-      if (*data != caml_ephe_none && Is_block(*data) && Is_minor(*data) ) {
+      if (*data != caml_ephe_none && Is_block(*data) && Is_young(*data) ) {
         resolve_infix_val(data);
         if (get_header_val(*data) == 0) { /* Value copied to major heap */
           *data = Op_val(*data)[0];
@@ -609,7 +609,7 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
     // We need to verify that all our remembered set entries are now in the major heap or promoted
     for( r = self_minor_tables->major_ref.base ; r < self_minor_tables->major_ref.ptr ; r++ ) {
       // Everything should be promoted
-      CAMLassert(!Is_minor(*r));
+      CAMLassert(!(Is_block(**r)) || !(Is_young(**r)));
     }
   #endif
 
@@ -617,7 +617,7 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
   caml_ev_begin("minor_gc/finalizers/oldify");
   for (elt = self_minor_tables->custom.base; elt < self_minor_tables->custom.ptr; elt++) {
     value *v = &elt->block;
-    if (Is_block(*v) && Is_minor(*v)) {
+    if (Is_block(*v) && Is_young(*v)) {
       if (get_header_val(*v) == 0) { /* value copied to major heap */
         *v = Op_val(*v)[0];
       } else {
@@ -646,12 +646,12 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
   for (r = self_minor_tables->major_ref.base;
        r < self_minor_tables->major_ref.ptr; r++) {
     value vnew = **r;
-    CAMLassert (!Is_block(vnew) || (get_header_val(vnew) != 0 && !Is_minor(vnew)));
+    CAMLassert (!Is_block(vnew) || (get_header_val(vnew) != 0 && !Is_young(vnew)));
   }
 
   for (elt = self_minor_tables->custom.base; elt < self_minor_tables->custom.ptr; elt++) {
     value vnew = elt->block;
-    CAMLassert (!Is_block(vnew) || (get_header_val(vnew) != 0 && !Is_minor(vnew)));
+    CAMLassert (!Is_block(vnew) || (get_header_val(vnew) != 0 && !Is_young(vnew)));
   }
 #endif
 

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -191,7 +191,7 @@ CAMLprim value caml_obj_force_promote_to (value obj, value upto)
 
 CAMLprim value caml_obj_is_shared (value obj)
 {
-  return Val_int(Is_long(obj) || !Is_minor(obj));
+  return Val_int(Is_long(obj) || !Is_young(obj));
 }
 
 /* The following functions are used in stdlib/lazy.ml.

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -411,7 +411,7 @@ value* caml_shared_try_alloc(struct caml_heap_state* local, mlsize_t wosize,
 
 struct pool* caml_pool_of_shared_block(value v)
 {
-  Assert (Is_block(v) && !Is_minor(v));
+  Assert (Is_block(v) && !Is_young(v));
   mlsize_t whsize = Whsize_wosize(Wosize_val(v));
   if (whsize > 0 && whsize <= SIZECLASS_MAX) {
     return (pool*)((uintnat)v &~(POOL_WSIZE * sizeof(value) - 1));
@@ -630,7 +630,7 @@ void verify_push(void* st_v, value v, value* p)
   struct heap_verify_state* st = st_v;
   if (!Is_block(v)) return;
 
-  if( Is_minor(v) ) {
+  if( Is_young(v) ) {
     caml_gc_log("minor in heap: %p, hd_val: %lx, p: %p", (value*)v, Hd_val(v), p);
     struct domain* domain = caml_owner_of_young_block(v);
     caml_gc_log("owner: %d, young_start: %p, young_end: %p, young_ptr: %p, young_limit: %p", domain->state->id, domain->state->young_start, domain->state->young_end, domain->state->young_ptr, (void *)domain->state->young_limit);
@@ -652,7 +652,7 @@ void caml_verify_root(void* state, value v, value* p)
 static void verify_object(struct heap_verify_state* st, value v) {
   if (!Is_block(v)) return;
 
-  Assert (!Is_minor(v));
+  Assert (!Is_young(v));
   Assert (Hd_val(v));
 
   if (Tag_val(v) == Infix_tag) {
@@ -677,7 +677,7 @@ static void verify_object(struct heap_verify_state* st, value v) {
     int i;
     for (i = 0; i < Wosize_val(v); i++) {
       value f = Op_val(v)[i];
-      if (Is_minor(v) && Is_minor(f)) {
+      if (Is_young(v) && Is_young(f)) {
         Assert(caml_owner_of_young_block(v) ==
                caml_owner_of_young_block(f));
       }

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -111,7 +111,7 @@ static void do_check_key_clean(value e, mlsize_t offset)
 
   value elt = Op_val(e)[offset];
   if (elt != caml_ephe_none && Is_block (elt) &&
-      !Is_minor (elt) && is_unmarked(elt)) {
+      !Is_young (elt) && is_unmarked(elt)) {
     Op_val(e)[offset] = caml_ephe_none;
     Op_val(e)[CAML_EPHE_DATA_OFFSET] = caml_ephe_none;
   }
@@ -139,15 +139,15 @@ void caml_ephe_clean (value v) {
             /* Do not short-circuit the pointer */
           } else {
             Op_val(v)[i] = child = f;
-            if (Is_block (f) && Is_minor (f))
+            if (Is_block (f) && Is_young (f))
               add_to_ephe_ref_table(&Caml_state->minor_tables->ephe_ref, v, i);
             goto ephemeron_again;
           }
         }
       }
 
-      // FIXME: Is_young -> Is_minor here is probably not what we want, fix this.
-      if (!Is_minor (child) && is_unmarked(child)) {
+      // FIXME: Is_young -> Is_young here is probably not what we want, fix this.
+      if (!Is_young (child) && is_unmarked(child)) {
         release_data = 1;
         Op_val(v)[i] = caml_ephe_none;
       }
@@ -174,10 +174,10 @@ static void clean_field (value e, mlsize_t offset)
 
 static void do_set (value e, mlsize_t offset, value v)
 {
-  if (Is_block(v) && Is_minor(v)) {
+  if (Is_block(v) && Is_young(v)) {
     value old = Op_val(e)[offset];
     Op_val(e)[offset] = v;
-    if (!(Is_block(old) && Is_minor(old)))
+    if (!(Is_block(old) && Is_young(old)))
       add_to_ephe_ref_table (&Caml_state->minor_tables->ephe_ref,
                              e, offset);
   } else {

--- a/utils/domainstate.ml.c
+++ b/utils/domainstate.ml.c
@@ -16,8 +16,6 @@
 
 #define CAML_CONFIG_H_NO_TYPEDEFS
 #include "config.h"
-let minor_heap_sel_bits = Minor_heap_sel_bits
-let minor_heap_align_bits = Minor_heap_align_bits
 let stack_ctx_words = Stack_ctx_words
 
 type t =

--- a/utils/domainstate.mli.c
+++ b/utils/domainstate.mli.c
@@ -14,8 +14,6 @@
 /*                                                                        */
 /**************************************************************************/
 
-val minor_heap_sel_bits : int
-val minor_heap_align_bits : int
 val stack_ctx_words : int
 
 type t =


### PR DESCRIPTION
This PR is a first step toward Domain local allocation buffers. (see also #398).
This first step aimed to rewrite the previous bit-twiddling logic of `Minor_heap_sel_bits` and `Minor_heap_align_bits` with a scheme closer to trunk.
The commits are split by duty, starting with the first one is likely the best.


The first commit introduce `Minor_heap_max`, and used this potential maximum size to reserve the minor heaps area.
The minor heaps area is reserved for Max_domains (so `Max_domains * Minor_heap_max`).
Further refactoring is done by removing `Is_minor` and only relying on `Is_young`, which is now a simple bound check (`minor_heaps_base < v < minor_heaps_end`). In parallel minor I believe such distinction is not required anymore.
This specific transition is done in the second commit however.

The third commit introduces a way to override the `Minor_heap_max` setting using `OCAMLRUNPARAM=s`.
This may not be the prettiest solution, and does not align with trunk (`Minor_heap_max` should not be exceeded by the user-configured minor heap.)

Sandmark run: 

![minor_heap_re2](https://user-images.githubusercontent.com/146049/96898617-38757500-1490-11eb-80e4-57970181f374.png)

![minor_heap_re1](https://user-images.githubusercontent.com/146049/96898621-3b706580-1490-11eb-8df5-efa2254ce97f.png)
