### PR TITLE
Replace global roots implementation

### DIFF
--- a/.depend
+++ b/.depend
@@ -1852,8 +1852,10 @@ bytecomp/printinstr.cmx : \
     bytecomp/printinstr.cmi
 bytecomp/printinstr.cmi : \
     bytecomp/instruct.cmi
+bytecomp/runtimedef.cmo :
+bytecomp/runtimedef.cmx :
 bytecomp/symtable.cmo : \
-    lambda/runtimedef.cmi \
+    bytecomp/runtimedef.cmo \
     typing/predef.cmi \
     utils/misc.cmi \
     bytecomp/meta.cmi \
@@ -1868,7 +1870,7 @@ bytecomp/symtable.cmo : \
     parsing/asttypes.cmi \
     bytecomp/symtable.cmi
 bytecomp/symtable.cmx : \
-    lambda/runtimedef.cmx \
+    bytecomp/runtimedef.cmx \
     typing/predef.cmx \
     utils/misc.cmx \
     bytecomp/meta.cmx \
@@ -2047,7 +2049,7 @@ asmcomp/asmlibrarian.cmx : \
     asmcomp/asmlibrarian.cmi
 asmcomp/asmlibrarian.cmi :
 asmcomp/asmlink.cmo : \
-    lambda/runtimedef.cmi \
+    bytecomp/runtimedef.cmo \
     utils/profile.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
@@ -2065,7 +2067,7 @@ asmcomp/asmlink.cmo : \
     asmcomp/asmgen.cmi \
     asmcomp/asmlink.cmi
 asmcomp/asmlink.cmx : \
-    lambda/runtimedef.cmx \
+    bytecomp/runtimedef.cmx \
     utils/profile.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
@@ -5613,6 +5615,7 @@ asmcomp/debug/reg_with_debug_info.cmx : \
 asmcomp/debug/reg_with_debug_info.cmi : \
     asmcomp/reg.cmi \
     middle_end/backend_var.cmi
+driver/compdynlink.cmi :
 driver/compenv.cmo : \
     utils/warnings.cmi \
     utils/profile.cmi \
@@ -5932,13 +5935,13 @@ driver/pparse.cmi : \
     parsing/parsetree.cmi
 toplevel/expunge.cmo : \
     bytecomp/symtable.cmi \
-    lambda/runtimedef.cmi \
+    bytecomp/runtimedef.cmo \
     utils/misc.cmi \
     typing/ident.cmi \
     bytecomp/bytesections.cmi
 toplevel/expunge.cmx : \
     bytecomp/symtable.cmx \
-    lambda/runtimedef.cmx \
+    bytecomp/runtimedef.cmx \
     utils/misc.cmx \
     typing/ident.cmx \
     bytecomp/bytesections.cmx

--- a/ocamltest/.depend
+++ b/ocamltest/.depend
@@ -1,25 +1,28 @@
 run_unix.$(O): run_unix.c run.h ../runtime/caml/misc.h \
-  ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
-  ../runtime/caml/camlatomic.h run_common.h
+ ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
+ ../runtime/caml/camlatomic.h ../runtime/caml/misc.h run_common.h
 run_stubs.$(O): run_stubs.c run.h ../runtime/caml/misc.h \
-  ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
-  ../runtime/caml/camlatomic.h ../runtime/caml/mlvalues.h \
-  ../runtime/caml/domain_state.h ../runtime/caml/domain_state.tbl \
-  ../runtime/caml/byte_domain_state.tbl ../runtime/caml/memory.h \
-  ../runtime/caml/gc.h ../runtime/caml/major_gc.h \
-  ../runtime/caml/minor_gc.h ../runtime/caml/addrmap.h \
-  ../runtime/caml/domain.h ../runtime/caml/platform.h \
-  ../runtime/caml/alloc.h ../runtime/caml/io.h ../runtime/caml/osdeps.h
+ ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
+ ../runtime/caml/camlatomic.h ../runtime/caml/misc.h \
+ ../runtime/caml/mlvalues.h ../runtime/caml/domain_state.h \
+ ../runtime/caml/domain_state.tbl ../runtime/caml/byte_domain_state.tbl \
+ ../runtime/caml/memory.h ../runtime/caml/gc.h ../runtime/caml/mlvalues.h \
+ ../runtime/caml/major_gc.h ../runtime/caml/minor_gc.h \
+ ../runtime/caml/addrmap.h ../runtime/caml/domain.h \
+ ../runtime/caml/memory.h ../runtime/caml/platform.h \
+ ../runtime/caml/alloc.h ../runtime/caml/io.h ../runtime/caml/osdeps.h
 ocamltest_stdlib_stubs.$(O): ocamltest_stdlib_stubs.c \
-  ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
-  ../runtime/caml/mlvalues.h ../runtime/caml/misc.h \
-  ../runtime/caml/camlatomic.h ../runtime/caml/domain_state.h \
-  ../runtime/caml/domain_state.tbl ../runtime/caml/byte_domain_state.tbl \
-  ../runtime/caml/memory.h ../runtime/caml/gc.h \
-  ../runtime/caml/major_gc.h ../runtime/caml/minor_gc.h \
-  ../runtime/caml/addrmap.h ../runtime/caml/domain.h \
-  ../runtime/caml/platform.h ../runtime/caml/alloc.h \
-  ../runtime/caml/signals.h ../runtime/caml/osdeps.h
+ ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
+ ../runtime/caml/mlvalues.h ../runtime/caml/config.h \
+ ../runtime/caml/misc.h ../runtime/caml/camlatomic.h \
+ ../runtime/caml/domain_state.h ../runtime/caml/domain_state.tbl \
+ ../runtime/caml/byte_domain_state.tbl ../runtime/caml/memory.h \
+ ../runtime/caml/gc.h ../runtime/caml/mlvalues.h \
+ ../runtime/caml/major_gc.h ../runtime/caml/minor_gc.h \
+ ../runtime/caml/addrmap.h ../runtime/caml/domain.h \
+ ../runtime/caml/memory.h ../runtime/caml/platform.h \
+ ../runtime/caml/alloc.h ../runtime/caml/alloc.h \
+ ../runtime/caml/signals.h ../runtime/caml/osdeps.h
 actions.cmo : \
     variables.cmi \
     result.cmi \

--- a/otherlibs/raw_spacetime_lib/.depend
+++ b/otherlibs/raw_spacetime_lib/.depend
@@ -1,16 +1,21 @@
 spacetime_offline.$(O): spacetime_offline.c ../../runtime/caml/alloc.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/fail.h \
-  ../../runtime/caml/gc.h ../../runtime/caml/intext.h \
-  ../../runtime/caml/io.h ../../runtime/caml/platform.h \
-  ../../runtime/caml/major_gc.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/roots.h \
-  ../../runtime/caml/signals.h ../../runtime/caml/stack.h \
-  ../../runtime/caml/sys.h ../../runtime/caml/spacetime.h
+ ../../runtime/caml/misc.h ../../runtime/caml/config.h \
+ ../../runtime/caml/m.h ../../runtime/caml/s.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/config.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/gc.h \
+ ../../runtime/caml/intext.h ../../runtime/caml/io.h \
+ ../../runtime/caml/platform.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/minor_gc.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/roots.h \
+ ../../runtime/caml/signals.h ../../runtime/caml/stack.h \
+ ../../runtime/caml/sys.h ../../runtime/caml/spacetime.h \
+ ../../runtime/caml/stack.h ../../runtime/caml/s.h
 raw_spacetime_lib.cmo : \
     raw_spacetime_lib.cmi
 raw_spacetime_lib.cmx : \

--- a/otherlibs/str/.depend
+++ b/otherlibs/str/.depend
@@ -1,11 +1,12 @@
 strstubs.$(O): strstubs.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
-  ../../runtime/caml/fail.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h
 str.cmo : \
     str.cmi
 str.cmx : \

--- a/otherlibs/unix/.depend
+++ b/otherlibs/unix/.depend
@@ -1,766 +1,829 @@
 accept.o: accept.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/signals.h unixsupport.h \
-  socketaddr.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h \
+ socketaddr.h ../../runtime/caml/misc.h
 access.o: access.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
-  ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/memory.h unixsupport.h
 addrofstr.o: addrofstr.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h unixsupport.h socketaddr.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/fail.h unixsupport.h \
+ socketaddr.h ../../runtime/caml/misc.h
 alarm.o: alarm.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
 bind.o: bind.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h socketaddr.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ unixsupport.h socketaddr.h ../../runtime/caml/misc.h
 channels.o: channels.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/io.h \
-  ../../runtime/caml/platform.h ../../runtime/caml/signals.h \
-  unixsupport.h socketaddr.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/io.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/signals.h unixsupport.h socketaddr.h \
+ ../../runtime/caml/misc.h
 chdir.o: chdir.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
-  ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/platform.h \
-  ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
-  ../../runtime/caml/osdeps.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/osdeps.h unixsupport.h
 chmod.o: chmod.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
-  ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/platform.h \
-  ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
-  ../../runtime/caml/osdeps.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/osdeps.h unixsupport.h
 chown.o: chown.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
-  ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h
 chroot.o: chroot.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
-  ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h
 close.o: close.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/signals.h \
-  unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/signals.h \
+ ../../runtime/caml/mlvalues.h unixsupport.h
 closedir.o: closedir.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
-  ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h
 connect.o: connect.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/signals.h \
-  unixsupport.h socketaddr.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/signals.h unixsupport.h socketaddr.h \
+ ../../runtime/caml/misc.h
 cst2constr.o: cst2constr.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/fail.h \
-  cst2constr.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/fail.h \
+ ../../runtime/caml/mlvalues.h cst2constr.h
 cstringv.o: cstringv.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
-  ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/platform.h \
-  ../../runtime/caml/alloc.h ../../runtime/caml/osdeps.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/osdeps.h unixsupport.h
 dup.o: dup.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
 dup2.o: dup2.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
 envir.o: envir.c ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h
+ ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h
 errmsg.o: errmsg.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h
 execv.o: execv.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
-  ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/platform.h \
-  ../../runtime/caml/alloc.h ../../runtime/caml/osdeps.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/osdeps.h unixsupport.h
 execve.o: execve.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
-  ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/platform.h \
-  ../../runtime/caml/alloc.h ../../runtime/caml/osdeps.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/osdeps.h unixsupport.h
 execvp.o: execvp.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
-  ../../runtime/caml/osdeps.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/memory.h unixsupport.h
 exit.o: exit.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
 fchmod.o: fchmod.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/signals.h \
-  unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/signals.h unixsupport.h
 fchown.o: fchown.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/signals.h \
-  unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/signals.h unixsupport.h
 fcntl.o: fcntl.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ unixsupport.h
 fork.o: fork.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/debugger.h \
-  unixsupport.h ../../runtime/caml/domain.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
-  ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
-  ../../runtime/caml/alloc.h ../../runtime/caml/platform.h \
-  ../../runtime/caml/fail.h
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/debugger.h \
+ ../../runtime/caml/mlvalues.h unixsupport.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/fail.h
 fsync.o: fsync.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/signals.h \
-  unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/signals.h \
+ ../../runtime/caml/mlvalues.h unixsupport.h
 ftruncate.o: ftruncate.c ../../runtime/caml/fail.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/io.h \
-  ../../runtime/caml/platform.h ../../runtime/caml/signals.h \
-  unixsupport.h
+ ../../runtime/caml/misc.h ../../runtime/caml/config.h \
+ ../../runtime/caml/m.h ../../runtime/caml/s.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/io.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/signals.h unixsupport.h
 getaddrinfo.o: getaddrinfo.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/signals.h unixsupport.h \
-  cst2constr.h socketaddr.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/signals.h unixsupport.h cst2constr.h socketaddr.h
 getcwd.o: getcwd.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h ../../runtime/caml/osdeps.h \
-  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
-  ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
-  ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
-  ../../runtime/caml/platform.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h unixsupport.h
 getegid.o: getegid.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
 geteuid.o: geteuid.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
 getgid.o: getgid.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
 getgr.o: getgr.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/fail.h \
-  ../../runtime/caml/alloc.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/fail.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h unixsupport.h
 getgroups.o: getgroups.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h unixsupport.h
 gethost.o: gethost.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/signals.h unixsupport.h \
-  socketaddr.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h \
+ socketaddr.h ../../runtime/caml/misc.h
 gethostname.o: gethostname.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h unixsupport.h
 getlogin.o: getlogin.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h unixsupport.h
 getnameinfo.o: getnameinfo.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/signals.h unixsupport.h \
-  socketaddr.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h \
+ socketaddr.h ../../runtime/caml/misc.h
 getpeername.o: getpeername.c ../../runtime/caml/fail.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h socketaddr.h
+ ../../runtime/caml/misc.h ../../runtime/caml/config.h \
+ ../../runtime/caml/m.h ../../runtime/caml/s.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ unixsupport.h socketaddr.h ../../runtime/caml/misc.h
 getpid.o: getpid.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
 getppid.o: getppid.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
 getproto.o: getproto.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h unixsupport.h
 getpw.o: getpw.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
-  ../../runtime/caml/fail.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h unixsupport.h
 getserv.o: getserv.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h unixsupport.h
 getsockname.o: getsockname.c ../../runtime/caml/fail.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h socketaddr.h
+ ../../runtime/caml/misc.h ../../runtime/caml/config.h \
+ ../../runtime/caml/m.h ../../runtime/caml/s.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ unixsupport.h socketaddr.h ../../runtime/caml/misc.h
 gettimeofday.o: gettimeofday.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h unixsupport.h
 getuid.o: getuid.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
 gmtime.o: gmtime.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h unixsupport.h
 initgroups.o: initgroups.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h unixsupport.h
 isatty.o: isatty.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
 itimer.o: itimer.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h unixsupport.h
 kill.o: kill.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/fail.h \
-  unixsupport.h ../../runtime/caml/signals.h
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/fail.h \
+ ../../runtime/caml/mlvalues.h unixsupport.h ../../runtime/caml/signals.h
 link.o: link.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
-  ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h
 listen.o: listen.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ unixsupport.h
 lockf.o: lockf.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/signals.h \
-  unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/signals.h unixsupport.h
 lseek.o: lseek.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/io.h ../../runtime/caml/platform.h \
-  ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/io.h \
+ ../../runtime/caml/platform.h ../../runtime/caml/signals.h unixsupport.h
 mkdir.o: mkdir.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
-  ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h
 mkfifo.o: mkfifo.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
-  ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h
 mmap.o: mmap.c ../../runtime/caml/bigarray.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/mlvalues.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/fail.h \
-  ../../runtime/caml/io.h ../../runtime/caml/platform.h \
-  ../../runtime/caml/signals.h ../../runtime/caml/sys.h unixsupport.h
+ ../../runtime/caml/m.h ../../runtime/caml/s.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/fail.h \
+ ../../runtime/caml/io.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/sys.h unixsupport.h
 mmap_ba.o: mmap_ba.c ../../runtime/caml/alloc.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/bigarray.h \
-  ../../runtime/caml/custom.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
-  ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/platform.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/bigarray.h \
+ ../../runtime/caml/custom.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/platform.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/misc.h
 nice.o: nice.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
 open.o: open.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
-  ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/misc.h ../../runtime/caml/signals.h unixsupport.h
 opendir.o: opendir.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
-  ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/signals.h unixsupport.h
 pipe.o: pipe.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  unixsupport.h
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h unixsupport.h
 putenv.o: putenv.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
-  ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/platform.h \
-  ../../runtime/caml/alloc.h ../../runtime/caml/osdeps.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/platform.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/osdeps.h unixsupport.h
 read.o: read.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
-  ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h
 readdir.o: readdir.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/fail.h \
-  ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/fail.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/signals.h unixsupport.h
 readlink.o: readlink.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/signals.h unixsupport.h
 rename.o: rename.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
-  ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h
 rewinddir.o: rewinddir.c ../../runtime/caml/fail.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/misc.h ../../runtime/caml/config.h \
+ ../../runtime/caml/m.h ../../runtime/caml/s.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ unixsupport.h
 rmdir.o: rmdir.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
-  ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/platform.h \
-  ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
-  ../../runtime/caml/osdeps.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/osdeps.h unixsupport.h
 select.o: select.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h
 sendrecv.o: sendrecv.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/signals.h unixsupport.h \
-  socketaddr.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h \
+ socketaddr.h ../../runtime/caml/misc.h
 setgid.o: setgid.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
 setgroups.o: setgroups.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h unixsupport.h
 setsid.o: setsid.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ unixsupport.h
 setuid.o: setuid.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
 shutdown.o: shutdown.c ../../runtime/caml/fail.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/misc.h ../../runtime/caml/config.h \
+ ../../runtime/caml/m.h ../../runtime/caml/s.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ unixsupport.h
 signals.o: signals.c ../../runtime/caml/alloc.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/fail.h \
-  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
-  ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
-  ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
-  ../../runtime/caml/platform.h ../../runtime/caml/signals.h \
-  unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/signals.h unixsupport.h
 sleep.o: sleep.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/signals.h \
-  unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/signals.h \
+ ../../runtime/caml/mlvalues.h unixsupport.h
 socket.o: socket.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ unixsupport.h
 socketaddr.o: socketaddr.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/memory.h ../../runtime/caml/domain.h unixsupport.h \
-  socketaddr.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/alloc.h unixsupport.h \
+ socketaddr.h ../../runtime/caml/misc.h
 socketpair.o: socketpair.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h unixsupport.h
 sockopt.o: sockopt.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h unixsupport.h socketaddr.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h unixsupport.h socketaddr.h \
+ ../../runtime/caml/misc.h
 spawn.o: spawn.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h unixsupport.h
 stat.o: stat.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
-  ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/platform.h \
-  ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
-  ../../runtime/caml/io.h unixsupport.h cst2constr.h nanosecond_stat.h
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/signals.h ../../runtime/caml/io.h unixsupport.h \
+ cst2constr.h nanosecond_stat.h
 strofaddr.o: strofaddr.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h unixsupport.h socketaddr.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h unixsupport.h \
+ socketaddr.h ../../runtime/caml/misc.h
 symlink.o: symlink.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
-  ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h
 termios.o: termios.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h unixsupport.h
 time.o: time.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  unixsupport.h
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h unixsupport.h
 times.o: times.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/memory.h ../../runtime/caml/domain.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/alloc.h unixsupport.h
 truncate.o: truncate.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
-  ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/platform.h \
-  ../../runtime/caml/alloc.h ../../runtime/caml/fail.h \
-  ../../runtime/caml/signals.h ../../runtime/caml/io.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/signals.h ../../runtime/caml/io.h unixsupport.h
 umask.o: umask.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
 unixsupport.o: unixsupport.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/callback.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/fail.h unixsupport.h \
-  cst2constr.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/callback.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/fail.h unixsupport.h cst2constr.h
 unlink.o: unlink.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
-  ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/platform.h \
-  ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
-  ../../runtime/caml/osdeps.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/osdeps.h unixsupport.h
 utimes.o: utimes.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
-  ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/platform.h \
-  ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
-  ../../runtime/caml/osdeps.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/osdeps.h unixsupport.h
 wait.o: wait.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
-  ../../runtime/caml/m.h ../../runtime/caml/s.h \
-  ../../runtime/caml/misc.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
-  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
-  ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/platform.h \
-  ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h
 write.o: write.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
-  ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h
 unix.cmo : \
     unix.cmi
 unix.cmx : \

--- a/otherlibs/win32unix/.depend
+++ b/otherlibs/win32unix/.depend
@@ -1,21 +1,675 @@
+accept.$(O): accept.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/signals.h unixsupport.h socketaddr.h \
+ ../../runtime/caml/misc.h
+bind.$(O): bind.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h socketaddr.h \
+ ../../runtime/caml/misc.h
+channels.$(O): channels.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/io.h \
+ ../../runtime/caml/platform.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/alloc.h unixsupport.h
+close.$(O): close.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h \
+ ../../runtime/caml/io.h
+close_on.$(O): close_on.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+connect.$(O): connect.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/signals.h \
+ ../../runtime/caml/mlvalues.h unixsupport.h socketaddr.h \
+ ../../runtime/caml/misc.h
+createprocess.$(O): createprocess.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h unixsupport.h ../../runtime/caml/osdeps.h
+dup.$(O): dup.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+dup2.$(O): dup2.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+errmsg.$(O): errmsg.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/platform.h ../../runtime/caml/alloc.h unixsupport.h
+envir.$(O): envir.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/platform.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/osdeps.h
+getpeername.$(O): getpeername.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h socketaddr.h \
+ ../../runtime/caml/misc.h
+getpid.$(O): getpid.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+getsockname.$(O): getsockname.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h socketaddr.h \
+ ../../runtime/caml/misc.h
+gettimeofday.$(O): gettimeofday.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h unixsupport.h
+isatty.$(O): isatty.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h unixsupport.h
+link.$(O): link.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/fail.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/platform.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/osdeps.h unixsupport.h
+listen.$(O): listen.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+lockf.$(O): lockf.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/fail.h unixsupport.h \
+ ../../runtime/caml/signals.h
+lseek.$(O): lseek.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h unixsupport.h
+nonblock.$(O): nonblock.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/signals.h \
+ ../../runtime/caml/mlvalues.h unixsupport.h
+mkdir.$(O): mkdir.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/memory.h unixsupport.h
+mmap.$(O): mmap.c ../../runtime/caml/alloc.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/bigarray.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/io.h \
+ ../../runtime/caml/platform.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/signals.h ../../runtime/caml/sys.h \
+ ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/alloc.h unixsupport.h
+open.$(O): open.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/platform.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/memory.h unixsupport.h
+pipe.$(O): pipe.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/alloc.h unixsupport.h
+read.$(O): read.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h
+readlink.$(O): readlink.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/osdeps.h unixsupport.h
+rename.$(O): rename.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/memory.h unixsupport.h
+select.$(O): select.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/signals.h winworker.h \
+ unixsupport.h windbug.h winlist.h
+sendrecv.$(O): sendrecv.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/signals.h unixsupport.h socketaddr.h \
+ ../../runtime/caml/misc.h
+shutdown.$(O): shutdown.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+sleep.$(O): sleep.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/signals.h \
+ ../../runtime/caml/mlvalues.h unixsupport.h
+socket.$(O): socket.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+sockopt.$(O): sockopt.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h unixsupport.h socketaddr.h \
+ ../../runtime/caml/misc.h
+startup.$(O): startup.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl winworker.h unixsupport.h \
+ windbug.h
+stat.$(O): stat.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h unixsupport.h \
+ ../unix/cst2constr.h
+symlink.$(O): symlink.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/osdeps.h unixsupport.h
+system.$(O): system.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h unixsupport.h
+times.$(O): times.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h unixsupport.h
+truncate.$(O): truncate.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/signals.h ../../runtime/caml/io.h \
+ ../../runtime/caml/osdeps.h unixsupport.h
+unixsupport.$(O): unixsupport.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/callback.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/custom.h unixsupport.h \
+ ../unix/cst2constr.h
+windir.$(O): windir.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/osdeps.h unixsupport.h
+winwait.$(O): winwait.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/signals.h unixsupport.h
+write.$(O): write.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h
+winlist.$(O): winlist.c winlist.h
+winworker.$(O): winworker.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/signals.h winworker.h unixsupport.h winlist.h \
+ windbug.h
 windbug.$(O): windbug.c windbug.h
+utimes.$(O): utimes.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/osdeps.h unixsupport.h
+access.$(O): access.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/memory.h unixsupport.h
+addrofstr.$(O): addrofstr.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/fail.h unixsupport.h \
+ socketaddr.h ../../runtime/caml/misc.h
+chdir.$(O): chdir.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/osdeps.h unixsupport.h
+chmod.$(O): chmod.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/osdeps.h unixsupport.h
 cst2constr.$(O): cst2constr.c ../../runtime/caml/mlvalues.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/fail.h \
-  ../unix/cst2constr.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/fail.h \
+ ../../runtime/caml/mlvalues.h ../unix/cst2constr.h
+cstringv.$(O): cstringv.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/osdeps.h unixsupport.h
+execv.$(O): execv.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/osdeps.h unixsupport.h
+execve.$(O): execve.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/osdeps.h unixsupport.h
+execvp.$(O): execvp.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/memory.h unixsupport.h
+exit.$(O): exit.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl unixsupport.h
+getaddrinfo.$(O): getaddrinfo.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/signals.h unixsupport.h ../unix/cst2constr.h \
+ socketaddr.h
+getcwd.$(O): getcwd.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h unixsupport.h
+gethost.$(O): gethost.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h \
+ socketaddr.h ../../runtime/caml/misc.h
+gethostname.$(O): gethostname.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h unixsupport.h
+getnameinfo.$(O): getnameinfo.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h \
+ socketaddr.h ../../runtime/caml/misc.h
+getproto.$(O): getproto.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h unixsupport.h
+getserv.$(O): getserv.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h unixsupport.h
+gmtime.$(O): gmtime.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/alloc.h unixsupport.h
 mmap_ba.$(O): mmap_ba.c ../../runtime/caml/alloc.h ../../runtime/caml/misc.h \
-  ../../runtime/caml/config.h ../../runtime/caml/m.h \
-  ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
-  ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
-  ../../runtime/caml/domain_state.tbl \
-  ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/bigarray.h \
-  ../../runtime/caml/custom.h ../../runtime/caml/memory.h \
-  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
-  ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
-  ../../runtime/caml/domain.h ../../runtime/caml/platform.h
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/bigarray.h \
+ ../../runtime/caml/custom.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/platform.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/misc.h
+putenv.$(O): putenv.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/camlatomic.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/minor_gc.h ../../runtime/caml/addrmap.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/platform.h ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/osdeps.h unixsupport.h
+rmdir.$(O): rmdir.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/osdeps.h unixsupport.h
+socketaddr.$(O): socketaddr.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/alloc.h unixsupport.h \
+ socketaddr.h ../../runtime/caml/misc.h
+strofaddr.$(O): strofaddr.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/fail.h unixsupport.h \
+ socketaddr.h ../../runtime/caml/misc.h
+time.$(O): time.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/mlvalues.h unixsupport.h
+unlink.$(O): unlink.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
+ ../../runtime/caml/addrmap.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/platform.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/osdeps.h unixsupport.h
+fsync.$(O): fsync.c ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/config.h ../../runtime/caml/m.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/camlatomic.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl \
+ ../../runtime/caml/byte_domain_state.tbl ../../runtime/caml/signals.h \
+ ../../runtime/caml/mlvalues.h unixsupport.h
 unix.cmo : \
     unix.cmi
 unix.cmx : \

--- a/runtime/.depend
+++ b/runtime/.depend
@@ -1,2911 +1,3384 @@
 addrmap_b.$(O): addrmap.c caml/config.h caml/m.h caml/s.h caml/memory.h \
-  caml/domain.h caml/misc.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/alloc.h caml/addrmap.h
-afl_b.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/osdeps.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h
+ caml/config.h caml/domain.h caml/misc.h caml/camlatomic.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/alloc.h caml/addrmap.h
+afl_b.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/osdeps.h \
+ caml/memory.h caml/gc.h caml/mlvalues.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h
 alloc_b.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/major_gc.h caml/memory.h caml/gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/fiber.h caml/roots.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/platform.h caml/alloc.h \
+ caml/mlvalues.h caml/fiber.h caml/roots.h caml/domain.h
 array_b.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/signals.h caml/spacetime.h \
-  caml/io.h caml/stack.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
 backtrace_b.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
-  caml/fail.h caml/debugger.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
 backtrace_byt_b.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/alloc.h \
-  caml/custom.h caml/io.h caml/platform.h caml/instruct.h caml/intext.h \
-  caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/startup.h \
-  caml/startup_aux.h caml/fiber.h caml/roots.h caml/sys.h \
-  caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/debugger.h
+ caml/mlvalues.h caml/config.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/alloc.h caml/mlvalues.h caml/custom.h caml/io.h caml/platform.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/exec.h caml/fix_code.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/startup.h caml/exec.h \
+ caml/startup_aux.h caml/fiber.h caml/roots.h caml/sys.h caml/backtrace.h \
+ caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
 backtrace_nat_b.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/backtrace.h caml/exec.h caml/backtrace_prim.h frame_descriptors.h \
-  caml/stack.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/fiber.h caml/roots.h \
-  caml/fail.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/backtrace.h \
+ caml/exec.h caml/backtrace_prim.h caml/backtrace.h frame_descriptors.h \
+ caml/config.h caml/stack.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/misc.h caml/mlvalues.h caml/fiber.h \
+ caml/roots.h caml/fail.h
 bigarray_b.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/bigarray.h \
-  caml/custom.h caml/fail.h caml/intext.h caml/io.h caml/platform.h \
-  caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/signals.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/bigarray.h \
+ caml/custom.h caml/fail.h caml/intext.h caml/io.h caml/platform.h \
+ caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/mlvalues.h \
+ caml/signals.h
 callback_b.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/fail.h caml/fiber.h caml/roots.h \
-  caml/interp.h caml/instruct.h caml/fix_code.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/fail.h caml/memory.h caml/mlvalues.h \
+ caml/platform.h caml/fiber.h caml/roots.h caml/interp.h caml/instruct.h \
+ caml/fix_code.h
 clambda_checks_b.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl
+ caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl
 compare_b.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h
+ caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h
 custom_b.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/shared_heap.h caml/roots.h caml/signals.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/mlvalues.h caml/shared_heap.h \
+ caml/roots.h caml/signals.h
 debugger_b.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/debugger.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/osdeps.h caml/fail.h \
-  caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/fiber.h \
-  caml/roots.h caml/sys.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/debugger.h caml/misc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/osdeps.h caml/fail.h caml/fix_code.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
+ caml/fiber.h caml/roots.h caml/sys.h
 domain_b.$(O): domain.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/platform.h caml/custom.h caml/shared_heap.h caml/roots.h \
-  caml/fail.h caml/globroots.h caml/signals.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h caml/fiber.h caml/callback.h caml/eventlog.h \
-  caml/gc_ctrl.h caml/osdeps.h caml/weak.h caml/finalise.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/alloc.h caml/platform.h caml/domain_state.h \
+ caml/platform.h caml/custom.h caml/major_gc.h caml/shared_heap.h \
+ caml/roots.h caml/memory.h caml/fail.h caml/globroots.h caml/signals.h \
+ caml/startup.h caml/exec.h caml/startup_aux.h caml/fiber.h \
+ caml/callback.h caml/minor_gc.h caml/eventlog.h caml/gc_ctrl.h \
+ caml/osdeps.h caml/weak.h caml/finalise.h
 dynlink_b.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/dynlink.h \
-  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/osdeps.h \
-  caml/prims.h caml/signals.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/dynlink.h caml/fail.h caml/mlvalues.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/osdeps.h \
+ caml/prims.h caml/signals.h
 dynlink_nat_b.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/stack.h caml/callback.h \
-  caml/intext.h caml/io.h caml/osdeps.h caml/fail.h frame_descriptors.h \
-  caml/globroots.h caml/roots.h caml/signals.h caml/hooks.h
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/stack.h \
+ caml/callback.h caml/alloc.h caml/intext.h caml/io.h caml/osdeps.h \
+ caml/fail.h frame_descriptors.h caml/config.h caml/globroots.h \
+ caml/roots.h caml/signals.h caml/hooks.h
 eventlog_b.$(O): eventlog.c caml/domain.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/alloc.h \
-  caml/platform.h caml/eventlog.h caml/osdeps.h caml/startup_aux.h
+ caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/platform.h caml/eventlog.h caml/osdeps.h \
+ caml/platform.h caml/startup_aux.h
 extern_b.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/platform.h \
-  caml/md5.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/reverse.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/custom.h caml/fail.h caml/gc.h caml/intext.h caml/io.h \
+ caml/platform.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h caml/reverse.h \
+ caml/addrmap.h
 fail_byt_b.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/fail.h caml/io.h caml/printexc.h \
-  caml/signals.h caml/fiber.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/fail.h caml/gc.h \
+ caml/io.h caml/memory.h caml/misc.h caml/mlvalues.h caml/printexc.h \
+ caml/signals.h caml/fiber.h caml/roots.h
 fail_nat_b.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/io.h \
-  caml/platform.h caml/gc.h caml/memory.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/printexc.h \
-  caml/signals.h caml/stack.h caml/roots.h caml/callback.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/io.h \
+ caml/platform.h caml/gc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h \
+ caml/mlvalues.h caml/printexc.h caml/signals.h caml/stack.h caml/roots.h \
+ caml/callback.h
 fiber_b.$(O): fiber.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/fiber.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h caml/gc_ctrl.h \
-  caml/instruct.h caml/fail.h caml/fix_code.h caml/shared_heap.h \
-  caml/startup_aux.h
+ caml/camlatomic.h caml/misc.h caml/fiber.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/roots.h caml/gc_ctrl.h \
+ caml/instruct.h caml/fail.h caml/alloc.h caml/platform.h caml/fix_code.h \
+ caml/minor_gc.h caml/major_gc.h caml/shared_heap.h caml/memory.h \
+ caml/startup_aux.h
 finalise_b.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/eventlog.h caml/fail.h \
-  caml/finalise.h caml/roots.h caml/shared_heap.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/eventlog.h caml/fail.h caml/finalise.h \
+ caml/roots.h caml/memory.h caml/minor_gc.h caml/misc.h caml/roots.h \
+ caml/shared_heap.h
 fix_code_b.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fix_code.h \
-  caml/instruct.h caml/intext.h caml/io.h caml/platform.h caml/md5.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/alloc.h caml/reverse.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/platform.h \
+ caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h caml/reverse.h
 floats_b.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/reverse.h caml/fiber.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/fiber.h caml/roots.h
 frame_descriptors_b.$(O): frame_descriptors.c frame_descriptors.h \
-  caml/config.h caml/m.h caml/s.h caml/platform.h caml/mlvalues.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/major_gc.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/alloc.h
+ caml/config.h caml/m.h caml/s.h caml/platform.h caml/mlvalues.h \
+ caml/config.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/major_gc.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h
 gc_ctrl_b.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/gc_ctrl.h caml/shared_heap.h caml/fiber.h caml/globroots.h \
-  caml/signals.h caml/startup.h caml/exec.h caml/startup_aux.h \
-  caml/eventlog.h caml/fail.h
-globroots_b.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
-  caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h caml/globroots.h \
-  caml/callback.h caml/shared_heap.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/minor_gc.h \
+ caml/shared_heap.h caml/misc.h caml/mlvalues.h caml/fiber.h \
+ caml/domain.h caml/globroots.h caml/signals.h caml/startup.h caml/exec.h \
+ caml/startup_aux.h caml/eventlog.h caml/fail.h
+globroots_b.$(O): globroots.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/roots.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/globroots.h caml/roots.h \
+ caml/skiplist.h caml/stack.h
 hash_b.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/hash.h caml/fail.h
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/custom.h caml/mlvalues.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/hash.h caml/fail.h
 instrtrace_b.$(O): instrtrace.c
 intern_b.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/custom.h caml/fail.h caml/intext.h \
-  caml/io.h caml/md5.h caml/reverse.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/config.h caml/custom.h \
+ caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h \
+ caml/memory.h caml/mlvalues.h caml/misc.h caml/reverse.h
 interp_b.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/backtrace.h \
-  caml/exec.h caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
-  caml/instruct.h caml/interp.h caml/prims.h caml/signals.h caml/fiber.h \
-  caml/roots.h caml/globroots.h caml/startup.h caml/startup_aux.h \
-  caml/jumptbl.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/backtrace.h \
+ caml/exec.h caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/debugger.h caml/fail.h caml/fix_code.h \
+ caml/instrtrace.h caml/instruct.h caml/interp.h caml/major_gc.h \
+ caml/memory.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
+ caml/fiber.h caml/roots.h caml/domain.h caml/globroots.h caml/startup.h \
+ caml/startup_aux.h caml/startup_aux.h caml/jumptbl.h
 ints_b.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/intext.h caml/io.h caml/platform.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/fail.h caml/intext.h caml/io.h caml/platform.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h
 io_b.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/io.h caml/platform.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/osdeps.h caml/signals.h caml/sys.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/fail.h caml/io.h caml/platform.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/signals.h caml/sys.h
 lexing_b.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fiber.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/mlvalues.h \
+ caml/fiber.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h caml/roots.h
 main_b.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/sys.h \
-  caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/sys.h \
+ caml/osdeps.h caml/memory.h caml/gc.h caml/mlvalues.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h
 major_gc_b.$(O): major_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/alloc.h \
-  caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h \
-  caml/finalise.h caml/globroots.h caml/shared_heap.h caml/startup_aux.h \
-  caml/weak.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/domain.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/alloc.h caml/platform.h \
+ caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h caml/finalise.h \
+ caml/globroots.h caml/memory.h caml/mlvalues.h caml/platform.h \
+ caml/roots.h caml/shared_heap.h caml/startup_aux.h caml/weak.h
 md5_b.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/md5.h caml/io.h caml/platform.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/reverse.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/md5.h \
+ caml/io.h caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
 memory_b.$(O): memory.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/fail.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/shared_heap.h caml/roots.h \
-  caml/fiber.h caml/eventlog.h
+ caml/config.h caml/camlatomic.h caml/misc.h caml/fail.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/major_gc.h \
+ caml/shared_heap.h caml/roots.h caml/domain.h caml/addrmap.h \
+ caml/roots.h caml/alloc.h caml/fiber.h caml/platform.h caml/eventlog.h
 memprof_b.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/roots.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/fail.h caml/callback.h \
-  caml/signals.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
-  caml/weak.h caml/stack.h
+ caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/fail.h caml/alloc.h \
+ caml/callback.h caml/signals.h caml/memory.h caml/minor_gc.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
+ caml/stack.h caml/misc.h
 meta_b.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/fix_code.h caml/interp.h caml/intext.h caml/io.h caml/platform.h \
-  caml/major_gc.h caml/memory.h caml/gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/prims.h caml/fiber.h caml/roots.h \
-  caml/startup_aux.h caml/debugger.h caml/backtrace_prim.h \
-  caml/backtrace.h caml/exec.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h caml/io.h \
+ caml/platform.h caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/fiber.h \
+ caml/roots.h caml/startup_aux.h caml/debugger.h caml/backtrace_prim.h \
+ caml/backtrace.h caml/exec.h
 minor_gc_b.$(O): minor_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/domain.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/alloc.h caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h \
-  caml/roots.h caml/finalise.h caml/gc_ctrl.h caml/shared_heap.h \
-  caml/signals.h caml/startup_aux.h caml/weak.h
-misc_b.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/memory.h caml/gc.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/osdeps.h caml/version.h \
-  caml/startup.h caml/exec.h caml/startup_aux.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/custom.h caml/domain.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/alloc.h \
+ caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h \
+ caml/finalise.h caml/gc.h caml/gc_ctrl.h caml/globroots.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/platform.h caml/roots.h caml/shared_heap.h \
+ caml/signals.h caml/startup_aux.h caml/weak.h
+misc_b.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/camlatomic.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/osdeps.h caml/version.h \
+ caml/domain.h caml/startup.h caml/exec.h caml/startup_aux.h \
+ caml/startup_aux.h
 obj_b.$(O): obj.c caml/camlatomic.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/alloc.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/gc.h \
-  caml/interp.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/prims.h \
-  caml/spacetime.h caml/io.h caml/stack.h
+ caml/misc.h caml/camlatomic.h caml/alloc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/platform.h caml/spacetime.h caml/io.h \
+ caml/stack.h
 parsing_b.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h
+ caml/config.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/alloc.h \
+ caml/startup.h caml/exec.h caml/startup_aux.h
 platform_b.$(O): platform.c caml/platform.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h
 prims_b.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/prims.h
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/prims.h
 printexc_b.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/exec.h \
-  caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/debugger.h caml/fail.h caml/printexc.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/exec.h \
+ caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h \
+ caml/debugger.h caml/fail.h caml/misc.h caml/mlvalues.h caml/printexc.h \
+ caml/memory.h
 roots_b.$(O): roots.c caml/finalise.h caml/roots.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/memory.h caml/gc.h \
-  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
-  caml/byte_domain_state.tbl caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h \
-  caml/globroots.h caml/shared_heap.h caml/fiber.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/shared_heap.h caml/fiber.h
 shared_heap_b.$(O): shared_heap.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/fiber.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/domain.h caml/platform.h caml/alloc.h \
-  caml/roots.h caml/globroots.h caml/shared_heap.h caml/sizeclasses.h \
-  caml/startup_aux.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/fail.h caml/fiber.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/roots.h caml/gc.h caml/globroots.h caml/memory.h \
+ caml/mlvalues.h caml/platform.h caml/roots.h caml/shared_heap.h \
+ caml/sizeclasses.h caml/startup_aux.h
 signals_b.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/fail.h caml/roots.h caml/signals.h \
-  caml/sys.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/config.h caml/fail.h \
+ caml/memory.h caml/misc.h caml/mlvalues.h caml/roots.h caml/signals.h \
+ caml/sys.h
 signals_byt_b.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/osdeps.h caml/signals.h
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/platform.h caml/alloc.h \
+ caml/osdeps.h caml/signals.h
 signals_nat_b.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/osdeps.h \
-  caml/signals.h caml/stack.h caml/spacetime.h caml/io.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/osdeps.h caml/domain.h \
+ caml/signals.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h
+skiplist_b.$(O): skiplist.c caml/config.h caml/m.h caml/s.h caml/memory.h \
+ caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/skiplist.h
 spacetime_byt_b.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/mlvalues.h
 spacetime_nat_b.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
-  caml/alloc.h caml/misc.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/platform.h \
-  caml/major_gc.h caml/memory.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/osdeps.h caml/roots.h caml/signals.h caml/stack.h \
-  caml/sys.h caml/spacetime.h
+ caml/alloc.h caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/platform.h \
+ caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/osdeps.h caml/roots.h caml/signals.h \
+ caml/stack.h caml/sys.h caml/spacetime.h caml/stack.h
 spacetime_snapshot_b.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
-  caml/config.h caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h caml/intext.h \
-  caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/roots.h \
-  caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h
+ caml/config.h caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
+ caml/intext.h caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 startup_aux_b.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/exec.h caml/dynlink.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/callback.h caml/osdeps.h caml/prims.h \
-  caml/startup_aux.h caml/version.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/exec.h caml/dynlink.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/callback.h caml/major_gc.h caml/misc.h \
+ caml/osdeps.h caml/prims.h caml/startup_aux.h caml/version.h
 startup_byt_b.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/backtrace.h \
-  caml/exec.h caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/custom.h caml/debugger.h caml/dynlink.h caml/eventlog.h \
-  caml/fail.h caml/fix_code.h caml/gc_ctrl.h caml/instrtrace.h \
-  caml/interp.h caml/intext.h caml/io.h caml/osdeps.h caml/startup_aux.h \
-  caml/prims.h caml/printexc.h caml/reverse.h caml/signals.h \
-  caml/fiber.h caml/roots.h caml/sys.h caml/startup.h caml/version.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/backtrace.h caml/exec.h caml/callback.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/custom.h caml/debugger.h \
+ caml/domain_state.h caml/dynlink.h caml/eventlog.h caml/exec.h \
+ caml/fail.h caml/fix_code.h caml/gc_ctrl.h caml/instrtrace.h \
+ caml/interp.h caml/intext.h caml/io.h caml/io.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/startup_aux.h caml/prims.h caml/printexc.h caml/reverse.h \
+ caml/signals.h caml/fiber.h caml/roots.h caml/sys.h caml/startup.h \
+ caml/startup_aux.h caml/version.h
 startup_nat_b.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/backtrace.h \
-  caml/exec.h caml/custom.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
-  caml/intext.h caml/io.h caml/osdeps.h caml/printexc.h caml/stack.h \
-  caml/sys.h caml/startup_aux.h caml/fiber.h caml/roots.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h \
+ caml/custom.h caml/debugger.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
+ caml/intext.h caml/io.h caml/memory.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/printexc.h caml/stack.h caml/sys.h caml/startup_aux.h \
+ caml/fiber.h caml/roots.h
 str_b.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h \
+ caml/misc.h
 sys_b.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/debugger.h \
-  caml/fail.h caml/gc_ctrl.h caml/io.h caml/platform.h caml/osdeps.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/signals.h caml/fiber.h caml/roots.h caml/sys.h \
-  caml/startup.h caml/exec.h caml/startup_aux.h caml/version.h \
-  caml/callback.h caml/shared_heap.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/debugger.h \
+ caml/fail.h caml/gc_ctrl.h caml/io.h caml/platform.h caml/mlvalues.h \
+ caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/alloc.h caml/signals.h caml/fiber.h \
+ caml/roots.h caml/sys.h caml/startup.h caml/exec.h caml/startup_aux.h \
+ caml/version.h caml/callback.h caml/startup_aux.h caml/major_gc.h \
+ caml/shared_heap.h
 unix_b.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/osdeps.h caml/signals.h caml/sys.h \
-  caml/io.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/osdeps.h \
+ caml/signals.h caml/sys.h caml/io.h caml/alloc.h
 weak_b.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/platform.h caml/fail.h caml/shared_heap.h caml/roots.h \
-  caml/weak.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/alloc.h caml/platform.h caml/fail.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/shared_heap.h caml/roots.h \
+ caml/weak.h
+win32_b.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/address_class.h \
+ caml/fail.h caml/io.h caml/platform.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/misc.h caml/osdeps.h caml/signals.h \
+ caml/sys.h caml/config.h
 addrmap_bd.$(O): addrmap.c caml/config.h caml/m.h caml/s.h caml/memory.h \
-  caml/domain.h caml/misc.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/alloc.h caml/addrmap.h
-afl_bd.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/osdeps.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h
+ caml/config.h caml/domain.h caml/misc.h caml/camlatomic.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/alloc.h caml/addrmap.h
+afl_bd.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/osdeps.h \
+ caml/memory.h caml/gc.h caml/mlvalues.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h
 alloc_bd.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/major_gc.h caml/memory.h caml/gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/fiber.h caml/roots.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/platform.h caml/alloc.h \
+ caml/mlvalues.h caml/fiber.h caml/roots.h caml/domain.h
 array_bd.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/signals.h caml/spacetime.h \
-  caml/io.h caml/stack.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
 backtrace_bd.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
-  caml/fail.h caml/debugger.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
 backtrace_byt_bd.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/alloc.h \
-  caml/custom.h caml/io.h caml/platform.h caml/instruct.h caml/intext.h \
-  caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/startup.h \
-  caml/startup_aux.h caml/fiber.h caml/roots.h caml/sys.h \
-  caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/debugger.h
+ caml/mlvalues.h caml/config.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/alloc.h caml/mlvalues.h caml/custom.h caml/io.h caml/platform.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/exec.h caml/fix_code.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/startup.h caml/exec.h \
+ caml/startup_aux.h caml/fiber.h caml/roots.h caml/sys.h caml/backtrace.h \
+ caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
 backtrace_nat_bd.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/backtrace.h caml/exec.h caml/backtrace_prim.h frame_descriptors.h \
-  caml/stack.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/fiber.h caml/roots.h \
-  caml/fail.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/backtrace.h \
+ caml/exec.h caml/backtrace_prim.h caml/backtrace.h frame_descriptors.h \
+ caml/config.h caml/stack.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/misc.h caml/mlvalues.h caml/fiber.h \
+ caml/roots.h caml/fail.h
 bigarray_bd.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/bigarray.h \
-  caml/custom.h caml/fail.h caml/intext.h caml/io.h caml/platform.h \
-  caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/signals.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/bigarray.h \
+ caml/custom.h caml/fail.h caml/intext.h caml/io.h caml/platform.h \
+ caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/mlvalues.h \
+ caml/signals.h
 callback_bd.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/fail.h caml/fiber.h caml/roots.h \
-  caml/interp.h caml/instruct.h caml/fix_code.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/fail.h caml/memory.h caml/mlvalues.h \
+ caml/platform.h caml/fiber.h caml/roots.h caml/interp.h caml/instruct.h \
+ caml/fix_code.h
 clambda_checks_bd.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl
+ caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl
 compare_bd.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h
+ caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h
 custom_bd.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/shared_heap.h caml/roots.h caml/signals.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/mlvalues.h caml/shared_heap.h \
+ caml/roots.h caml/signals.h
 debugger_bd.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/debugger.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/osdeps.h caml/fail.h \
-  caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/fiber.h \
-  caml/roots.h caml/sys.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/debugger.h caml/misc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/osdeps.h caml/fail.h caml/fix_code.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
+ caml/fiber.h caml/roots.h caml/sys.h
 domain_bd.$(O): domain.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/platform.h caml/custom.h caml/shared_heap.h caml/roots.h \
-  caml/fail.h caml/globroots.h caml/signals.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h caml/fiber.h caml/callback.h caml/eventlog.h \
-  caml/gc_ctrl.h caml/osdeps.h caml/weak.h caml/finalise.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/alloc.h caml/platform.h caml/domain_state.h \
+ caml/platform.h caml/custom.h caml/major_gc.h caml/shared_heap.h \
+ caml/roots.h caml/memory.h caml/fail.h caml/globroots.h caml/signals.h \
+ caml/startup.h caml/exec.h caml/startup_aux.h caml/fiber.h \
+ caml/callback.h caml/minor_gc.h caml/eventlog.h caml/gc_ctrl.h \
+ caml/osdeps.h caml/weak.h caml/finalise.h caml/domain_state.tbl
 dynlink_bd.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/dynlink.h \
-  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/osdeps.h \
-  caml/prims.h caml/signals.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/dynlink.h caml/fail.h caml/mlvalues.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/osdeps.h \
+ caml/prims.h caml/signals.h
 dynlink_nat_bd.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/stack.h caml/callback.h \
-  caml/intext.h caml/io.h caml/osdeps.h caml/fail.h frame_descriptors.h \
-  caml/globroots.h caml/roots.h caml/signals.h caml/hooks.h
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/stack.h \
+ caml/callback.h caml/alloc.h caml/intext.h caml/io.h caml/osdeps.h \
+ caml/fail.h frame_descriptors.h caml/config.h caml/globroots.h \
+ caml/roots.h caml/signals.h caml/hooks.h
 eventlog_bd.$(O): eventlog.c caml/domain.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/alloc.h \
-  caml/platform.h caml/eventlog.h caml/osdeps.h caml/startup_aux.h
+ caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/platform.h caml/eventlog.h caml/osdeps.h \
+ caml/platform.h caml/startup_aux.h
 extern_bd.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/platform.h \
-  caml/md5.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/reverse.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/custom.h caml/fail.h caml/gc.h caml/intext.h caml/io.h \
+ caml/platform.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h caml/reverse.h \
+ caml/addrmap.h
 fail_byt_bd.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/fail.h caml/io.h caml/printexc.h \
-  caml/signals.h caml/fiber.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/fail.h caml/gc.h \
+ caml/io.h caml/memory.h caml/misc.h caml/mlvalues.h caml/printexc.h \
+ caml/signals.h caml/fiber.h caml/roots.h
 fail_nat_bd.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/io.h \
-  caml/platform.h caml/gc.h caml/memory.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/printexc.h \
-  caml/signals.h caml/stack.h caml/roots.h caml/callback.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/io.h \
+ caml/platform.h caml/gc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h \
+ caml/mlvalues.h caml/printexc.h caml/signals.h caml/stack.h caml/roots.h \
+ caml/callback.h
 fiber_bd.$(O): fiber.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/fiber.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h caml/gc_ctrl.h \
-  caml/instruct.h caml/fail.h caml/fix_code.h caml/shared_heap.h \
-  caml/startup_aux.h
+ caml/camlatomic.h caml/misc.h caml/fiber.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/roots.h caml/gc_ctrl.h \
+ caml/instruct.h caml/fail.h caml/alloc.h caml/platform.h caml/fix_code.h \
+ caml/minor_gc.h caml/major_gc.h caml/shared_heap.h caml/memory.h \
+ caml/startup_aux.h
 finalise_bd.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/eventlog.h caml/fail.h \
-  caml/finalise.h caml/roots.h caml/shared_heap.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/eventlog.h caml/fail.h caml/finalise.h \
+ caml/roots.h caml/memory.h caml/minor_gc.h caml/misc.h caml/roots.h \
+ caml/shared_heap.h
 fix_code_bd.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fix_code.h \
-  caml/instruct.h caml/intext.h caml/io.h caml/platform.h caml/md5.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/alloc.h caml/reverse.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/platform.h \
+ caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h caml/reverse.h
 floats_bd.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/reverse.h caml/fiber.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/fiber.h caml/roots.h
 frame_descriptors_bd.$(O): frame_descriptors.c frame_descriptors.h \
-  caml/config.h caml/m.h caml/s.h caml/platform.h caml/mlvalues.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/major_gc.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/alloc.h
+ caml/config.h caml/m.h caml/s.h caml/platform.h caml/mlvalues.h \
+ caml/config.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/major_gc.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h
 gc_ctrl_bd.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/gc_ctrl.h caml/shared_heap.h caml/fiber.h caml/globroots.h \
-  caml/signals.h caml/startup.h caml/exec.h caml/startup_aux.h \
-  caml/eventlog.h caml/fail.h
-globroots_bd.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
-  caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h caml/globroots.h \
-  caml/callback.h caml/shared_heap.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/minor_gc.h \
+ caml/shared_heap.h caml/misc.h caml/mlvalues.h caml/fiber.h \
+ caml/domain.h caml/globroots.h caml/signals.h caml/startup.h caml/exec.h \
+ caml/startup_aux.h caml/eventlog.h caml/fail.h
+globroots_bd.$(O): globroots.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/roots.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/globroots.h caml/roots.h \
+ caml/skiplist.h caml/stack.h
 hash_bd.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/hash.h caml/fail.h
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/custom.h caml/mlvalues.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/hash.h caml/fail.h
 instrtrace_bd.$(O): instrtrace.c caml/instrtrace.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/instruct.h caml/opnames.h caml/prims.h caml/fiber.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/instruct.h caml/misc.h caml/mlvalues.h caml/opnames.h caml/prims.h \
+ caml/fiber.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h caml/roots.h \
+ caml/domain.h caml/startup.h caml/exec.h caml/startup_aux.h
 intern_bd.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/custom.h caml/fail.h caml/intext.h \
-  caml/io.h caml/md5.h caml/reverse.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/config.h caml/custom.h \
+ caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h \
+ caml/memory.h caml/mlvalues.h caml/misc.h caml/reverse.h
 interp_bd.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/backtrace.h \
-  caml/exec.h caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
-  caml/instruct.h caml/interp.h caml/prims.h caml/signals.h caml/fiber.h \
-  caml/roots.h caml/globroots.h caml/startup.h caml/startup_aux.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/backtrace.h \
+ caml/exec.h caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/debugger.h caml/fail.h caml/fix_code.h \
+ caml/instrtrace.h caml/instruct.h caml/interp.h caml/major_gc.h \
+ caml/memory.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
+ caml/fiber.h caml/roots.h caml/domain.h caml/globroots.h caml/startup.h \
+ caml/startup_aux.h caml/startup_aux.h
 ints_bd.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/intext.h caml/io.h caml/platform.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/fail.h caml/intext.h caml/io.h caml/platform.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h
 io_bd.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/io.h caml/platform.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/osdeps.h caml/signals.h caml/sys.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/fail.h caml/io.h caml/platform.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/signals.h caml/sys.h
 lexing_bd.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fiber.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/mlvalues.h \
+ caml/fiber.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h caml/roots.h
 main_bd.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/sys.h \
-  caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/sys.h \
+ caml/osdeps.h caml/memory.h caml/gc.h caml/mlvalues.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h
 major_gc_bd.$(O): major_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/alloc.h \
-  caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h \
-  caml/finalise.h caml/globroots.h caml/shared_heap.h caml/startup_aux.h \
-  caml/weak.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/domain.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/alloc.h caml/platform.h \
+ caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h caml/finalise.h \
+ caml/globroots.h caml/memory.h caml/mlvalues.h caml/platform.h \
+ caml/roots.h caml/shared_heap.h caml/startup_aux.h caml/weak.h
 md5_bd.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/md5.h caml/io.h caml/platform.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/reverse.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/md5.h \
+ caml/io.h caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
 memory_bd.$(O): memory.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/fail.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/shared_heap.h caml/roots.h \
-  caml/fiber.h caml/eventlog.h
+ caml/config.h caml/camlatomic.h caml/misc.h caml/fail.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/major_gc.h \
+ caml/shared_heap.h caml/roots.h caml/domain.h caml/addrmap.h \
+ caml/roots.h caml/alloc.h caml/fiber.h caml/platform.h caml/eventlog.h
 memprof_bd.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/roots.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/fail.h caml/callback.h \
-  caml/signals.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
-  caml/weak.h caml/stack.h
+ caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/fail.h caml/alloc.h \
+ caml/callback.h caml/signals.h caml/memory.h caml/minor_gc.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
+ caml/stack.h caml/misc.h
 meta_bd.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/fix_code.h caml/interp.h caml/intext.h caml/io.h caml/platform.h \
-  caml/major_gc.h caml/memory.h caml/gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/prims.h caml/fiber.h caml/roots.h \
-  caml/startup_aux.h caml/debugger.h caml/backtrace_prim.h \
-  caml/backtrace.h caml/exec.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h caml/io.h \
+ caml/platform.h caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/fiber.h \
+ caml/roots.h caml/startup_aux.h caml/debugger.h caml/backtrace_prim.h \
+ caml/backtrace.h caml/exec.h
 minor_gc_bd.$(O): minor_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/domain.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/alloc.h caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h \
-  caml/roots.h caml/finalise.h caml/gc_ctrl.h caml/shared_heap.h \
-  caml/signals.h caml/startup_aux.h caml/weak.h
-misc_bd.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/memory.h caml/gc.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/osdeps.h caml/version.h \
-  caml/startup.h caml/exec.h caml/startup_aux.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/custom.h caml/domain.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/alloc.h \
+ caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h \
+ caml/finalise.h caml/gc.h caml/gc_ctrl.h caml/globroots.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/platform.h caml/roots.h caml/shared_heap.h \
+ caml/signals.h caml/startup_aux.h caml/weak.h
+misc_bd.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/camlatomic.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/osdeps.h caml/version.h \
+ caml/domain.h caml/startup.h caml/exec.h caml/startup_aux.h \
+ caml/startup_aux.h
 obj_bd.$(O): obj.c caml/camlatomic.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/alloc.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/gc.h \
-  caml/interp.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/prims.h \
-  caml/spacetime.h caml/io.h caml/stack.h
+ caml/misc.h caml/camlatomic.h caml/alloc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/platform.h caml/spacetime.h caml/io.h \
+ caml/stack.h
 parsing_bd.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h
+ caml/config.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/alloc.h \
+ caml/startup.h caml/exec.h caml/startup_aux.h
 platform_bd.$(O): platform.c caml/platform.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h
 prims_bd.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/prims.h
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/prims.h
 printexc_bd.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/exec.h \
-  caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/debugger.h caml/fail.h caml/printexc.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/exec.h \
+ caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h \
+ caml/debugger.h caml/fail.h caml/misc.h caml/mlvalues.h caml/printexc.h \
+ caml/memory.h
 roots_bd.$(O): roots.c caml/finalise.h caml/roots.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/memory.h caml/gc.h \
-  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
-  caml/byte_domain_state.tbl caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h \
-  caml/globroots.h caml/shared_heap.h caml/fiber.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/shared_heap.h caml/fiber.h
 shared_heap_bd.$(O): shared_heap.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/fiber.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/domain.h caml/platform.h caml/alloc.h \
-  caml/roots.h caml/globroots.h caml/shared_heap.h caml/sizeclasses.h \
-  caml/startup_aux.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/fail.h caml/fiber.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/roots.h caml/gc.h caml/globroots.h caml/memory.h \
+ caml/mlvalues.h caml/platform.h caml/roots.h caml/shared_heap.h \
+ caml/sizeclasses.h caml/startup_aux.h
 signals_bd.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/fail.h caml/roots.h caml/signals.h \
-  caml/sys.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/config.h caml/fail.h \
+ caml/memory.h caml/misc.h caml/mlvalues.h caml/roots.h caml/signals.h \
+ caml/sys.h
 signals_byt_bd.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/osdeps.h caml/signals.h
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/platform.h caml/alloc.h \
+ caml/osdeps.h caml/signals.h
 signals_nat_bd.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/osdeps.h \
-  caml/signals.h caml/stack.h caml/spacetime.h caml/io.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/osdeps.h caml/domain.h \
+ caml/signals.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h
+skiplist_bd.$(O): skiplist.c caml/config.h caml/m.h caml/s.h caml/memory.h \
+ caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/skiplist.h
 spacetime_byt_bd.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/mlvalues.h
 spacetime_nat_bd.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
-  caml/alloc.h caml/misc.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/platform.h \
-  caml/major_gc.h caml/memory.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/osdeps.h caml/roots.h caml/signals.h caml/stack.h \
-  caml/sys.h caml/spacetime.h
+ caml/alloc.h caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/platform.h \
+ caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/osdeps.h caml/roots.h caml/signals.h \
+ caml/stack.h caml/sys.h caml/spacetime.h caml/stack.h
 spacetime_snapshot_bd.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
-  caml/config.h caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h caml/intext.h \
-  caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/roots.h \
-  caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h
+ caml/config.h caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
+ caml/intext.h caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 startup_aux_bd.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/exec.h caml/dynlink.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/callback.h caml/osdeps.h caml/prims.h \
-  caml/startup_aux.h caml/version.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/exec.h caml/dynlink.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/callback.h caml/major_gc.h caml/misc.h \
+ caml/osdeps.h caml/prims.h caml/startup_aux.h caml/version.h
 startup_byt_bd.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/backtrace.h \
-  caml/exec.h caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/custom.h caml/debugger.h caml/dynlink.h caml/eventlog.h \
-  caml/fail.h caml/fix_code.h caml/gc_ctrl.h caml/instrtrace.h \
-  caml/interp.h caml/intext.h caml/io.h caml/osdeps.h caml/startup_aux.h \
-  caml/prims.h caml/printexc.h caml/reverse.h caml/signals.h \
-  caml/fiber.h caml/roots.h caml/sys.h caml/startup.h caml/version.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/backtrace.h caml/exec.h caml/callback.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/custom.h caml/debugger.h \
+ caml/domain_state.h caml/dynlink.h caml/eventlog.h caml/exec.h \
+ caml/fail.h caml/fix_code.h caml/gc_ctrl.h caml/instrtrace.h \
+ caml/interp.h caml/intext.h caml/io.h caml/io.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/startup_aux.h caml/prims.h caml/printexc.h caml/reverse.h \
+ caml/signals.h caml/fiber.h caml/roots.h caml/sys.h caml/startup.h \
+ caml/startup_aux.h caml/version.h
 startup_nat_bd.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/backtrace.h \
-  caml/exec.h caml/custom.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
-  caml/intext.h caml/io.h caml/osdeps.h caml/printexc.h caml/stack.h \
-  caml/sys.h caml/startup_aux.h caml/fiber.h caml/roots.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h \
+ caml/custom.h caml/debugger.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
+ caml/intext.h caml/io.h caml/memory.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/printexc.h caml/stack.h caml/sys.h caml/startup_aux.h \
+ caml/fiber.h caml/roots.h
 str_bd.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h \
+ caml/misc.h
 sys_bd.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/debugger.h \
-  caml/fail.h caml/gc_ctrl.h caml/io.h caml/platform.h caml/osdeps.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/signals.h caml/fiber.h caml/roots.h caml/sys.h \
-  caml/startup.h caml/exec.h caml/startup_aux.h caml/version.h \
-  caml/callback.h caml/shared_heap.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/debugger.h \
+ caml/fail.h caml/gc_ctrl.h caml/io.h caml/platform.h caml/mlvalues.h \
+ caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/alloc.h caml/signals.h caml/fiber.h \
+ caml/roots.h caml/sys.h caml/startup.h caml/exec.h caml/startup_aux.h \
+ caml/version.h caml/callback.h caml/startup_aux.h caml/major_gc.h \
+ caml/shared_heap.h
 unix_bd.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/osdeps.h caml/signals.h caml/sys.h \
-  caml/io.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/osdeps.h \
+ caml/signals.h caml/sys.h caml/io.h caml/alloc.h
 weak_bd.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/platform.h caml/fail.h caml/shared_heap.h caml/roots.h \
-  caml/weak.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/alloc.h caml/platform.h caml/fail.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/shared_heap.h caml/roots.h \
+ caml/weak.h
+win32_bd.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/address_class.h \
+ caml/fail.h caml/io.h caml/platform.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/misc.h caml/osdeps.h caml/signals.h \
+ caml/sys.h caml/config.h
 addrmap_bi.$(O): addrmap.c caml/config.h caml/m.h caml/s.h caml/memory.h \
-  caml/domain.h caml/misc.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/alloc.h caml/addrmap.h
-afl_bi.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/osdeps.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h
+ caml/config.h caml/domain.h caml/misc.h caml/camlatomic.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/alloc.h caml/addrmap.h
+afl_bi.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/osdeps.h \
+ caml/memory.h caml/gc.h caml/mlvalues.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h
 alloc_bi.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/major_gc.h caml/memory.h caml/gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/fiber.h caml/roots.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/platform.h caml/alloc.h \
+ caml/mlvalues.h caml/fiber.h caml/roots.h caml/domain.h
 array_bi.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/signals.h caml/spacetime.h \
-  caml/io.h caml/stack.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
 backtrace_bi.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
-  caml/fail.h caml/debugger.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
 backtrace_byt_bi.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/alloc.h \
-  caml/custom.h caml/io.h caml/platform.h caml/instruct.h caml/intext.h \
-  caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/startup.h \
-  caml/startup_aux.h caml/fiber.h caml/roots.h caml/sys.h \
-  caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/debugger.h
+ caml/mlvalues.h caml/config.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/alloc.h caml/mlvalues.h caml/custom.h caml/io.h caml/platform.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/exec.h caml/fix_code.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/startup.h caml/exec.h \
+ caml/startup_aux.h caml/fiber.h caml/roots.h caml/sys.h caml/backtrace.h \
+ caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
 backtrace_nat_bi.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/backtrace.h caml/exec.h caml/backtrace_prim.h frame_descriptors.h \
-  caml/stack.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/fiber.h caml/roots.h \
-  caml/fail.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/backtrace.h \
+ caml/exec.h caml/backtrace_prim.h caml/backtrace.h frame_descriptors.h \
+ caml/config.h caml/stack.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/misc.h caml/mlvalues.h caml/fiber.h \
+ caml/roots.h caml/fail.h
 bigarray_bi.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/bigarray.h \
-  caml/custom.h caml/fail.h caml/intext.h caml/io.h caml/platform.h \
-  caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/signals.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/bigarray.h \
+ caml/custom.h caml/fail.h caml/intext.h caml/io.h caml/platform.h \
+ caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/mlvalues.h \
+ caml/signals.h
 callback_bi.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/fail.h caml/fiber.h caml/roots.h \
-  caml/interp.h caml/instruct.h caml/fix_code.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/fail.h caml/memory.h caml/mlvalues.h \
+ caml/platform.h caml/fiber.h caml/roots.h caml/interp.h caml/instruct.h \
+ caml/fix_code.h
 clambda_checks_bi.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl
+ caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl
 compare_bi.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h
+ caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h
 custom_bi.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/shared_heap.h caml/roots.h caml/signals.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/mlvalues.h caml/shared_heap.h \
+ caml/roots.h caml/signals.h
 debugger_bi.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/debugger.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/osdeps.h caml/fail.h \
-  caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/fiber.h \
-  caml/roots.h caml/sys.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/debugger.h caml/misc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/osdeps.h caml/fail.h caml/fix_code.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
+ caml/fiber.h caml/roots.h caml/sys.h
 domain_bi.$(O): domain.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/platform.h caml/custom.h caml/shared_heap.h caml/roots.h \
-  caml/fail.h caml/globroots.h caml/signals.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h caml/fiber.h caml/callback.h caml/eventlog.h \
-  caml/gc_ctrl.h caml/osdeps.h caml/weak.h caml/finalise.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/alloc.h caml/platform.h caml/domain_state.h \
+ caml/platform.h caml/custom.h caml/major_gc.h caml/shared_heap.h \
+ caml/roots.h caml/memory.h caml/fail.h caml/globroots.h caml/signals.h \
+ caml/startup.h caml/exec.h caml/startup_aux.h caml/fiber.h \
+ caml/callback.h caml/minor_gc.h caml/eventlog.h caml/gc_ctrl.h \
+ caml/osdeps.h caml/weak.h caml/finalise.h
 dynlink_bi.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/dynlink.h \
-  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/osdeps.h \
-  caml/prims.h caml/signals.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/dynlink.h caml/fail.h caml/mlvalues.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/osdeps.h \
+ caml/prims.h caml/signals.h
 dynlink_nat_bi.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/stack.h caml/callback.h \
-  caml/intext.h caml/io.h caml/osdeps.h caml/fail.h frame_descriptors.h \
-  caml/globroots.h caml/roots.h caml/signals.h caml/hooks.h
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/stack.h \
+ caml/callback.h caml/alloc.h caml/intext.h caml/io.h caml/osdeps.h \
+ caml/fail.h frame_descriptors.h caml/config.h caml/globroots.h \
+ caml/roots.h caml/signals.h caml/hooks.h
 eventlog_bi.$(O): eventlog.c caml/domain.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/alloc.h \
-  caml/platform.h caml/eventlog.h caml/osdeps.h caml/startup_aux.h
+ caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/platform.h caml/eventlog.h caml/osdeps.h \
+ caml/platform.h caml/startup_aux.h
 extern_bi.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/platform.h \
-  caml/md5.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/reverse.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/custom.h caml/fail.h caml/gc.h caml/intext.h caml/io.h \
+ caml/platform.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h caml/reverse.h \
+ caml/addrmap.h
 fail_byt_bi.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/fail.h caml/io.h caml/printexc.h \
-  caml/signals.h caml/fiber.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/fail.h caml/gc.h \
+ caml/io.h caml/memory.h caml/misc.h caml/mlvalues.h caml/printexc.h \
+ caml/signals.h caml/fiber.h caml/roots.h
 fail_nat_bi.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/io.h \
-  caml/platform.h caml/gc.h caml/memory.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/printexc.h \
-  caml/signals.h caml/stack.h caml/roots.h caml/callback.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/io.h \
+ caml/platform.h caml/gc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h \
+ caml/mlvalues.h caml/printexc.h caml/signals.h caml/stack.h caml/roots.h \
+ caml/callback.h
 fiber_bi.$(O): fiber.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/fiber.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h caml/gc_ctrl.h \
-  caml/instruct.h caml/fail.h caml/fix_code.h caml/shared_heap.h \
-  caml/startup_aux.h
+ caml/camlatomic.h caml/misc.h caml/fiber.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/roots.h caml/gc_ctrl.h \
+ caml/instruct.h caml/fail.h caml/alloc.h caml/platform.h caml/fix_code.h \
+ caml/minor_gc.h caml/major_gc.h caml/shared_heap.h caml/memory.h \
+ caml/startup_aux.h
 finalise_bi.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/eventlog.h caml/fail.h \
-  caml/finalise.h caml/roots.h caml/shared_heap.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/eventlog.h caml/fail.h caml/finalise.h \
+ caml/roots.h caml/memory.h caml/minor_gc.h caml/misc.h caml/roots.h \
+ caml/shared_heap.h
 fix_code_bi.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fix_code.h \
-  caml/instruct.h caml/intext.h caml/io.h caml/platform.h caml/md5.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/alloc.h caml/reverse.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/platform.h \
+ caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h caml/reverse.h
 floats_bi.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/reverse.h caml/fiber.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/fiber.h caml/roots.h
 frame_descriptors_bi.$(O): frame_descriptors.c frame_descriptors.h \
-  caml/config.h caml/m.h caml/s.h caml/platform.h caml/mlvalues.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/major_gc.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/alloc.h
+ caml/config.h caml/m.h caml/s.h caml/platform.h caml/mlvalues.h \
+ caml/config.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/major_gc.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h
 gc_ctrl_bi.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/gc_ctrl.h caml/shared_heap.h caml/fiber.h caml/globroots.h \
-  caml/signals.h caml/startup.h caml/exec.h caml/startup_aux.h \
-  caml/eventlog.h caml/fail.h
-globroots_bi.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
-  caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h caml/globroots.h \
-  caml/callback.h caml/shared_heap.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/minor_gc.h \
+ caml/shared_heap.h caml/misc.h caml/mlvalues.h caml/fiber.h \
+ caml/domain.h caml/globroots.h caml/signals.h caml/startup.h caml/exec.h \
+ caml/startup_aux.h caml/eventlog.h caml/fail.h
+globroots_bi.$(O): globroots.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/roots.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/globroots.h caml/roots.h \
+ caml/skiplist.h caml/stack.h
 hash_bi.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/hash.h caml/fail.h
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/custom.h caml/mlvalues.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/hash.h caml/fail.h
 instrtrace_bi.$(O): instrtrace.c
 intern_bi.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/custom.h caml/fail.h caml/intext.h \
-  caml/io.h caml/md5.h caml/reverse.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/config.h caml/custom.h \
+ caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h \
+ caml/memory.h caml/mlvalues.h caml/misc.h caml/reverse.h
 interp_bi.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/backtrace.h \
-  caml/exec.h caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
-  caml/instruct.h caml/interp.h caml/prims.h caml/signals.h caml/fiber.h \
-  caml/roots.h caml/globroots.h caml/startup.h caml/startup_aux.h \
-  caml/jumptbl.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/backtrace.h \
+ caml/exec.h caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/debugger.h caml/fail.h caml/fix_code.h \
+ caml/instrtrace.h caml/instruct.h caml/interp.h caml/major_gc.h \
+ caml/memory.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
+ caml/fiber.h caml/roots.h caml/domain.h caml/globroots.h caml/startup.h \
+ caml/startup_aux.h caml/startup_aux.h caml/jumptbl.h
 ints_bi.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/intext.h caml/io.h caml/platform.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/fail.h caml/intext.h caml/io.h caml/platform.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h
 io_bi.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/io.h caml/platform.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/osdeps.h caml/signals.h caml/sys.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/fail.h caml/io.h caml/platform.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/signals.h caml/sys.h
 lexing_bi.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fiber.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/mlvalues.h \
+ caml/fiber.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h caml/roots.h
 main_bi.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/sys.h \
-  caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/sys.h \
+ caml/osdeps.h caml/memory.h caml/gc.h caml/mlvalues.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h
 major_gc_bi.$(O): major_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/alloc.h \
-  caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h \
-  caml/finalise.h caml/globroots.h caml/shared_heap.h caml/startup_aux.h \
-  caml/weak.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/domain.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/alloc.h caml/platform.h \
+ caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h caml/finalise.h \
+ caml/globroots.h caml/memory.h caml/mlvalues.h caml/platform.h \
+ caml/roots.h caml/shared_heap.h caml/startup_aux.h caml/weak.h
 md5_bi.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/md5.h caml/io.h caml/platform.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/reverse.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/md5.h \
+ caml/io.h caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
 memory_bi.$(O): memory.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/fail.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/shared_heap.h caml/roots.h \
-  caml/fiber.h caml/eventlog.h
+ caml/config.h caml/camlatomic.h caml/misc.h caml/fail.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/major_gc.h \
+ caml/shared_heap.h caml/roots.h caml/domain.h caml/addrmap.h \
+ caml/roots.h caml/alloc.h caml/fiber.h caml/platform.h caml/eventlog.h
 memprof_bi.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/roots.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/fail.h caml/callback.h \
-  caml/signals.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
-  caml/weak.h caml/stack.h
+ caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/fail.h caml/alloc.h \
+ caml/callback.h caml/signals.h caml/memory.h caml/minor_gc.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
+ caml/stack.h caml/misc.h
 meta_bi.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/fix_code.h caml/interp.h caml/intext.h caml/io.h caml/platform.h \
-  caml/major_gc.h caml/memory.h caml/gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/prims.h caml/fiber.h caml/roots.h \
-  caml/startup_aux.h caml/debugger.h caml/backtrace_prim.h \
-  caml/backtrace.h caml/exec.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h caml/io.h \
+ caml/platform.h caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/fiber.h \
+ caml/roots.h caml/startup_aux.h caml/debugger.h caml/backtrace_prim.h \
+ caml/backtrace.h caml/exec.h
 minor_gc_bi.$(O): minor_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/domain.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/alloc.h caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h \
-  caml/roots.h caml/finalise.h caml/gc_ctrl.h caml/shared_heap.h \
-  caml/signals.h caml/startup_aux.h caml/weak.h
-misc_bi.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/memory.h caml/gc.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/osdeps.h caml/version.h \
-  caml/startup.h caml/exec.h caml/startup_aux.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/custom.h caml/domain.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/alloc.h \
+ caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h \
+ caml/finalise.h caml/gc.h caml/gc_ctrl.h caml/globroots.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/platform.h caml/roots.h caml/shared_heap.h \
+ caml/signals.h caml/startup_aux.h caml/weak.h
+misc_bi.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/camlatomic.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/osdeps.h caml/version.h \
+ caml/domain.h caml/startup.h caml/exec.h caml/startup_aux.h \
+ caml/startup_aux.h
 obj_bi.$(O): obj.c caml/camlatomic.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/alloc.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/gc.h \
-  caml/interp.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/prims.h \
-  caml/spacetime.h caml/io.h caml/stack.h
+ caml/misc.h caml/camlatomic.h caml/alloc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/platform.h caml/spacetime.h caml/io.h \
+ caml/stack.h
 parsing_bi.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h
+ caml/config.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/alloc.h \
+ caml/startup.h caml/exec.h caml/startup_aux.h
 platform_bi.$(O): platform.c caml/platform.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h
 prims_bi.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/prims.h
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/prims.h
 printexc_bi.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/exec.h \
-  caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/debugger.h caml/fail.h caml/printexc.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/exec.h \
+ caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h \
+ caml/debugger.h caml/fail.h caml/misc.h caml/mlvalues.h caml/printexc.h \
+ caml/memory.h
 roots_bi.$(O): roots.c caml/finalise.h caml/roots.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/memory.h caml/gc.h \
-  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
-  caml/byte_domain_state.tbl caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h \
-  caml/globroots.h caml/shared_heap.h caml/fiber.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/shared_heap.h caml/fiber.h
 shared_heap_bi.$(O): shared_heap.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/fiber.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/domain.h caml/platform.h caml/alloc.h \
-  caml/roots.h caml/globroots.h caml/shared_heap.h caml/sizeclasses.h \
-  caml/startup_aux.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/fail.h caml/fiber.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/roots.h caml/gc.h caml/globroots.h caml/memory.h \
+ caml/mlvalues.h caml/platform.h caml/roots.h caml/shared_heap.h \
+ caml/sizeclasses.h caml/startup_aux.h
 signals_bi.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/fail.h caml/roots.h caml/signals.h \
-  caml/sys.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/config.h caml/fail.h \
+ caml/memory.h caml/misc.h caml/mlvalues.h caml/roots.h caml/signals.h \
+ caml/sys.h
 signals_byt_bi.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/osdeps.h caml/signals.h
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/platform.h caml/alloc.h \
+ caml/osdeps.h caml/signals.h
 signals_nat_bi.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/osdeps.h \
-  caml/signals.h caml/stack.h caml/spacetime.h caml/io.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/osdeps.h caml/domain.h \
+ caml/signals.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h
+skiplist_bi.$(O): skiplist.c caml/config.h caml/m.h caml/s.h caml/memory.h \
+ caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/skiplist.h
 spacetime_byt_bi.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/mlvalues.h
 spacetime_nat_bi.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
-  caml/alloc.h caml/misc.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/platform.h \
-  caml/major_gc.h caml/memory.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/osdeps.h caml/roots.h caml/signals.h caml/stack.h \
-  caml/sys.h caml/spacetime.h
+ caml/alloc.h caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/platform.h \
+ caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/osdeps.h caml/roots.h caml/signals.h \
+ caml/stack.h caml/sys.h caml/spacetime.h caml/stack.h
 spacetime_snapshot_bi.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
-  caml/config.h caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h caml/intext.h \
-  caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/roots.h \
-  caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h
+ caml/config.h caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
+ caml/intext.h caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 startup_aux_bi.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/exec.h caml/dynlink.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/callback.h caml/osdeps.h caml/prims.h \
-  caml/startup_aux.h caml/version.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/exec.h caml/dynlink.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/callback.h caml/major_gc.h caml/misc.h \
+ caml/osdeps.h caml/prims.h caml/startup_aux.h caml/version.h
 startup_byt_bi.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/backtrace.h \
-  caml/exec.h caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/custom.h caml/debugger.h caml/dynlink.h caml/eventlog.h \
-  caml/fail.h caml/fix_code.h caml/gc_ctrl.h caml/instrtrace.h \
-  caml/interp.h caml/intext.h caml/io.h caml/osdeps.h caml/startup_aux.h \
-  caml/prims.h caml/printexc.h caml/reverse.h caml/signals.h \
-  caml/fiber.h caml/roots.h caml/sys.h caml/startup.h caml/version.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/backtrace.h caml/exec.h caml/callback.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/custom.h caml/debugger.h \
+ caml/domain_state.h caml/dynlink.h caml/eventlog.h caml/exec.h \
+ caml/fail.h caml/fix_code.h caml/gc_ctrl.h caml/instrtrace.h \
+ caml/interp.h caml/intext.h caml/io.h caml/io.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/startup_aux.h caml/prims.h caml/printexc.h caml/reverse.h \
+ caml/signals.h caml/fiber.h caml/roots.h caml/sys.h caml/startup.h \
+ caml/startup_aux.h caml/version.h
 startup_nat_bi.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/backtrace.h \
-  caml/exec.h caml/custom.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
-  caml/intext.h caml/io.h caml/osdeps.h caml/printexc.h caml/stack.h \
-  caml/sys.h caml/startup_aux.h caml/fiber.h caml/roots.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h \
+ caml/custom.h caml/debugger.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
+ caml/intext.h caml/io.h caml/memory.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/printexc.h caml/stack.h caml/sys.h caml/startup_aux.h \
+ caml/fiber.h caml/roots.h
 str_bi.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h \
+ caml/misc.h
 sys_bi.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/debugger.h \
-  caml/fail.h caml/gc_ctrl.h caml/io.h caml/platform.h caml/osdeps.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/signals.h caml/fiber.h caml/roots.h caml/sys.h \
-  caml/startup.h caml/exec.h caml/startup_aux.h caml/version.h \
-  caml/callback.h caml/shared_heap.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/debugger.h \
+ caml/fail.h caml/gc_ctrl.h caml/io.h caml/platform.h caml/mlvalues.h \
+ caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/alloc.h caml/signals.h caml/fiber.h \
+ caml/roots.h caml/sys.h caml/startup.h caml/exec.h caml/startup_aux.h \
+ caml/version.h caml/callback.h caml/startup_aux.h caml/major_gc.h \
+ caml/shared_heap.h
 unix_bi.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/osdeps.h caml/signals.h caml/sys.h \
-  caml/io.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/osdeps.h \
+ caml/signals.h caml/sys.h caml/io.h caml/alloc.h
 weak_bi.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/platform.h caml/fail.h caml/shared_heap.h caml/roots.h \
-  caml/weak.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/alloc.h caml/platform.h caml/fail.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/shared_heap.h caml/roots.h \
+ caml/weak.h
+win32_bi.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/address_class.h \
+ caml/fail.h caml/io.h caml/platform.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/misc.h caml/osdeps.h caml/signals.h \
+ caml/sys.h caml/config.h
 addrmap_bpic.$(O): addrmap.c caml/config.h caml/m.h caml/s.h caml/memory.h \
-  caml/domain.h caml/misc.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/alloc.h caml/addrmap.h
-afl_bpic.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/osdeps.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h
+ caml/config.h caml/domain.h caml/misc.h caml/camlatomic.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/alloc.h caml/addrmap.h
+afl_bpic.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/osdeps.h \
+ caml/memory.h caml/gc.h caml/mlvalues.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h
 alloc_bpic.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/major_gc.h caml/memory.h caml/gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/fiber.h caml/roots.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/platform.h caml/alloc.h \
+ caml/mlvalues.h caml/fiber.h caml/roots.h caml/domain.h
 array_bpic.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/signals.h caml/spacetime.h \
-  caml/io.h caml/stack.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
 backtrace_bpic.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
-  caml/fail.h caml/debugger.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
 backtrace_byt_bpic.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/alloc.h \
-  caml/custom.h caml/io.h caml/platform.h caml/instruct.h caml/intext.h \
-  caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/startup.h \
-  caml/startup_aux.h caml/fiber.h caml/roots.h caml/sys.h \
-  caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/debugger.h
+ caml/mlvalues.h caml/config.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/alloc.h caml/mlvalues.h caml/custom.h caml/io.h caml/platform.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/exec.h caml/fix_code.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/startup.h caml/exec.h \
+ caml/startup_aux.h caml/fiber.h caml/roots.h caml/sys.h caml/backtrace.h \
+ caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
 backtrace_nat_bpic.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/backtrace.h caml/exec.h caml/backtrace_prim.h frame_descriptors.h \
-  caml/stack.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/fiber.h caml/roots.h \
-  caml/fail.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/backtrace.h \
+ caml/exec.h caml/backtrace_prim.h caml/backtrace.h frame_descriptors.h \
+ caml/config.h caml/stack.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/misc.h caml/mlvalues.h caml/fiber.h \
+ caml/roots.h caml/fail.h
 bigarray_bpic.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/bigarray.h \
-  caml/custom.h caml/fail.h caml/intext.h caml/io.h caml/platform.h \
-  caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/signals.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/bigarray.h \
+ caml/custom.h caml/fail.h caml/intext.h caml/io.h caml/platform.h \
+ caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/mlvalues.h \
+ caml/signals.h
 callback_bpic.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/fail.h caml/fiber.h caml/roots.h \
-  caml/interp.h caml/instruct.h caml/fix_code.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/fail.h caml/memory.h caml/mlvalues.h \
+ caml/platform.h caml/fiber.h caml/roots.h caml/interp.h caml/instruct.h \
+ caml/fix_code.h
 clambda_checks_bpic.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl
+ caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl
 compare_bpic.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h
+ caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h
 custom_bpic.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/shared_heap.h caml/roots.h caml/signals.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/mlvalues.h caml/shared_heap.h \
+ caml/roots.h caml/signals.h
 debugger_bpic.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/debugger.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/osdeps.h caml/fail.h \
-  caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/fiber.h \
-  caml/roots.h caml/sys.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/debugger.h caml/misc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/osdeps.h caml/fail.h caml/fix_code.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
+ caml/fiber.h caml/roots.h caml/sys.h
 domain_bpic.$(O): domain.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/platform.h caml/custom.h caml/shared_heap.h caml/roots.h \
-  caml/fail.h caml/globroots.h caml/signals.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h caml/fiber.h caml/callback.h caml/eventlog.h \
-  caml/gc_ctrl.h caml/osdeps.h caml/weak.h caml/finalise.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/alloc.h caml/platform.h caml/domain_state.h \
+ caml/platform.h caml/custom.h caml/major_gc.h caml/shared_heap.h \
+ caml/roots.h caml/memory.h caml/fail.h caml/globroots.h caml/signals.h \
+ caml/startup.h caml/exec.h caml/startup_aux.h caml/fiber.h \
+ caml/callback.h caml/minor_gc.h caml/eventlog.h caml/gc_ctrl.h \
+ caml/osdeps.h caml/weak.h caml/finalise.h
 dynlink_bpic.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/dynlink.h \
-  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/osdeps.h \
-  caml/prims.h caml/signals.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/dynlink.h caml/fail.h caml/mlvalues.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/osdeps.h \
+ caml/prims.h caml/signals.h
 dynlink_nat_bpic.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/stack.h caml/callback.h \
-  caml/intext.h caml/io.h caml/osdeps.h caml/fail.h frame_descriptors.h \
-  caml/globroots.h caml/roots.h caml/signals.h caml/hooks.h
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/stack.h \
+ caml/callback.h caml/alloc.h caml/intext.h caml/io.h caml/osdeps.h \
+ caml/fail.h frame_descriptors.h caml/config.h caml/globroots.h \
+ caml/roots.h caml/signals.h caml/hooks.h
 eventlog_bpic.$(O): eventlog.c caml/domain.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/alloc.h \
-  caml/platform.h caml/eventlog.h caml/osdeps.h caml/startup_aux.h
+ caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/platform.h caml/eventlog.h caml/osdeps.h \
+ caml/platform.h caml/startup_aux.h
 extern_bpic.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/platform.h \
-  caml/md5.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/reverse.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/custom.h caml/fail.h caml/gc.h caml/intext.h caml/io.h \
+ caml/platform.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h caml/reverse.h \
+ caml/addrmap.h
 fail_byt_bpic.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/fail.h caml/io.h caml/printexc.h \
-  caml/signals.h caml/fiber.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/fail.h caml/gc.h \
+ caml/io.h caml/memory.h caml/misc.h caml/mlvalues.h caml/printexc.h \
+ caml/signals.h caml/fiber.h caml/roots.h
 fail_nat_bpic.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/io.h \
-  caml/platform.h caml/gc.h caml/memory.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/printexc.h \
-  caml/signals.h caml/stack.h caml/roots.h caml/callback.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/io.h \
+ caml/platform.h caml/gc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h \
+ caml/mlvalues.h caml/printexc.h caml/signals.h caml/stack.h caml/roots.h \
+ caml/callback.h
 fiber_bpic.$(O): fiber.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/fiber.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h caml/gc_ctrl.h \
-  caml/instruct.h caml/fail.h caml/fix_code.h caml/shared_heap.h \
-  caml/startup_aux.h
+ caml/camlatomic.h caml/misc.h caml/fiber.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/roots.h caml/gc_ctrl.h \
+ caml/instruct.h caml/fail.h caml/alloc.h caml/platform.h caml/fix_code.h \
+ caml/minor_gc.h caml/major_gc.h caml/shared_heap.h caml/memory.h \
+ caml/startup_aux.h
 finalise_bpic.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/eventlog.h caml/fail.h \
-  caml/finalise.h caml/roots.h caml/shared_heap.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/eventlog.h caml/fail.h caml/finalise.h \
+ caml/roots.h caml/memory.h caml/minor_gc.h caml/misc.h caml/roots.h \
+ caml/shared_heap.h
 fix_code_bpic.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fix_code.h \
-  caml/instruct.h caml/intext.h caml/io.h caml/platform.h caml/md5.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/alloc.h caml/reverse.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/platform.h \
+ caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h caml/reverse.h
 floats_bpic.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/reverse.h caml/fiber.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/fiber.h caml/roots.h
 frame_descriptors_bpic.$(O): frame_descriptors.c frame_descriptors.h \
-  caml/config.h caml/m.h caml/s.h caml/platform.h caml/mlvalues.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/major_gc.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/alloc.h
+ caml/config.h caml/m.h caml/s.h caml/platform.h caml/mlvalues.h \
+ caml/config.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/major_gc.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h
 gc_ctrl_bpic.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/gc_ctrl.h caml/shared_heap.h caml/fiber.h caml/globroots.h \
-  caml/signals.h caml/startup.h caml/exec.h caml/startup_aux.h \
-  caml/eventlog.h caml/fail.h
-globroots_bpic.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
-  caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h caml/globroots.h \
-  caml/callback.h caml/shared_heap.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/minor_gc.h \
+ caml/shared_heap.h caml/misc.h caml/mlvalues.h caml/fiber.h \
+ caml/domain.h caml/globroots.h caml/signals.h caml/startup.h caml/exec.h \
+ caml/startup_aux.h caml/eventlog.h caml/fail.h
+globroots_bpic.$(O): globroots.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/roots.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/globroots.h caml/roots.h \
+ caml/skiplist.h caml/stack.h
 hash_bpic.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/hash.h caml/fail.h
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/custom.h caml/mlvalues.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/hash.h caml/fail.h
 instrtrace_bpic.$(O): instrtrace.c
 intern_bpic.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/custom.h caml/fail.h caml/intext.h \
-  caml/io.h caml/md5.h caml/reverse.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/config.h caml/custom.h \
+ caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h \
+ caml/memory.h caml/mlvalues.h caml/misc.h caml/reverse.h
 interp_bpic.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/backtrace.h \
-  caml/exec.h caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
-  caml/instruct.h caml/interp.h caml/prims.h caml/signals.h caml/fiber.h \
-  caml/roots.h caml/globroots.h caml/startup.h caml/startup_aux.h \
-  caml/jumptbl.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/backtrace.h \
+ caml/exec.h caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/debugger.h caml/fail.h caml/fix_code.h \
+ caml/instrtrace.h caml/instruct.h caml/interp.h caml/major_gc.h \
+ caml/memory.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
+ caml/fiber.h caml/roots.h caml/domain.h caml/globroots.h caml/startup.h \
+ caml/startup_aux.h caml/startup_aux.h caml/jumptbl.h
 ints_bpic.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/intext.h caml/io.h caml/platform.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/fail.h caml/intext.h caml/io.h caml/platform.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h
 io_bpic.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/io.h caml/platform.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/osdeps.h caml/signals.h caml/sys.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/fail.h caml/io.h caml/platform.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/signals.h caml/sys.h
 lexing_bpic.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fiber.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/mlvalues.h \
+ caml/fiber.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h caml/roots.h
 main_bpic.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/sys.h \
-  caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/sys.h \
+ caml/osdeps.h caml/memory.h caml/gc.h caml/mlvalues.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h
 major_gc_bpic.$(O): major_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/alloc.h \
-  caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h \
-  caml/finalise.h caml/globroots.h caml/shared_heap.h caml/startup_aux.h \
-  caml/weak.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/domain.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/alloc.h caml/platform.h \
+ caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h caml/finalise.h \
+ caml/globroots.h caml/memory.h caml/mlvalues.h caml/platform.h \
+ caml/roots.h caml/shared_heap.h caml/startup_aux.h caml/weak.h
 md5_bpic.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/md5.h caml/io.h caml/platform.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/reverse.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/md5.h \
+ caml/io.h caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
 memory_bpic.$(O): memory.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/fail.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/shared_heap.h caml/roots.h \
-  caml/fiber.h caml/eventlog.h
+ caml/config.h caml/camlatomic.h caml/misc.h caml/fail.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/major_gc.h \
+ caml/shared_heap.h caml/roots.h caml/domain.h caml/addrmap.h \
+ caml/roots.h caml/alloc.h caml/fiber.h caml/platform.h caml/eventlog.h
 memprof_bpic.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/roots.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/fail.h caml/callback.h \
-  caml/signals.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
-  caml/weak.h caml/stack.h
+ caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/fail.h caml/alloc.h \
+ caml/callback.h caml/signals.h caml/memory.h caml/minor_gc.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
+ caml/stack.h caml/misc.h
 meta_bpic.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/fix_code.h caml/interp.h caml/intext.h caml/io.h caml/platform.h \
-  caml/major_gc.h caml/memory.h caml/gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/prims.h caml/fiber.h caml/roots.h \
-  caml/startup_aux.h caml/debugger.h caml/backtrace_prim.h \
-  caml/backtrace.h caml/exec.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h caml/io.h \
+ caml/platform.h caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/fiber.h \
+ caml/roots.h caml/startup_aux.h caml/debugger.h caml/backtrace_prim.h \
+ caml/backtrace.h caml/exec.h
 minor_gc_bpic.$(O): minor_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/domain.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
-  caml/alloc.h caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h \
-  caml/roots.h caml/finalise.h caml/gc_ctrl.h caml/shared_heap.h \
-  caml/signals.h caml/startup_aux.h caml/weak.h
-misc_bpic.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/memory.h caml/gc.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/osdeps.h caml/version.h \
-  caml/startup.h caml/exec.h caml/startup_aux.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/config.h \
+ caml/custom.h caml/domain.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/alloc.h \
+ caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h \
+ caml/finalise.h caml/gc.h caml/gc_ctrl.h caml/globroots.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/platform.h caml/roots.h caml/shared_heap.h \
+ caml/signals.h caml/startup_aux.h caml/weak.h
+misc_bpic.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/camlatomic.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/osdeps.h caml/version.h \
+ caml/domain.h caml/startup.h caml/exec.h caml/startup_aux.h \
+ caml/startup_aux.h
 obj_bpic.$(O): obj.c caml/camlatomic.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/alloc.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/gc.h \
-  caml/interp.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/prims.h \
-  caml/spacetime.h caml/io.h caml/stack.h
+ caml/misc.h caml/camlatomic.h caml/alloc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/platform.h caml/spacetime.h caml/io.h \
+ caml/stack.h
 parsing_bpic.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h
+ caml/config.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/alloc.h \
+ caml/startup.h caml/exec.h caml/startup_aux.h
 platform_bpic.$(O): platform.c caml/platform.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h
 prims_bpic.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/prims.h
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/prims.h
 printexc_bpic.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/exec.h \
-  caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/debugger.h caml/fail.h caml/printexc.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/exec.h \
+ caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h \
+ caml/debugger.h caml/fail.h caml/misc.h caml/mlvalues.h caml/printexc.h \
+ caml/memory.h
 roots_bpic.$(O): roots.c caml/finalise.h caml/roots.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/memory.h caml/gc.h \
-  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
-  caml/byte_domain_state.tbl caml/major_gc.h caml/minor_gc.h \
-  caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h \
-  caml/globroots.h caml/shared_heap.h caml/fiber.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/shared_heap.h caml/fiber.h
 shared_heap_bpic.$(O): shared_heap.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
-  caml/fail.h caml/fiber.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/domain.h caml/platform.h caml/alloc.h \
-  caml/roots.h caml/globroots.h caml/shared_heap.h caml/sizeclasses.h \
-  caml/startup_aux.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/custom.h \
+ caml/fail.h caml/fiber.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/roots.h caml/gc.h caml/globroots.h caml/memory.h \
+ caml/mlvalues.h caml/platform.h caml/roots.h caml/shared_heap.h \
+ caml/sizeclasses.h caml/startup_aux.h
 signals_bpic.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/fail.h caml/roots.h caml/signals.h \
-  caml/sys.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/callback.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/config.h caml/fail.h \
+ caml/memory.h caml/misc.h caml/mlvalues.h caml/roots.h caml/signals.h \
+ caml/sys.h
 signals_byt_bpic.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/osdeps.h caml/signals.h
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/byte_domain_state.tbl caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/platform.h caml/alloc.h \
+ caml/osdeps.h caml/signals.h
 signals_nat_bpic.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/osdeps.h \
-  caml/signals.h caml/stack.h caml/spacetime.h caml/io.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/osdeps.h caml/domain.h \
+ caml/signals.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h
+skiplist_bpic.$(O): skiplist.c caml/config.h caml/m.h caml/s.h caml/memory.h \
+ caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/skiplist.h
 spacetime_byt_bpic.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/mlvalues.h
 spacetime_nat_bpic.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
-  caml/alloc.h caml/misc.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/platform.h \
-  caml/major_gc.h caml/memory.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/osdeps.h caml/roots.h caml/signals.h caml/stack.h \
-  caml/sys.h caml/spacetime.h
+ caml/alloc.h caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/platform.h \
+ caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/osdeps.h caml/roots.h caml/signals.h \
+ caml/stack.h caml/sys.h caml/spacetime.h caml/stack.h
 spacetime_snapshot_bpic.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
-  caml/config.h caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h caml/intext.h \
-  caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/roots.h \
-  caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h
+ caml/config.h caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
+ caml/intext.h caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 startup_aux_bpic.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/exec.h caml/dynlink.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/callback.h caml/osdeps.h caml/prims.h \
-  caml/startup_aux.h caml/version.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/exec.h caml/dynlink.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/callback.h caml/major_gc.h caml/misc.h \
+ caml/osdeps.h caml/prims.h caml/startup_aux.h caml/version.h
 startup_byt_bpic.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/backtrace.h \
-  caml/exec.h caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/custom.h caml/debugger.h caml/dynlink.h caml/eventlog.h \
-  caml/fail.h caml/fix_code.h caml/gc_ctrl.h caml/instrtrace.h \
-  caml/interp.h caml/intext.h caml/io.h caml/osdeps.h caml/startup_aux.h \
-  caml/prims.h caml/printexc.h caml/reverse.h caml/signals.h \
-  caml/fiber.h caml/roots.h caml/sys.h caml/startup.h caml/version.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/backtrace.h caml/exec.h caml/callback.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/custom.h caml/debugger.h \
+ caml/domain_state.h caml/dynlink.h caml/eventlog.h caml/exec.h \
+ caml/fail.h caml/fix_code.h caml/gc_ctrl.h caml/instrtrace.h \
+ caml/interp.h caml/intext.h caml/io.h caml/io.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/startup_aux.h caml/prims.h caml/printexc.h caml/reverse.h \
+ caml/signals.h caml/fiber.h caml/roots.h caml/sys.h caml/startup.h \
+ caml/startup_aux.h caml/version.h
 startup_nat_bpic.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/backtrace.h \
-  caml/exec.h caml/custom.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
-  caml/intext.h caml/io.h caml/osdeps.h caml/printexc.h caml/stack.h \
-  caml/sys.h caml/startup_aux.h caml/fiber.h caml/roots.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/byte_domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h \
+ caml/custom.h caml/debugger.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
+ caml/intext.h caml/io.h caml/memory.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/printexc.h caml/stack.h caml/sys.h caml/startup_aux.h \
+ caml/fiber.h caml/roots.h
 str_bpic.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h \
+ caml/misc.h
 sys_bpic.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/debugger.h \
-  caml/fail.h caml/gc_ctrl.h caml/io.h caml/platform.h caml/osdeps.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/signals.h caml/fiber.h caml/roots.h caml/sys.h \
-  caml/startup.h caml/exec.h caml/startup_aux.h caml/version.h \
-  caml/callback.h caml/shared_heap.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/debugger.h \
+ caml/fail.h caml/gc_ctrl.h caml/io.h caml/platform.h caml/mlvalues.h \
+ caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/alloc.h caml/signals.h caml/fiber.h \
+ caml/roots.h caml/sys.h caml/startup.h caml/exec.h caml/startup_aux.h \
+ caml/version.h caml/callback.h caml/startup_aux.h caml/major_gc.h \
+ caml/shared_heap.h
 unix_bpic.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/osdeps.h caml/signals.h caml/sys.h \
-  caml/io.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/osdeps.h \
+ caml/signals.h caml/sys.h caml/io.h caml/alloc.h
 weak_bpic.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/platform.h caml/fail.h caml/shared_heap.h caml/roots.h \
-  caml/weak.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/domain.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/alloc.h caml/platform.h caml/fail.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/shared_heap.h caml/roots.h \
+ caml/weak.h
+win32_bpic.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/byte_domain_state.tbl caml/address_class.h \
+ caml/fail.h caml/io.h caml/platform.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/misc.h caml/osdeps.h caml/signals.h \
+ caml/sys.h caml/config.h
 addrmap_n.$(O): addrmap.c caml/config.h caml/m.h caml/s.h caml/memory.h \
-  caml/domain.h caml/misc.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/alloc.h caml/addrmap.h
-afl_n.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h
+ caml/config.h caml/domain.h caml/misc.h caml/camlatomic.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/alloc.h \
+ caml/addrmap.h
+afl_n.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h
 alloc_n.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/major_gc.h caml/memory.h \
-  caml/gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/fiber.h caml/roots.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/major_gc.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h caml/fiber.h \
+ caml/roots.h caml/domain.h
 array_n.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
 backtrace_n.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/backtrace.h caml/exec.h caml/backtrace_prim.h caml/fail.h \
-  caml/debugger.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
 backtrace_byt_n.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/alloc.h caml/custom.h caml/io.h \
-  caml/platform.h caml/instruct.h caml/intext.h caml/exec.h \
-  caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/startup.h \
-  caml/startup_aux.h caml/fiber.h caml/roots.h caml/sys.h \
-  caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/debugger.h
+ caml/mlvalues.h caml/config.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/alloc.h caml/mlvalues.h \
+ caml/custom.h caml/io.h caml/platform.h caml/instruct.h caml/intext.h \
+ caml/io.h caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/startup.h caml/exec.h caml/startup_aux.h \
+ caml/fiber.h caml/roots.h caml/sys.h caml/backtrace.h caml/fail.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
 backtrace_nat_n.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/backtrace.h caml/exec.h \
-  caml/backtrace_prim.h frame_descriptors.h caml/stack.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/fiber.h caml/roots.h caml/fail.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
+ caml/backtrace.h frame_descriptors.h caml/config.h caml/stack.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h caml/fiber.h caml/roots.h caml/fail.h
 bigarray_n.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/bigarray.h caml/custom.h caml/fail.h \
-  caml/intext.h caml/io.h caml/platform.h caml/hash.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/signals.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/bigarray.h caml/custom.h caml/fail.h \
+ caml/intext.h caml/io.h caml/platform.h caml/hash.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/mlvalues.h caml/signals.h
 callback_n.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/fail.h caml/fiber.h caml/roots.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/fail.h caml/memory.h caml/mlvalues.h caml/platform.h \
+ caml/fiber.h caml/roots.h
 clambda_checks_n.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl
+ caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl
 compare_n.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h
+ caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/mlvalues.h
 custom_n.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/gc_ctrl.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/shared_heap.h caml/roots.h \
-  caml/signals.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/fail.h caml/gc_ctrl.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h \
+ caml/shared_heap.h caml/roots.h caml/signals.h
 debugger_n.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/debugger.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/osdeps.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/debugger.h caml/misc.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/osdeps.h
 domain_n.$(O): domain.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/platform.h \
-  caml/custom.h caml/shared_heap.h caml/roots.h caml/fail.h \
-  caml/globroots.h caml/signals.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h caml/fiber.h caml/callback.h caml/eventlog.h \
-  caml/gc_ctrl.h caml/osdeps.h caml/weak.h caml/finalise.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/platform.h caml/domain_state.h caml/platform.h \
+ caml/custom.h caml/major_gc.h caml/shared_heap.h caml/roots.h \
+ caml/memory.h caml/fail.h caml/globroots.h caml/signals.h caml/startup.h \
+ caml/exec.h caml/startup_aux.h caml/fiber.h caml/callback.h \
+ caml/minor_gc.h caml/eventlog.h caml/gc_ctrl.h caml/osdeps.h caml/weak.h \
+ caml/finalise.h
 dynlink_n.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/osdeps.h caml/prims.h caml/signals.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/dynlink.h caml/fail.h \
+ caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/platform.h caml/alloc.h \
+ caml/misc.h caml/osdeps.h caml/prims.h caml/signals.h
 dynlink_nat_n.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/stack.h caml/callback.h caml/intext.h caml/io.h \
-  caml/osdeps.h caml/fail.h frame_descriptors.h caml/globroots.h \
-  caml/roots.h caml/signals.h caml/hooks.h
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/stack.h caml/callback.h \
+ caml/alloc.h caml/intext.h caml/io.h caml/osdeps.h caml/fail.h \
+ frame_descriptors.h caml/config.h caml/globroots.h caml/roots.h \
+ caml/signals.h caml/hooks.h
 eventlog_n.$(O): eventlog.c caml/domain.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/alloc.h caml/platform.h \
-  caml/eventlog.h caml/osdeps.h caml/startup_aux.h
+ caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/alloc.h \
+ caml/platform.h caml/eventlog.h caml/osdeps.h caml/platform.h \
+ caml/startup_aux.h
 extern_n.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/gc.h \
-  caml/intext.h caml/io.h caml/platform.h caml/md5.h caml/memory.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/reverse.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/custom.h caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/platform.h caml/io.h caml/md5.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h caml/addrmap.h
 fail_byt_n.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/fail.h caml/io.h caml/printexc.h caml/signals.h \
-  caml/fiber.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/fail.h caml/gc.h caml/io.h \
+ caml/memory.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
+ caml/fiber.h caml/roots.h
 fail_nat_n.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/io.h caml/platform.h caml/gc.h \
-  caml/memory.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/printexc.h caml/signals.h caml/stack.h caml/roots.h \
-  caml/callback.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/io.h caml/platform.h caml/gc.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/mlvalues.h caml/printexc.h \
+ caml/signals.h caml/stack.h caml/roots.h caml/callback.h
 fiber_n.$(O): fiber.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/fiber.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/roots.h caml/gc_ctrl.h caml/instruct.h caml/fail.h \
-  caml/fix_code.h caml/shared_heap.h caml/startup_aux.h caml/stack.h \
-  frame_descriptors.h
+ caml/camlatomic.h caml/misc.h caml/fiber.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/roots.h caml/gc_ctrl.h caml/instruct.h \
+ caml/fail.h caml/alloc.h caml/platform.h caml/fix_code.h caml/minor_gc.h \
+ caml/major_gc.h caml/shared_heap.h caml/memory.h caml/startup_aux.h \
+ caml/stack.h frame_descriptors.h caml/config.h
 finalise_n.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/eventlog.h caml/fail.h caml/finalise.h caml/roots.h \
-  caml/shared_heap.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/eventlog.h caml/fail.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/minor_gc.h caml/misc.h caml/roots.h \
+ caml/shared_heap.h
 fix_code_n.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
-  caml/io.h caml/platform.h caml/md5.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/alloc.h caml/reverse.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/fix_code.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/platform.h caml/md5.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 floats_n.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/reverse.h caml/fiber.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h caml/misc.h \
+ caml/reverse.h caml/fiber.h caml/roots.h
 frame_descriptors_n.$(O): frame_descriptors.c frame_descriptors.h \
-  caml/config.h caml/m.h caml/s.h caml/platform.h caml/mlvalues.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/major_gc.h caml/memory.h caml/gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/alloc.h
+ caml/config.h caml/m.h caml/s.h caml/platform.h caml/mlvalues.h \
+ caml/config.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/major_gc.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h
 gc_ctrl_n.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/finalise.h caml/roots.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/gc_ctrl.h caml/shared_heap.h \
-  caml/stack.h frame_descriptors.h caml/globroots.h caml/signals.h \
-  caml/startup.h caml/exec.h caml/startup_aux.h caml/eventlog.h \
-  caml/fail.h
-globroots_n.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
-  caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/roots.h caml/globroots.h caml/callback.h \
-  caml/shared_heap.h caml/stack.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/minor_gc.h caml/shared_heap.h caml/misc.h \
+ caml/mlvalues.h caml/stack.h frame_descriptors.h caml/config.h \
+ caml/domain.h caml/globroots.h caml/signals.h caml/startup.h caml/exec.h \
+ caml/startup_aux.h caml/eventlog.h caml/fail.h
+globroots_n.$(O): globroots.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/roots.h caml/memory.h caml/gc.h caml/mlvalues.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/globroots.h caml/roots.h caml/skiplist.h caml/stack.h
 hash_n.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/hash.h caml/fail.h
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/hash.h caml/fail.h
 instrtrace_n.$(O): instrtrace.c
 intern_n.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
-  caml/md5.h caml/reverse.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/config.h caml/custom.h caml/fail.h \
+ caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h \
+ caml/mlvalues.h caml/misc.h caml/reverse.h
 interp_n.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/debugger.h caml/fail.h \
-  caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
-  caml/prims.h caml/signals.h caml/fiber.h caml/roots.h caml/globroots.h \
-  caml/startup.h caml/startup_aux.h caml/jumptbl.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/debugger.h caml/fail.h \
+ caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
+ caml/major_gc.h caml/memory.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/signals.h caml/fiber.h caml/roots.h caml/domain.h caml/globroots.h \
+ caml/startup.h caml/startup_aux.h caml/startup_aux.h caml/jumptbl.h
 ints_n.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/intext.h \
-  caml/io.h caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/fail.h caml/intext.h caml/io.h \
+ caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h
 io_n.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/io.h \
-  caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/osdeps.h \
-  caml/signals.h caml/sys.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/fail.h caml/io.h \
+ caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/signals.h caml/sys.h
 lexing_n.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fiber.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/mlvalues.h caml/fiber.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/roots.h
 main_n.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h
 major_gc_n.$(O): major_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/alloc.h caml/platform.h \
-  caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h caml/finalise.h \
-  caml/globroots.h caml/shared_heap.h caml/startup_aux.h caml/weak.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/domain.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h \
+ caml/roots.h caml/finalise.h caml/globroots.h caml/memory.h \
+ caml/mlvalues.h caml/platform.h caml/roots.h caml/shared_heap.h \
+ caml/startup_aux.h caml/weak.h
 md5_n.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/md5.h caml/io.h caml/platform.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/reverse.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/md5.h caml/io.h caml/platform.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/mlvalues.h caml/io.h \
+ caml/reverse.h
 memory_n.$(O): memory.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/fail.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/shared_heap.h caml/roots.h caml/fiber.h \
-  caml/eventlog.h
+ caml/config.h caml/camlatomic.h caml/misc.h caml/fail.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/major_gc.h \
+ caml/shared_heap.h caml/roots.h caml/domain.h caml/addrmap.h \
+ caml/roots.h caml/alloc.h caml/fiber.h caml/platform.h caml/eventlog.h
 memprof_n.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/roots.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/fail.h caml/callback.h \
-  caml/signals.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
-  caml/weak.h caml/stack.h
+ caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/roots.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/fail.h caml/alloc.h caml/callback.h \
+ caml/signals.h caml/memory.h caml/minor_gc.h caml/backtrace_prim.h \
+ caml/backtrace.h caml/exec.h caml/weak.h caml/stack.h caml/misc.h
 meta_n.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/fix_code.h caml/interp.h \
-  caml/intext.h caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
-  caml/gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h caml/prims.h \
-  caml/fiber.h caml/roots.h caml/startup_aux.h caml/debugger.h \
-  caml/backtrace_prim.h caml/backtrace.h caml/exec.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/fail.h caml/fix_code.h \
+ caml/interp.h caml/intext.h caml/io.h caml/platform.h caml/major_gc.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/fiber.h caml/roots.h \
+ caml/startup_aux.h caml/debugger.h caml/backtrace_prim.h \
+ caml/backtrace.h caml/exec.h
 minor_gc_n.$(O): minor_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/domain.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/alloc.h caml/platform.h \
-  caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h caml/finalise.h \
-  caml/gc_ctrl.h caml/shared_heap.h caml/signals.h caml/startup_aux.h \
-  caml/weak.h
-misc_n.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/memory.h caml/gc.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/osdeps.h caml/version.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/custom.h caml/domain.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/alloc.h caml/platform.h caml/eventlog.h caml/fail.h \
+ caml/fiber.h caml/roots.h caml/finalise.h caml/gc.h caml/gc_ctrl.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/platform.h caml/roots.h \
+ caml/shared_heap.h caml/signals.h caml/startup_aux.h caml/weak.h
+misc_n.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/camlatomic.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/osdeps.h caml/version.h caml/domain.h \
+ caml/startup.h caml/exec.h caml/startup_aux.h caml/startup_aux.h
 obj_n.$(O): obj.c caml/camlatomic.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/alloc.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/gc.h caml/interp.h \
-  caml/major_gc.h caml/memory.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/prims.h caml/spacetime.h caml/io.h \
-  caml/stack.h
+ caml/misc.h caml/camlatomic.h caml/alloc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/fail.h caml/gc.h \
+ caml/interp.h caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/prims.h caml/platform.h caml/spacetime.h caml/io.h caml/stack.h
 parsing_n.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/startup.h caml/exec.h caml/startup_aux.h
+ caml/config.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/alloc.h caml/startup.h \
+ caml/exec.h caml/startup_aux.h
 platform_n.$(O): platform.c caml/platform.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h
 prims_n.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/prims.h
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/prims.h
 printexc_n.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/exec.h caml/callback.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/debugger.h caml/fail.h \
-  caml/printexc.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/exec.h caml/callback.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/debugger.h caml/fail.h caml/misc.h \
+ caml/mlvalues.h caml/printexc.h caml/memory.h
 roots_n.$(O): roots.c caml/finalise.h caml/roots.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/memory.h caml/gc.h \
-  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/globroots.h caml/shared_heap.h \
-  caml/fiber.h caml/stack.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/globroots.h caml/major_gc.h \
+ caml/memory.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/shared_heap.h caml/fiber.h caml/stack.h
 shared_heap_n.$(O): shared_heap.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/fiber.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h caml/globroots.h \
-  caml/shared_heap.h caml/sizeclasses.h caml/startup_aux.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/fail.h caml/fiber.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/roots.h caml/gc.h \
+ caml/globroots.h caml/memory.h caml/mlvalues.h caml/platform.h \
+ caml/roots.h caml/shared_heap.h caml/sizeclasses.h caml/startup_aux.h
 signals_n.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/fail.h caml/roots.h caml/signals.h caml/sys.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/config.h caml/fail.h caml/memory.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/signals.h caml/sys.h
 signals_byt_n.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/osdeps.h caml/signals.h
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/osdeps.h caml/signals.h
 signals_nat_n.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/osdeps.h caml/signals.h caml/stack.h \
-  caml/spacetime.h caml/io.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/osdeps.h caml/domain.h caml/signals.h \
+ caml/stack.h caml/spacetime.h caml/io.h caml/stack.h
+skiplist_n.$(O): skiplist.c caml/config.h caml/m.h caml/s.h caml/memory.h \
+ caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/misc.h caml/skiplist.h
 spacetime_byt_n.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/mlvalues.h
 spacetime_nat_n.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
-  caml/alloc.h caml/misc.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/fail.h caml/gc.h \
-  caml/intext.h caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/osdeps.h \
-  caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h
+ caml/alloc.h caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
+ caml/spacetime.h caml/stack.h
 spacetime_snapshot_n.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
-  caml/config.h caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/custom.h caml/fail.h \
-  caml/gc.h caml/gc_ctrl.h caml/intext.h caml/io.h caml/platform.h \
-  caml/major_gc.h caml/memory.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
-  caml/spacetime.h
+ caml/config.h caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/config.h caml/custom.h \
+ caml/fail.h caml/gc.h caml/gc_ctrl.h caml/intext.h caml/io.h \
+ caml/platform.h caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/signals.h \
+ caml/stack.h caml/sys.h caml/spacetime.h caml/stack.h
 startup_aux_n.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/exec.h caml/dynlink.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/callback.h \
-  caml/osdeps.h caml/prims.h caml/startup_aux.h caml/version.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/exec.h caml/dynlink.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/callback.h \
+ caml/major_gc.h caml/misc.h caml/osdeps.h caml/prims.h \
+ caml/startup_aux.h caml/version.h
 startup_byt_n.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/custom.h caml/debugger.h \
-  caml/dynlink.h caml/eventlog.h caml/fail.h caml/fix_code.h \
-  caml/gc_ctrl.h caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h \
-  caml/osdeps.h caml/startup_aux.h caml/prims.h caml/printexc.h \
-  caml/reverse.h caml/signals.h caml/fiber.h caml/roots.h caml/sys.h \
-  caml/startup.h caml/version.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/backtrace.h caml/exec.h \
+ caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h caml/custom.h \
+ caml/debugger.h caml/domain_state.h caml/dynlink.h caml/eventlog.h \
+ caml/exec.h caml/fail.h caml/fix_code.h caml/gc_ctrl.h caml/instrtrace.h \
+ caml/interp.h caml/intext.h caml/io.h caml/io.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/startup_aux.h caml/prims.h caml/printexc.h caml/reverse.h \
+ caml/signals.h caml/fiber.h caml/roots.h caml/sys.h caml/startup.h \
+ caml/startup_aux.h caml/version.h
 startup_nat_n.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h \
-  caml/custom.h caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/intext.h \
-  caml/io.h caml/osdeps.h caml/printexc.h caml/stack.h caml/sys.h \
-  caml/startup_aux.h caml/fiber.h caml/roots.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h caml/custom.h \
+ caml/debugger.h caml/fail.h caml/gc.h caml/gc_ctrl.h caml/intext.h \
+ caml/io.h caml/memory.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/printexc.h caml/stack.h caml/sys.h caml/startup_aux.h caml/fiber.h \
+ caml/roots.h
 str_n.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h caml/misc.h
 sys_n.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/debugger.h caml/fail.h caml/gc_ctrl.h \
-  caml/io.h caml/platform.h caml/osdeps.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/signals.h caml/fiber.h caml/roots.h caml/sys.h caml/startup.h \
-  caml/exec.h caml/startup_aux.h caml/version.h caml/callback.h \
-  caml/shared_heap.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/debugger.h caml/fail.h caml/gc_ctrl.h \
+ caml/io.h caml/platform.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/signals.h caml/fiber.h caml/roots.h caml/sys.h \
+ caml/startup.h caml/exec.h caml/startup_aux.h caml/version.h \
+ caml/callback.h caml/startup_aux.h caml/major_gc.h caml/shared_heap.h
 unix_n.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/osdeps.h caml/signals.h caml/sys.h caml/io.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/misc.h caml/osdeps.h caml/signals.h \
+ caml/sys.h caml/io.h caml/alloc.h
 weak_n.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/platform.h \
-  caml/fail.h caml/shared_heap.h caml/roots.h caml/weak.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/platform.h caml/fail.h caml/major_gc.h caml/memory.h \
+ caml/mlvalues.h caml/shared_heap.h caml/roots.h caml/weak.h
+win32_n.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/address_class.h caml/fail.h caml/io.h \
+ caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/misc.h \
+ caml/osdeps.h caml/signals.h caml/sys.h caml/config.h
 addrmap_nd.$(O): addrmap.c caml/config.h caml/m.h caml/s.h caml/memory.h \
-  caml/domain.h caml/misc.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/alloc.h caml/addrmap.h
-afl_nd.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h
+ caml/config.h caml/domain.h caml/misc.h caml/camlatomic.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/alloc.h \
+ caml/addrmap.h
+afl_nd.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h
 alloc_nd.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/major_gc.h caml/memory.h \
-  caml/gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/fiber.h caml/roots.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/major_gc.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h caml/fiber.h \
+ caml/roots.h caml/domain.h
 array_nd.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
 backtrace_nd.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/backtrace.h caml/exec.h caml/backtrace_prim.h caml/fail.h \
-  caml/debugger.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
 backtrace_byt_nd.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/alloc.h caml/custom.h caml/io.h \
-  caml/platform.h caml/instruct.h caml/intext.h caml/exec.h \
-  caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/startup.h \
-  caml/startup_aux.h caml/fiber.h caml/roots.h caml/sys.h \
-  caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/debugger.h
+ caml/mlvalues.h caml/config.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/alloc.h caml/mlvalues.h \
+ caml/custom.h caml/io.h caml/platform.h caml/instruct.h caml/intext.h \
+ caml/io.h caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/startup.h caml/exec.h caml/startup_aux.h \
+ caml/fiber.h caml/roots.h caml/sys.h caml/backtrace.h caml/fail.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
 backtrace_nat_nd.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/backtrace.h caml/exec.h \
-  caml/backtrace_prim.h frame_descriptors.h caml/stack.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/fiber.h caml/roots.h caml/fail.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
+ caml/backtrace.h frame_descriptors.h caml/config.h caml/stack.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h caml/fiber.h caml/roots.h caml/fail.h
 bigarray_nd.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/bigarray.h caml/custom.h caml/fail.h \
-  caml/intext.h caml/io.h caml/platform.h caml/hash.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/signals.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/bigarray.h caml/custom.h caml/fail.h \
+ caml/intext.h caml/io.h caml/platform.h caml/hash.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/mlvalues.h caml/signals.h
 callback_nd.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/fail.h caml/fiber.h caml/roots.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/fail.h caml/memory.h caml/mlvalues.h caml/platform.h \
+ caml/fiber.h caml/roots.h
 clambda_checks_nd.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl
+ caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl
 compare_nd.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h
+ caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/mlvalues.h
 custom_nd.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/gc_ctrl.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/shared_heap.h caml/roots.h \
-  caml/signals.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/fail.h caml/gc_ctrl.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h \
+ caml/shared_heap.h caml/roots.h caml/signals.h
 debugger_nd.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/debugger.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/osdeps.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/debugger.h caml/misc.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/osdeps.h
 domain_nd.$(O): domain.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/platform.h \
-  caml/custom.h caml/shared_heap.h caml/roots.h caml/fail.h \
-  caml/globroots.h caml/signals.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h caml/fiber.h caml/callback.h caml/eventlog.h \
-  caml/gc_ctrl.h caml/osdeps.h caml/weak.h caml/finalise.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/platform.h caml/domain_state.h caml/platform.h \
+ caml/custom.h caml/major_gc.h caml/shared_heap.h caml/roots.h \
+ caml/memory.h caml/fail.h caml/globroots.h caml/signals.h caml/startup.h \
+ caml/exec.h caml/startup_aux.h caml/fiber.h caml/callback.h \
+ caml/minor_gc.h caml/eventlog.h caml/gc_ctrl.h caml/osdeps.h caml/weak.h \
+ caml/finalise.h caml/domain_state.tbl
 dynlink_nd.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/osdeps.h caml/prims.h caml/signals.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/dynlink.h caml/fail.h \
+ caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/platform.h caml/alloc.h \
+ caml/misc.h caml/osdeps.h caml/prims.h caml/signals.h
 dynlink_nat_nd.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/stack.h caml/callback.h caml/intext.h caml/io.h \
-  caml/osdeps.h caml/fail.h frame_descriptors.h caml/globroots.h \
-  caml/roots.h caml/signals.h caml/hooks.h
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/stack.h caml/callback.h \
+ caml/alloc.h caml/intext.h caml/io.h caml/osdeps.h caml/fail.h \
+ frame_descriptors.h caml/config.h caml/globroots.h caml/roots.h \
+ caml/signals.h caml/hooks.h
 eventlog_nd.$(O): eventlog.c caml/domain.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/alloc.h caml/platform.h \
-  caml/eventlog.h caml/osdeps.h caml/startup_aux.h
+ caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/alloc.h \
+ caml/platform.h caml/eventlog.h caml/osdeps.h caml/platform.h \
+ caml/startup_aux.h
 extern_nd.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/gc.h \
-  caml/intext.h caml/io.h caml/platform.h caml/md5.h caml/memory.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/reverse.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/custom.h caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/platform.h caml/io.h caml/md5.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h caml/addrmap.h
 fail_byt_nd.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/fail.h caml/io.h caml/printexc.h caml/signals.h \
-  caml/fiber.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/fail.h caml/gc.h caml/io.h \
+ caml/memory.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
+ caml/fiber.h caml/roots.h
 fail_nat_nd.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/io.h caml/platform.h caml/gc.h \
-  caml/memory.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/printexc.h caml/signals.h caml/stack.h caml/roots.h \
-  caml/callback.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/io.h caml/platform.h caml/gc.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/mlvalues.h caml/printexc.h \
+ caml/signals.h caml/stack.h caml/roots.h caml/callback.h
 fiber_nd.$(O): fiber.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/fiber.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/roots.h caml/gc_ctrl.h caml/instruct.h caml/fail.h \
-  caml/fix_code.h caml/shared_heap.h caml/startup_aux.h caml/stack.h \
-  frame_descriptors.h
+ caml/camlatomic.h caml/misc.h caml/fiber.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/roots.h caml/gc_ctrl.h caml/instruct.h \
+ caml/fail.h caml/alloc.h caml/platform.h caml/fix_code.h caml/minor_gc.h \
+ caml/major_gc.h caml/shared_heap.h caml/memory.h caml/startup_aux.h \
+ caml/stack.h frame_descriptors.h caml/config.h
 finalise_nd.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/eventlog.h caml/fail.h caml/finalise.h caml/roots.h \
-  caml/shared_heap.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/eventlog.h caml/fail.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/minor_gc.h caml/misc.h caml/roots.h \
+ caml/shared_heap.h
 fix_code_nd.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
-  caml/io.h caml/platform.h caml/md5.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/alloc.h caml/reverse.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/fix_code.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/platform.h caml/md5.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 floats_nd.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/reverse.h caml/fiber.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h caml/misc.h \
+ caml/reverse.h caml/fiber.h caml/roots.h
 frame_descriptors_nd.$(O): frame_descriptors.c frame_descriptors.h \
-  caml/config.h caml/m.h caml/s.h caml/platform.h caml/mlvalues.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/major_gc.h caml/memory.h caml/gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/alloc.h
+ caml/config.h caml/m.h caml/s.h caml/platform.h caml/mlvalues.h \
+ caml/config.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/major_gc.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h
 gc_ctrl_nd.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/finalise.h caml/roots.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/gc_ctrl.h caml/shared_heap.h \
-  caml/stack.h frame_descriptors.h caml/globroots.h caml/signals.h \
-  caml/startup.h caml/exec.h caml/startup_aux.h caml/eventlog.h \
-  caml/fail.h
-globroots_nd.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
-  caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/roots.h caml/globroots.h caml/callback.h \
-  caml/shared_heap.h caml/stack.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/minor_gc.h caml/shared_heap.h caml/misc.h \
+ caml/mlvalues.h caml/stack.h frame_descriptors.h caml/config.h \
+ caml/domain.h caml/globroots.h caml/signals.h caml/startup.h caml/exec.h \
+ caml/startup_aux.h caml/eventlog.h caml/fail.h
+globroots_nd.$(O): globroots.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/roots.h caml/memory.h caml/gc.h caml/mlvalues.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/globroots.h caml/roots.h caml/skiplist.h caml/stack.h
 hash_nd.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/hash.h caml/fail.h
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/hash.h caml/fail.h
 instrtrace_nd.$(O): instrtrace.c caml/instrtrace.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/instruct.h \
-  caml/opnames.h caml/prims.h caml/fiber.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/instruct.h caml/misc.h \
+ caml/mlvalues.h caml/opnames.h caml/prims.h caml/fiber.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/roots.h caml/domain.h caml/startup.h \
+ caml/exec.h caml/startup_aux.h
 intern_nd.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
-  caml/md5.h caml/reverse.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/config.h caml/custom.h caml/fail.h \
+ caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h \
+ caml/mlvalues.h caml/misc.h caml/reverse.h
 interp_nd.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/debugger.h caml/fail.h \
-  caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
-  caml/prims.h caml/signals.h caml/fiber.h caml/roots.h caml/globroots.h \
-  caml/startup.h caml/startup_aux.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/debugger.h caml/fail.h \
+ caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
+ caml/major_gc.h caml/memory.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/signals.h caml/fiber.h caml/roots.h caml/domain.h caml/globroots.h \
+ caml/startup.h caml/startup_aux.h caml/startup_aux.h
 ints_nd.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/intext.h \
-  caml/io.h caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/fail.h caml/intext.h caml/io.h \
+ caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h
 io_nd.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/io.h \
-  caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/osdeps.h \
-  caml/signals.h caml/sys.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/fail.h caml/io.h \
+ caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/signals.h caml/sys.h
 lexing_nd.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fiber.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/mlvalues.h caml/fiber.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/roots.h
 main_nd.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h
 major_gc_nd.$(O): major_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/alloc.h caml/platform.h \
-  caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h caml/finalise.h \
-  caml/globroots.h caml/shared_heap.h caml/startup_aux.h caml/weak.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/domain.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h \
+ caml/roots.h caml/finalise.h caml/globroots.h caml/memory.h \
+ caml/mlvalues.h caml/platform.h caml/roots.h caml/shared_heap.h \
+ caml/startup_aux.h caml/weak.h
 md5_nd.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/md5.h caml/io.h caml/platform.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/reverse.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/md5.h caml/io.h caml/platform.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/mlvalues.h caml/io.h \
+ caml/reverse.h
 memory_nd.$(O): memory.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/fail.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/shared_heap.h caml/roots.h caml/fiber.h \
-  caml/eventlog.h
+ caml/config.h caml/camlatomic.h caml/misc.h caml/fail.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/major_gc.h \
+ caml/shared_heap.h caml/roots.h caml/domain.h caml/addrmap.h \
+ caml/roots.h caml/alloc.h caml/fiber.h caml/platform.h caml/eventlog.h
 memprof_nd.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/roots.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/fail.h caml/callback.h \
-  caml/signals.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
-  caml/weak.h caml/stack.h
+ caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/roots.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/fail.h caml/alloc.h caml/callback.h \
+ caml/signals.h caml/memory.h caml/minor_gc.h caml/backtrace_prim.h \
+ caml/backtrace.h caml/exec.h caml/weak.h caml/stack.h caml/misc.h
 meta_nd.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/fix_code.h caml/interp.h \
-  caml/intext.h caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
-  caml/gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h caml/prims.h \
-  caml/fiber.h caml/roots.h caml/startup_aux.h caml/debugger.h \
-  caml/backtrace_prim.h caml/backtrace.h caml/exec.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/fail.h caml/fix_code.h \
+ caml/interp.h caml/intext.h caml/io.h caml/platform.h caml/major_gc.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/fiber.h caml/roots.h \
+ caml/startup_aux.h caml/debugger.h caml/backtrace_prim.h \
+ caml/backtrace.h caml/exec.h
 minor_gc_nd.$(O): minor_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/domain.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/alloc.h caml/platform.h \
-  caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h caml/finalise.h \
-  caml/gc_ctrl.h caml/shared_heap.h caml/signals.h caml/startup_aux.h \
-  caml/weak.h
-misc_nd.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/memory.h caml/gc.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/osdeps.h caml/version.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/custom.h caml/domain.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/alloc.h caml/platform.h caml/eventlog.h caml/fail.h \
+ caml/fiber.h caml/roots.h caml/finalise.h caml/gc.h caml/gc_ctrl.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/platform.h caml/roots.h \
+ caml/shared_heap.h caml/signals.h caml/startup_aux.h caml/weak.h
+misc_nd.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/camlatomic.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/osdeps.h caml/version.h caml/domain.h \
+ caml/startup.h caml/exec.h caml/startup_aux.h caml/startup_aux.h
 obj_nd.$(O): obj.c caml/camlatomic.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/alloc.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/gc.h caml/interp.h \
-  caml/major_gc.h caml/memory.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/prims.h caml/spacetime.h caml/io.h \
-  caml/stack.h
+ caml/misc.h caml/camlatomic.h caml/alloc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/fail.h caml/gc.h \
+ caml/interp.h caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/prims.h caml/platform.h caml/spacetime.h caml/io.h caml/stack.h
 parsing_nd.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/startup.h caml/exec.h caml/startup_aux.h
+ caml/config.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/alloc.h caml/startup.h \
+ caml/exec.h caml/startup_aux.h
 platform_nd.$(O): platform.c caml/platform.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h
 prims_nd.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/prims.h
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/prims.h
 printexc_nd.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/exec.h caml/callback.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/debugger.h caml/fail.h \
-  caml/printexc.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/exec.h caml/callback.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/debugger.h caml/fail.h caml/misc.h \
+ caml/mlvalues.h caml/printexc.h caml/memory.h
 roots_nd.$(O): roots.c caml/finalise.h caml/roots.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/memory.h caml/gc.h \
-  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/globroots.h caml/shared_heap.h \
-  caml/fiber.h caml/stack.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/globroots.h caml/major_gc.h \
+ caml/memory.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/shared_heap.h caml/fiber.h caml/stack.h
 shared_heap_nd.$(O): shared_heap.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/fiber.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h caml/globroots.h \
-  caml/shared_heap.h caml/sizeclasses.h caml/startup_aux.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/fail.h caml/fiber.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/roots.h caml/gc.h \
+ caml/globroots.h caml/memory.h caml/mlvalues.h caml/platform.h \
+ caml/roots.h caml/shared_heap.h caml/sizeclasses.h caml/startup_aux.h
 signals_nd.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/fail.h caml/roots.h caml/signals.h caml/sys.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/config.h caml/fail.h caml/memory.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/signals.h caml/sys.h
 signals_byt_nd.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/osdeps.h caml/signals.h
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/osdeps.h caml/signals.h
 signals_nat_nd.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/osdeps.h caml/signals.h caml/stack.h \
-  caml/spacetime.h caml/io.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/osdeps.h caml/domain.h caml/signals.h \
+ caml/stack.h caml/spacetime.h caml/io.h caml/stack.h
+skiplist_nd.$(O): skiplist.c caml/config.h caml/m.h caml/s.h caml/memory.h \
+ caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/misc.h caml/skiplist.h
 spacetime_byt_nd.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/mlvalues.h
 spacetime_nat_nd.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
-  caml/alloc.h caml/misc.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/fail.h caml/gc.h \
-  caml/intext.h caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/osdeps.h \
-  caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h
+ caml/alloc.h caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
+ caml/spacetime.h caml/stack.h
 spacetime_snapshot_nd.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
-  caml/config.h caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/custom.h caml/fail.h \
-  caml/gc.h caml/gc_ctrl.h caml/intext.h caml/io.h caml/platform.h \
-  caml/major_gc.h caml/memory.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
-  caml/spacetime.h
+ caml/config.h caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/config.h caml/custom.h \
+ caml/fail.h caml/gc.h caml/gc_ctrl.h caml/intext.h caml/io.h \
+ caml/platform.h caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/signals.h \
+ caml/stack.h caml/sys.h caml/spacetime.h caml/stack.h
 startup_aux_nd.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/exec.h caml/dynlink.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/callback.h \
-  caml/osdeps.h caml/prims.h caml/startup_aux.h caml/version.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/exec.h caml/dynlink.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/callback.h \
+ caml/major_gc.h caml/misc.h caml/osdeps.h caml/prims.h \
+ caml/startup_aux.h caml/version.h
 startup_byt_nd.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/custom.h caml/debugger.h \
-  caml/dynlink.h caml/eventlog.h caml/fail.h caml/fix_code.h \
-  caml/gc_ctrl.h caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h \
-  caml/osdeps.h caml/startup_aux.h caml/prims.h caml/printexc.h \
-  caml/reverse.h caml/signals.h caml/fiber.h caml/roots.h caml/sys.h \
-  caml/startup.h caml/version.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/backtrace.h caml/exec.h \
+ caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h caml/custom.h \
+ caml/debugger.h caml/domain_state.h caml/dynlink.h caml/eventlog.h \
+ caml/exec.h caml/fail.h caml/fix_code.h caml/gc_ctrl.h caml/instrtrace.h \
+ caml/interp.h caml/intext.h caml/io.h caml/io.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/startup_aux.h caml/prims.h caml/printexc.h caml/reverse.h \
+ caml/signals.h caml/fiber.h caml/roots.h caml/sys.h caml/startup.h \
+ caml/startup_aux.h caml/version.h
 startup_nat_nd.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h \
-  caml/custom.h caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/intext.h \
-  caml/io.h caml/osdeps.h caml/printexc.h caml/stack.h caml/sys.h \
-  caml/startup_aux.h caml/fiber.h caml/roots.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h caml/custom.h \
+ caml/debugger.h caml/fail.h caml/gc.h caml/gc_ctrl.h caml/intext.h \
+ caml/io.h caml/memory.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/printexc.h caml/stack.h caml/sys.h caml/startup_aux.h caml/fiber.h \
+ caml/roots.h
 str_nd.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h caml/misc.h
 sys_nd.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/debugger.h caml/fail.h caml/gc_ctrl.h \
-  caml/io.h caml/platform.h caml/osdeps.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/signals.h caml/fiber.h caml/roots.h caml/sys.h caml/startup.h \
-  caml/exec.h caml/startup_aux.h caml/version.h caml/callback.h \
-  caml/shared_heap.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/debugger.h caml/fail.h caml/gc_ctrl.h \
+ caml/io.h caml/platform.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/signals.h caml/fiber.h caml/roots.h caml/sys.h \
+ caml/startup.h caml/exec.h caml/startup_aux.h caml/version.h \
+ caml/callback.h caml/startup_aux.h caml/major_gc.h caml/shared_heap.h
 unix_nd.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/osdeps.h caml/signals.h caml/sys.h caml/io.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/misc.h caml/osdeps.h caml/signals.h \
+ caml/sys.h caml/io.h caml/alloc.h
 weak_nd.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/platform.h \
-  caml/fail.h caml/shared_heap.h caml/roots.h caml/weak.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/platform.h caml/fail.h caml/major_gc.h caml/memory.h \
+ caml/mlvalues.h caml/shared_heap.h caml/roots.h caml/weak.h
+win32_nd.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/address_class.h caml/fail.h caml/io.h \
+ caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/misc.h \
+ caml/osdeps.h caml/signals.h caml/sys.h caml/config.h
 addrmap_ni.$(O): addrmap.c caml/config.h caml/m.h caml/s.h caml/memory.h \
-  caml/domain.h caml/misc.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/alloc.h caml/addrmap.h
-afl_ni.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h
+ caml/config.h caml/domain.h caml/misc.h caml/camlatomic.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/alloc.h \
+ caml/addrmap.h
+afl_ni.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h
 alloc_ni.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/major_gc.h caml/memory.h \
-  caml/gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/fiber.h caml/roots.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/major_gc.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h caml/fiber.h \
+ caml/roots.h caml/domain.h
 array_ni.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
 backtrace_ni.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/backtrace.h caml/exec.h caml/backtrace_prim.h caml/fail.h \
-  caml/debugger.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
 backtrace_byt_ni.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/alloc.h caml/custom.h caml/io.h \
-  caml/platform.h caml/instruct.h caml/intext.h caml/exec.h \
-  caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/startup.h \
-  caml/startup_aux.h caml/fiber.h caml/roots.h caml/sys.h \
-  caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/debugger.h
+ caml/mlvalues.h caml/config.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/alloc.h caml/mlvalues.h \
+ caml/custom.h caml/io.h caml/platform.h caml/instruct.h caml/intext.h \
+ caml/io.h caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/startup.h caml/exec.h caml/startup_aux.h \
+ caml/fiber.h caml/roots.h caml/sys.h caml/backtrace.h caml/fail.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
 backtrace_nat_ni.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/backtrace.h caml/exec.h \
-  caml/backtrace_prim.h frame_descriptors.h caml/stack.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/fiber.h caml/roots.h caml/fail.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
+ caml/backtrace.h frame_descriptors.h caml/config.h caml/stack.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h caml/fiber.h caml/roots.h caml/fail.h
 bigarray_ni.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/bigarray.h caml/custom.h caml/fail.h \
-  caml/intext.h caml/io.h caml/platform.h caml/hash.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/signals.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/bigarray.h caml/custom.h caml/fail.h \
+ caml/intext.h caml/io.h caml/platform.h caml/hash.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/mlvalues.h caml/signals.h
 callback_ni.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/fail.h caml/fiber.h caml/roots.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/fail.h caml/memory.h caml/mlvalues.h caml/platform.h \
+ caml/fiber.h caml/roots.h
 clambda_checks_ni.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl
+ caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl
 compare_ni.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h
+ caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/mlvalues.h
 custom_ni.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/gc_ctrl.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/shared_heap.h caml/roots.h \
-  caml/signals.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/fail.h caml/gc_ctrl.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h \
+ caml/shared_heap.h caml/roots.h caml/signals.h
 debugger_ni.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/debugger.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/osdeps.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/debugger.h caml/misc.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/osdeps.h
 domain_ni.$(O): domain.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/platform.h \
-  caml/custom.h caml/shared_heap.h caml/roots.h caml/fail.h \
-  caml/globroots.h caml/signals.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h caml/fiber.h caml/callback.h caml/eventlog.h \
-  caml/gc_ctrl.h caml/osdeps.h caml/weak.h caml/finalise.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/platform.h caml/domain_state.h caml/platform.h \
+ caml/custom.h caml/major_gc.h caml/shared_heap.h caml/roots.h \
+ caml/memory.h caml/fail.h caml/globroots.h caml/signals.h caml/startup.h \
+ caml/exec.h caml/startup_aux.h caml/fiber.h caml/callback.h \
+ caml/minor_gc.h caml/eventlog.h caml/gc_ctrl.h caml/osdeps.h caml/weak.h \
+ caml/finalise.h
 dynlink_ni.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/osdeps.h caml/prims.h caml/signals.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/dynlink.h caml/fail.h \
+ caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/platform.h caml/alloc.h \
+ caml/misc.h caml/osdeps.h caml/prims.h caml/signals.h
 dynlink_nat_ni.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/stack.h caml/callback.h caml/intext.h caml/io.h \
-  caml/osdeps.h caml/fail.h frame_descriptors.h caml/globroots.h \
-  caml/roots.h caml/signals.h caml/hooks.h
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/stack.h caml/callback.h \
+ caml/alloc.h caml/intext.h caml/io.h caml/osdeps.h caml/fail.h \
+ frame_descriptors.h caml/config.h caml/globroots.h caml/roots.h \
+ caml/signals.h caml/hooks.h
 eventlog_ni.$(O): eventlog.c caml/domain.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/alloc.h caml/platform.h \
-  caml/eventlog.h caml/osdeps.h caml/startup_aux.h
+ caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/alloc.h \
+ caml/platform.h caml/eventlog.h caml/osdeps.h caml/platform.h \
+ caml/startup_aux.h
 extern_ni.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/gc.h \
-  caml/intext.h caml/io.h caml/platform.h caml/md5.h caml/memory.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/reverse.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/custom.h caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/platform.h caml/io.h caml/md5.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h caml/addrmap.h
 fail_byt_ni.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/fail.h caml/io.h caml/printexc.h caml/signals.h \
-  caml/fiber.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/fail.h caml/gc.h caml/io.h \
+ caml/memory.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
+ caml/fiber.h caml/roots.h
 fail_nat_ni.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/io.h caml/platform.h caml/gc.h \
-  caml/memory.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/printexc.h caml/signals.h caml/stack.h caml/roots.h \
-  caml/callback.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/io.h caml/platform.h caml/gc.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/mlvalues.h caml/printexc.h \
+ caml/signals.h caml/stack.h caml/roots.h caml/callback.h
 fiber_ni.$(O): fiber.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/fiber.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/roots.h caml/gc_ctrl.h caml/instruct.h caml/fail.h \
-  caml/fix_code.h caml/shared_heap.h caml/startup_aux.h caml/stack.h \
-  frame_descriptors.h
+ caml/camlatomic.h caml/misc.h caml/fiber.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/roots.h caml/gc_ctrl.h caml/instruct.h \
+ caml/fail.h caml/alloc.h caml/platform.h caml/fix_code.h caml/minor_gc.h \
+ caml/major_gc.h caml/shared_heap.h caml/memory.h caml/startup_aux.h \
+ caml/stack.h frame_descriptors.h caml/config.h
 finalise_ni.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/eventlog.h caml/fail.h caml/finalise.h caml/roots.h \
-  caml/shared_heap.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/eventlog.h caml/fail.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/minor_gc.h caml/misc.h caml/roots.h \
+ caml/shared_heap.h
 fix_code_ni.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
-  caml/io.h caml/platform.h caml/md5.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/alloc.h caml/reverse.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/fix_code.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/platform.h caml/md5.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 floats_ni.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/reverse.h caml/fiber.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h caml/misc.h \
+ caml/reverse.h caml/fiber.h caml/roots.h
 frame_descriptors_ni.$(O): frame_descriptors.c frame_descriptors.h \
-  caml/config.h caml/m.h caml/s.h caml/platform.h caml/mlvalues.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/major_gc.h caml/memory.h caml/gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/alloc.h
+ caml/config.h caml/m.h caml/s.h caml/platform.h caml/mlvalues.h \
+ caml/config.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/major_gc.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h
 gc_ctrl_ni.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/finalise.h caml/roots.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/gc_ctrl.h caml/shared_heap.h \
-  caml/stack.h frame_descriptors.h caml/globroots.h caml/signals.h \
-  caml/startup.h caml/exec.h caml/startup_aux.h caml/eventlog.h \
-  caml/fail.h
-globroots_ni.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
-  caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/roots.h caml/globroots.h caml/callback.h \
-  caml/shared_heap.h caml/stack.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/minor_gc.h caml/shared_heap.h caml/misc.h \
+ caml/mlvalues.h caml/stack.h frame_descriptors.h caml/config.h \
+ caml/domain.h caml/globroots.h caml/signals.h caml/startup.h caml/exec.h \
+ caml/startup_aux.h caml/eventlog.h caml/fail.h
+globroots_ni.$(O): globroots.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/roots.h caml/memory.h caml/gc.h caml/mlvalues.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/globroots.h caml/roots.h caml/skiplist.h caml/stack.h
 hash_ni.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/hash.h caml/fail.h
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/hash.h caml/fail.h
 instrtrace_ni.$(O): instrtrace.c
 intern_ni.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
-  caml/md5.h caml/reverse.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/config.h caml/custom.h caml/fail.h \
+ caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h \
+ caml/mlvalues.h caml/misc.h caml/reverse.h
 interp_ni.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/debugger.h caml/fail.h \
-  caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
-  caml/prims.h caml/signals.h caml/fiber.h caml/roots.h caml/globroots.h \
-  caml/startup.h caml/startup_aux.h caml/jumptbl.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/debugger.h caml/fail.h \
+ caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
+ caml/major_gc.h caml/memory.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/signals.h caml/fiber.h caml/roots.h caml/domain.h caml/globroots.h \
+ caml/startup.h caml/startup_aux.h caml/startup_aux.h caml/jumptbl.h
 ints_ni.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/intext.h \
-  caml/io.h caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/fail.h caml/intext.h caml/io.h \
+ caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h
 io_ni.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/io.h \
-  caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/osdeps.h \
-  caml/signals.h caml/sys.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/fail.h caml/io.h \
+ caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/signals.h caml/sys.h
 lexing_ni.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fiber.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/mlvalues.h caml/fiber.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/roots.h
 main_ni.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h
 major_gc_ni.$(O): major_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/alloc.h caml/platform.h \
-  caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h caml/finalise.h \
-  caml/globroots.h caml/shared_heap.h caml/startup_aux.h caml/weak.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/domain.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h \
+ caml/roots.h caml/finalise.h caml/globroots.h caml/memory.h \
+ caml/mlvalues.h caml/platform.h caml/roots.h caml/shared_heap.h \
+ caml/startup_aux.h caml/weak.h
 md5_ni.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/md5.h caml/io.h caml/platform.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/reverse.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/md5.h caml/io.h caml/platform.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/mlvalues.h caml/io.h \
+ caml/reverse.h
 memory_ni.$(O): memory.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/fail.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/shared_heap.h caml/roots.h caml/fiber.h \
-  caml/eventlog.h
+ caml/config.h caml/camlatomic.h caml/misc.h caml/fail.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/major_gc.h \
+ caml/shared_heap.h caml/roots.h caml/domain.h caml/addrmap.h \
+ caml/roots.h caml/alloc.h caml/fiber.h caml/platform.h caml/eventlog.h
 memprof_ni.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/roots.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/fail.h caml/callback.h \
-  caml/signals.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
-  caml/weak.h caml/stack.h
+ caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/roots.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/fail.h caml/alloc.h caml/callback.h \
+ caml/signals.h caml/memory.h caml/minor_gc.h caml/backtrace_prim.h \
+ caml/backtrace.h caml/exec.h caml/weak.h caml/stack.h caml/misc.h
 meta_ni.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/fix_code.h caml/interp.h \
-  caml/intext.h caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
-  caml/gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h caml/prims.h \
-  caml/fiber.h caml/roots.h caml/startup_aux.h caml/debugger.h \
-  caml/backtrace_prim.h caml/backtrace.h caml/exec.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/fail.h caml/fix_code.h \
+ caml/interp.h caml/intext.h caml/io.h caml/platform.h caml/major_gc.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/fiber.h caml/roots.h \
+ caml/startup_aux.h caml/debugger.h caml/backtrace_prim.h \
+ caml/backtrace.h caml/exec.h
 minor_gc_ni.$(O): minor_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/domain.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/alloc.h caml/platform.h \
-  caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h caml/finalise.h \
-  caml/gc_ctrl.h caml/shared_heap.h caml/signals.h caml/startup_aux.h \
-  caml/weak.h
-misc_ni.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/memory.h caml/gc.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/osdeps.h caml/version.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/custom.h caml/domain.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/alloc.h caml/platform.h caml/eventlog.h caml/fail.h \
+ caml/fiber.h caml/roots.h caml/finalise.h caml/gc.h caml/gc_ctrl.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/platform.h caml/roots.h \
+ caml/shared_heap.h caml/signals.h caml/startup_aux.h caml/weak.h
+misc_ni.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/camlatomic.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/osdeps.h caml/version.h caml/domain.h \
+ caml/startup.h caml/exec.h caml/startup_aux.h caml/startup_aux.h
 obj_ni.$(O): obj.c caml/camlatomic.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/alloc.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/gc.h caml/interp.h \
-  caml/major_gc.h caml/memory.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/prims.h caml/spacetime.h caml/io.h \
-  caml/stack.h
+ caml/misc.h caml/camlatomic.h caml/alloc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/fail.h caml/gc.h \
+ caml/interp.h caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/prims.h caml/platform.h caml/spacetime.h caml/io.h caml/stack.h
 parsing_ni.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/startup.h caml/exec.h caml/startup_aux.h
+ caml/config.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/alloc.h caml/startup.h \
+ caml/exec.h caml/startup_aux.h
 platform_ni.$(O): platform.c caml/platform.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h
 prims_ni.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/prims.h
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/prims.h
 printexc_ni.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/exec.h caml/callback.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/debugger.h caml/fail.h \
-  caml/printexc.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/exec.h caml/callback.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/debugger.h caml/fail.h caml/misc.h \
+ caml/mlvalues.h caml/printexc.h caml/memory.h
 roots_ni.$(O): roots.c caml/finalise.h caml/roots.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/memory.h caml/gc.h \
-  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/globroots.h caml/shared_heap.h \
-  caml/fiber.h caml/stack.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/globroots.h caml/major_gc.h \
+ caml/memory.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/shared_heap.h caml/fiber.h caml/stack.h
 shared_heap_ni.$(O): shared_heap.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/fiber.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h caml/globroots.h \
-  caml/shared_heap.h caml/sizeclasses.h caml/startup_aux.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/fail.h caml/fiber.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/roots.h caml/gc.h \
+ caml/globroots.h caml/memory.h caml/mlvalues.h caml/platform.h \
+ caml/roots.h caml/shared_heap.h caml/sizeclasses.h caml/startup_aux.h
 signals_ni.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/fail.h caml/roots.h caml/signals.h caml/sys.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/config.h caml/fail.h caml/memory.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/signals.h caml/sys.h
 signals_byt_ni.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/osdeps.h caml/signals.h
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/osdeps.h caml/signals.h
 signals_nat_ni.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/osdeps.h caml/signals.h caml/stack.h \
-  caml/spacetime.h caml/io.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/osdeps.h caml/domain.h caml/signals.h \
+ caml/stack.h caml/spacetime.h caml/io.h caml/stack.h
+skiplist_ni.$(O): skiplist.c caml/config.h caml/m.h caml/s.h caml/memory.h \
+ caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/misc.h caml/skiplist.h
 spacetime_byt_ni.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/mlvalues.h
 spacetime_nat_ni.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
-  caml/alloc.h caml/misc.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/fail.h caml/gc.h \
-  caml/intext.h caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/osdeps.h \
-  caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h
+ caml/alloc.h caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
+ caml/spacetime.h caml/stack.h
 spacetime_snapshot_ni.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
-  caml/config.h caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/custom.h caml/fail.h \
-  caml/gc.h caml/gc_ctrl.h caml/intext.h caml/io.h caml/platform.h \
-  caml/major_gc.h caml/memory.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
-  caml/spacetime.h
+ caml/config.h caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/config.h caml/custom.h \
+ caml/fail.h caml/gc.h caml/gc_ctrl.h caml/intext.h caml/io.h \
+ caml/platform.h caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/signals.h \
+ caml/stack.h caml/sys.h caml/spacetime.h caml/stack.h
 startup_aux_ni.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/exec.h caml/dynlink.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/callback.h \
-  caml/osdeps.h caml/prims.h caml/startup_aux.h caml/version.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/exec.h caml/dynlink.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/callback.h \
+ caml/major_gc.h caml/misc.h caml/osdeps.h caml/prims.h \
+ caml/startup_aux.h caml/version.h
 startup_byt_ni.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/custom.h caml/debugger.h \
-  caml/dynlink.h caml/eventlog.h caml/fail.h caml/fix_code.h \
-  caml/gc_ctrl.h caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h \
-  caml/osdeps.h caml/startup_aux.h caml/prims.h caml/printexc.h \
-  caml/reverse.h caml/signals.h caml/fiber.h caml/roots.h caml/sys.h \
-  caml/startup.h caml/version.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/backtrace.h caml/exec.h \
+ caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h caml/custom.h \
+ caml/debugger.h caml/domain_state.h caml/dynlink.h caml/eventlog.h \
+ caml/exec.h caml/fail.h caml/fix_code.h caml/gc_ctrl.h caml/instrtrace.h \
+ caml/interp.h caml/intext.h caml/io.h caml/io.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/startup_aux.h caml/prims.h caml/printexc.h caml/reverse.h \
+ caml/signals.h caml/fiber.h caml/roots.h caml/sys.h caml/startup.h \
+ caml/startup_aux.h caml/version.h
 startup_nat_ni.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h \
-  caml/custom.h caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/intext.h \
-  caml/io.h caml/osdeps.h caml/printexc.h caml/stack.h caml/sys.h \
-  caml/startup_aux.h caml/fiber.h caml/roots.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h caml/custom.h \
+ caml/debugger.h caml/fail.h caml/gc.h caml/gc_ctrl.h caml/intext.h \
+ caml/io.h caml/memory.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/printexc.h caml/stack.h caml/sys.h caml/startup_aux.h caml/fiber.h \
+ caml/roots.h
 str_ni.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h caml/misc.h
 sys_ni.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/debugger.h caml/fail.h caml/gc_ctrl.h \
-  caml/io.h caml/platform.h caml/osdeps.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/signals.h caml/fiber.h caml/roots.h caml/sys.h caml/startup.h \
-  caml/exec.h caml/startup_aux.h caml/version.h caml/callback.h \
-  caml/shared_heap.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/debugger.h caml/fail.h caml/gc_ctrl.h \
+ caml/io.h caml/platform.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/signals.h caml/fiber.h caml/roots.h caml/sys.h \
+ caml/startup.h caml/exec.h caml/startup_aux.h caml/version.h \
+ caml/callback.h caml/startup_aux.h caml/major_gc.h caml/shared_heap.h
 unix_ni.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/osdeps.h caml/signals.h caml/sys.h caml/io.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/misc.h caml/osdeps.h caml/signals.h \
+ caml/sys.h caml/io.h caml/alloc.h
 weak_ni.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/platform.h \
-  caml/fail.h caml/shared_heap.h caml/roots.h caml/weak.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/platform.h caml/fail.h caml/major_gc.h caml/memory.h \
+ caml/mlvalues.h caml/shared_heap.h caml/roots.h caml/weak.h
+win32_ni.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/address_class.h caml/fail.h caml/io.h \
+ caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/misc.h \
+ caml/osdeps.h caml/signals.h caml/sys.h caml/config.h
 addrmap_npic.$(O): addrmap.c caml/config.h caml/m.h caml/s.h caml/memory.h \
-  caml/domain.h caml/misc.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/alloc.h caml/addrmap.h
-afl_npic.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h
+ caml/config.h caml/domain.h caml/misc.h caml/camlatomic.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/alloc.h \
+ caml/addrmap.h
+afl_npic.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h
 alloc_npic.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/major_gc.h caml/memory.h \
-  caml/gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/fiber.h caml/roots.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/major_gc.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h caml/fiber.h \
+ caml/roots.h caml/domain.h
 array_npic.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
 backtrace_npic.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/backtrace.h caml/exec.h caml/backtrace_prim.h caml/fail.h \
-  caml/debugger.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
 backtrace_byt_npic.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/alloc.h caml/custom.h caml/io.h \
-  caml/platform.h caml/instruct.h caml/intext.h caml/exec.h \
-  caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/startup.h \
-  caml/startup_aux.h caml/fiber.h caml/roots.h caml/sys.h \
-  caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/debugger.h
+ caml/mlvalues.h caml/config.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/alloc.h caml/mlvalues.h \
+ caml/custom.h caml/io.h caml/platform.h caml/instruct.h caml/intext.h \
+ caml/io.h caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/startup.h caml/exec.h caml/startup_aux.h \
+ caml/fiber.h caml/roots.h caml/sys.h caml/backtrace.h caml/fail.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
 backtrace_nat_npic.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/backtrace.h caml/exec.h \
-  caml/backtrace_prim.h frame_descriptors.h caml/stack.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/fiber.h caml/roots.h caml/fail.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
+ caml/backtrace.h frame_descriptors.h caml/config.h caml/stack.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h caml/fiber.h caml/roots.h caml/fail.h
 bigarray_npic.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/bigarray.h caml/custom.h caml/fail.h \
-  caml/intext.h caml/io.h caml/platform.h caml/hash.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/signals.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/bigarray.h caml/custom.h caml/fail.h \
+ caml/intext.h caml/io.h caml/platform.h caml/hash.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/mlvalues.h caml/signals.h
 callback_npic.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/fail.h caml/fiber.h caml/roots.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/fail.h caml/memory.h caml/mlvalues.h caml/platform.h \
+ caml/fiber.h caml/roots.h
 clambda_checks_npic.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl
+ caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl
 compare_npic.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h
+ caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/misc.h caml/mlvalues.h
 custom_npic.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/gc_ctrl.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/shared_heap.h caml/roots.h \
-  caml/signals.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/fail.h caml/gc_ctrl.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h \
+ caml/shared_heap.h caml/roots.h caml/signals.h
 debugger_npic.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/debugger.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/osdeps.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/debugger.h caml/misc.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/osdeps.h
 domain_npic.$(O): domain.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/platform.h \
-  caml/custom.h caml/shared_heap.h caml/roots.h caml/fail.h \
-  caml/globroots.h caml/signals.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h caml/fiber.h caml/callback.h caml/eventlog.h \
-  caml/gc_ctrl.h caml/osdeps.h caml/weak.h caml/finalise.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/platform.h caml/domain_state.h caml/platform.h \
+ caml/custom.h caml/major_gc.h caml/shared_heap.h caml/roots.h \
+ caml/memory.h caml/fail.h caml/globroots.h caml/signals.h caml/startup.h \
+ caml/exec.h caml/startup_aux.h caml/fiber.h caml/callback.h \
+ caml/minor_gc.h caml/eventlog.h caml/gc_ctrl.h caml/osdeps.h caml/weak.h \
+ caml/finalise.h
 dynlink_npic.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/osdeps.h caml/prims.h caml/signals.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/dynlink.h caml/fail.h \
+ caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/platform.h caml/alloc.h \
+ caml/misc.h caml/osdeps.h caml/prims.h caml/signals.h
 dynlink_nat_npic.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/stack.h caml/callback.h caml/intext.h caml/io.h \
-  caml/osdeps.h caml/fail.h frame_descriptors.h caml/globroots.h \
-  caml/roots.h caml/signals.h caml/hooks.h
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/stack.h caml/callback.h \
+ caml/alloc.h caml/intext.h caml/io.h caml/osdeps.h caml/fail.h \
+ frame_descriptors.h caml/config.h caml/globroots.h caml/roots.h \
+ caml/signals.h caml/hooks.h
 eventlog_npic.$(O): eventlog.c caml/domain.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/alloc.h caml/platform.h \
-  caml/eventlog.h caml/osdeps.h caml/startup_aux.h
+ caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/alloc.h \
+ caml/platform.h caml/eventlog.h caml/osdeps.h caml/platform.h \
+ caml/startup_aux.h
 extern_npic.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/gc.h \
-  caml/intext.h caml/io.h caml/platform.h caml/md5.h caml/memory.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/reverse.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/custom.h caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/platform.h caml/io.h caml/md5.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h caml/addrmap.h
 fail_byt_npic.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/fail.h caml/io.h caml/printexc.h caml/signals.h \
-  caml/fiber.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/fail.h caml/gc.h caml/io.h \
+ caml/memory.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
+ caml/fiber.h caml/roots.h
 fail_nat_npic.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/io.h caml/platform.h caml/gc.h \
-  caml/memory.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/printexc.h caml/signals.h caml/stack.h caml/roots.h \
-  caml/callback.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/io.h caml/platform.h caml/gc.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/mlvalues.h caml/printexc.h \
+ caml/signals.h caml/stack.h caml/roots.h caml/callback.h
 fiber_npic.$(O): fiber.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/fiber.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/roots.h caml/gc_ctrl.h caml/instruct.h caml/fail.h \
-  caml/fix_code.h caml/shared_heap.h caml/startup_aux.h caml/stack.h \
-  frame_descriptors.h
+ caml/camlatomic.h caml/misc.h caml/fiber.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/roots.h caml/gc_ctrl.h caml/instruct.h \
+ caml/fail.h caml/alloc.h caml/platform.h caml/fix_code.h caml/minor_gc.h \
+ caml/major_gc.h caml/shared_heap.h caml/memory.h caml/startup_aux.h \
+ caml/stack.h frame_descriptors.h caml/config.h
 finalise_npic.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/eventlog.h caml/fail.h caml/finalise.h caml/roots.h \
-  caml/shared_heap.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/eventlog.h caml/fail.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/minor_gc.h caml/misc.h caml/roots.h \
+ caml/shared_heap.h
 fix_code_npic.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
-  caml/io.h caml/platform.h caml/md5.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/alloc.h caml/reverse.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/fix_code.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/platform.h caml/md5.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 floats_npic.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/reverse.h caml/fiber.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h caml/misc.h \
+ caml/reverse.h caml/fiber.h caml/roots.h
 frame_descriptors_npic.$(O): frame_descriptors.c frame_descriptors.h \
-  caml/config.h caml/m.h caml/s.h caml/platform.h caml/mlvalues.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/major_gc.h caml/memory.h caml/gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/alloc.h
+ caml/config.h caml/m.h caml/s.h caml/platform.h caml/mlvalues.h \
+ caml/config.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/major_gc.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h
 gc_ctrl_npic.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/finalise.h caml/roots.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/gc_ctrl.h caml/shared_heap.h \
-  caml/stack.h frame_descriptors.h caml/globroots.h caml/signals.h \
-  caml/startup.h caml/exec.h caml/startup_aux.h caml/eventlog.h \
-  caml/fail.h
-globroots_npic.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
-  caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/roots.h caml/globroots.h caml/callback.h \
-  caml/shared_heap.h caml/stack.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/minor_gc.h caml/shared_heap.h caml/misc.h \
+ caml/mlvalues.h caml/stack.h frame_descriptors.h caml/config.h \
+ caml/domain.h caml/globroots.h caml/signals.h caml/startup.h caml/exec.h \
+ caml/startup_aux.h caml/eventlog.h caml/fail.h
+globroots_npic.$(O): globroots.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/roots.h caml/memory.h caml/gc.h caml/mlvalues.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
+ caml/alloc.h caml/globroots.h caml/roots.h caml/skiplist.h caml/stack.h
 hash_npic.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/hash.h caml/fail.h
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/hash.h caml/fail.h
 instrtrace_npic.$(O): instrtrace.c
 intern_npic.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
-  caml/md5.h caml/reverse.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/config.h caml/custom.h caml/fail.h \
+ caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h \
+ caml/mlvalues.h caml/misc.h caml/reverse.h
 interp_npic.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/debugger.h caml/fail.h \
-  caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
-  caml/prims.h caml/signals.h caml/fiber.h caml/roots.h caml/globroots.h \
-  caml/startup.h caml/startup_aux.h caml/jumptbl.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/debugger.h caml/fail.h \
+ caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
+ caml/major_gc.h caml/memory.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/signals.h caml/fiber.h caml/roots.h caml/domain.h caml/globroots.h \
+ caml/startup.h caml/startup_aux.h caml/startup_aux.h caml/jumptbl.h
 ints_npic.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/intext.h \
-  caml/io.h caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/fail.h caml/intext.h caml/io.h \
+ caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h
 io_npic.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/io.h \
-  caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/osdeps.h \
-  caml/signals.h caml/sys.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/fail.h caml/io.h \
+ caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/signals.h caml/sys.h
 lexing_npic.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fiber.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/mlvalues.h caml/fiber.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/roots.h
 main_npic.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h
+ caml/camlatomic.h caml/misc.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h
 major_gc_npic.$(O): major_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/alloc.h caml/platform.h \
-  caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h caml/finalise.h \
-  caml/globroots.h caml/shared_heap.h caml/startup_aux.h caml/weak.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/domain.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h \
+ caml/roots.h caml/finalise.h caml/globroots.h caml/memory.h \
+ caml/mlvalues.h caml/platform.h caml/roots.h caml/shared_heap.h \
+ caml/startup_aux.h caml/weak.h
 md5_npic.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/md5.h caml/io.h caml/platform.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/reverse.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/md5.h caml/io.h caml/platform.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/mlvalues.h caml/io.h \
+ caml/reverse.h
 memory_npic.$(O): memory.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/fail.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/shared_heap.h caml/roots.h caml/fiber.h \
-  caml/eventlog.h
+ caml/config.h caml/camlatomic.h caml/misc.h caml/fail.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/major_gc.h \
+ caml/shared_heap.h caml/roots.h caml/domain.h caml/addrmap.h \
+ caml/roots.h caml/alloc.h caml/fiber.h caml/platform.h caml/eventlog.h
 memprof_npic.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/roots.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/fail.h caml/callback.h \
-  caml/signals.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
-  caml/weak.h caml/stack.h
+ caml/mlvalues.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/roots.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/fail.h caml/alloc.h caml/callback.h \
+ caml/signals.h caml/memory.h caml/minor_gc.h caml/backtrace_prim.h \
+ caml/backtrace.h caml/exec.h caml/weak.h caml/stack.h caml/misc.h
 meta_npic.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/fix_code.h caml/interp.h \
-  caml/intext.h caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
-  caml/gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h caml/prims.h \
-  caml/fiber.h caml/roots.h caml/startup_aux.h caml/debugger.h \
-  caml/backtrace_prim.h caml/backtrace.h caml/exec.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/fail.h caml/fix_code.h \
+ caml/interp.h caml/intext.h caml/io.h caml/platform.h caml/major_gc.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/alloc.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/fiber.h caml/roots.h \
+ caml/startup_aux.h caml/debugger.h caml/backtrace_prim.h \
+ caml/backtrace.h caml/exec.h
 minor_gc_npic.$(O): minor_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/domain.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/alloc.h caml/platform.h \
-  caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h caml/finalise.h \
-  caml/gc_ctrl.h caml/shared_heap.h caml/signals.h caml/startup_aux.h \
-  caml/weak.h
-misc_npic.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h \
-  caml/camlatomic.h caml/memory.h caml/gc.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/osdeps.h caml/version.h caml/startup.h caml/exec.h \
-  caml/startup_aux.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/config.h caml/custom.h caml/domain.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/alloc.h caml/platform.h caml/eventlog.h caml/fail.h \
+ caml/fiber.h caml/roots.h caml/finalise.h caml/gc.h caml/gc_ctrl.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/platform.h caml/roots.h \
+ caml/shared_heap.h caml/signals.h caml/startup_aux.h caml/weak.h
+misc_npic.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/camlatomic.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/osdeps.h caml/version.h caml/domain.h \
+ caml/startup.h caml/exec.h caml/startup_aux.h caml/startup_aux.h
 obj_npic.$(O): obj.c caml/camlatomic.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/alloc.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/gc.h caml/interp.h \
-  caml/major_gc.h caml/memory.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/prims.h caml/spacetime.h caml/io.h \
-  caml/stack.h
+ caml/misc.h caml/camlatomic.h caml/alloc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/fail.h caml/gc.h \
+ caml/interp.h caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/prims.h caml/platform.h caml/spacetime.h caml/io.h caml/stack.h
 parsing_npic.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/startup.h caml/exec.h caml/startup_aux.h
+ caml/config.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/alloc.h caml/startup.h \
+ caml/exec.h caml/startup_aux.h
 platform_npic.$(O): platform.c caml/platform.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h
 prims_npic.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/prims.h
+ caml/misc.h caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/prims.h
 printexc_npic.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/exec.h caml/callback.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/debugger.h caml/fail.h \
-  caml/printexc.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/exec.h caml/callback.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/debugger.h caml/fail.h caml/misc.h \
+ caml/mlvalues.h caml/printexc.h caml/memory.h
 roots_npic.$(O): roots.c caml/finalise.h caml/roots.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/memory.h caml/gc.h \
-  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/globroots.h caml/shared_heap.h \
-  caml/fiber.h caml/stack.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/globroots.h caml/major_gc.h \
+ caml/memory.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/shared_heap.h caml/fiber.h caml/stack.h
 shared_heap_npic.$(O): shared_heap.c caml/addrmap.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
-  caml/domain_state.tbl caml/custom.h caml/fail.h caml/fiber.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/roots.h caml/globroots.h \
-  caml/shared_heap.h caml/sizeclasses.h caml/startup_aux.h
+ caml/m.h caml/s.h caml/misc.h caml/camlatomic.h caml/domain_state.h \
+ caml/domain_state.tbl caml/custom.h caml/fail.h caml/fiber.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/platform.h caml/alloc.h caml/roots.h caml/gc.h \
+ caml/globroots.h caml/memory.h caml/mlvalues.h caml/platform.h \
+ caml/roots.h caml/shared_heap.h caml/sizeclasses.h caml/startup_aux.h
 signals_npic.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/fail.h caml/roots.h caml/signals.h caml/sys.h
+ caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/callback.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/config.h caml/fail.h caml/memory.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/signals.h caml/sys.h
 signals_byt_npic.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/osdeps.h caml/signals.h
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/camlatomic.h caml/domain_state.h caml/domain_state.tbl \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/osdeps.h caml/signals.h
 signals_nat_npic.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/osdeps.h caml/signals.h caml/stack.h \
-  caml/spacetime.h caml/io.h
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/osdeps.h caml/domain.h caml/signals.h \
+ caml/stack.h caml/spacetime.h caml/io.h caml/stack.h
+skiplist_npic.$(O): skiplist.c caml/config.h caml/m.h caml/s.h caml/memory.h \
+ caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/misc.h caml/skiplist.h
 spacetime_byt_npic.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl
+ caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/mlvalues.h
 spacetime_nat_npic.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
-  caml/alloc.h caml/misc.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/fail.h caml/gc.h \
-  caml/intext.h caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/osdeps.h \
-  caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h
+ caml/alloc.h caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/platform.h caml/major_gc.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/alloc.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
+ caml/spacetime.h caml/stack.h
 spacetime_snapshot_npic.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
-  caml/config.h caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
-  caml/domain_state.h caml/domain_state.tbl caml/custom.h caml/fail.h \
-  caml/gc.h caml/gc_ctrl.h caml/intext.h caml/io.h caml/platform.h \
-  caml/major_gc.h caml/memory.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
-  caml/spacetime.h
+ caml/config.h caml/m.h caml/s.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/config.h caml/custom.h \
+ caml/fail.h caml/gc.h caml/gc_ctrl.h caml/intext.h caml/io.h \
+ caml/platform.h caml/major_gc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/signals.h \
+ caml/stack.h caml/sys.h caml/spacetime.h caml/stack.h
 startup_aux_npic.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/exec.h caml/dynlink.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/alloc.h caml/callback.h \
-  caml/osdeps.h caml/prims.h caml/startup_aux.h caml/version.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/exec.h caml/dynlink.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
+ caml/domain.h caml/memory.h caml/platform.h caml/alloc.h caml/callback.h \
+ caml/major_gc.h caml/misc.h caml/osdeps.h caml/prims.h \
+ caml/startup_aux.h caml/version.h
 startup_byt_npic.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h \
-  caml/domain.h caml/platform.h caml/custom.h caml/debugger.h \
-  caml/dynlink.h caml/eventlog.h caml/fail.h caml/fix_code.h \
-  caml/gc_ctrl.h caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h \
-  caml/osdeps.h caml/startup_aux.h caml/prims.h caml/printexc.h \
-  caml/reverse.h caml/signals.h caml/fiber.h caml/roots.h caml/sys.h \
-  caml/startup.h caml/version.h
+ caml/misc.h caml/config.h caml/camlatomic.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/backtrace.h caml/exec.h \
+ caml/callback.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/platform.h caml/alloc.h caml/custom.h \
+ caml/debugger.h caml/domain_state.h caml/dynlink.h caml/eventlog.h \
+ caml/exec.h caml/fail.h caml/fix_code.h caml/gc_ctrl.h caml/instrtrace.h \
+ caml/interp.h caml/intext.h caml/io.h caml/io.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/startup_aux.h caml/prims.h caml/printexc.h caml/reverse.h \
+ caml/signals.h caml/fiber.h caml/roots.h caml/sys.h caml/startup.h \
+ caml/startup_aux.h caml/version.h
 startup_nat_npic.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
-  caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h \
-  caml/custom.h caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/intext.h \
-  caml/io.h caml/osdeps.h caml/printexc.h caml/stack.h caml/sys.h \
-  caml/startup_aux.h caml/fiber.h caml/roots.h
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/camlatomic.h \
+ caml/domain_state.h caml/domain_state.tbl caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/platform.h caml/alloc.h caml/backtrace.h caml/exec.h caml/custom.h \
+ caml/debugger.h caml/fail.h caml/gc.h caml/gc_ctrl.h caml/intext.h \
+ caml/io.h caml/memory.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/printexc.h caml/stack.h caml/sys.h caml/startup_aux.h caml/fiber.h \
+ caml/roots.h
 str_npic.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/platform.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/memory.h caml/platform.h caml/alloc.h caml/mlvalues.h caml/misc.h
 sys_npic.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/debugger.h caml/fail.h caml/gc_ctrl.h \
-  caml/io.h caml/platform.h caml/osdeps.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
-  caml/signals.h caml/fiber.h caml/roots.h caml/sys.h caml/startup.h \
-  caml/exec.h caml/startup_aux.h caml/version.h caml/callback.h \
-  caml/shared_heap.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/debugger.h caml/fail.h caml/gc_ctrl.h \
+ caml/io.h caml/platform.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/signals.h caml/fiber.h caml/roots.h caml/sys.h \
+ caml/startup.h caml/exec.h caml/startup_aux.h caml/version.h \
+ caml/callback.h caml/startup_aux.h caml/major_gc.h caml/shared_heap.h
 unix_npic.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/minor_gc.h caml/addrmap.h caml/domain.h caml/platform.h \
-  caml/alloc.h caml/osdeps.h caml/signals.h caml/sys.h caml/io.h
+ caml/config.h caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/addrmap.h caml/domain.h caml/memory.h \
+ caml/platform.h caml/alloc.h caml/misc.h caml/osdeps.h caml/signals.h \
+ caml/sys.h caml/io.h caml/alloc.h
 weak_npic.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
-  caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/platform.h \
-  caml/fail.h caml/shared_heap.h caml/roots.h caml/weak.h
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/domain.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/addrmap.h caml/domain.h \
+ caml/alloc.h caml/platform.h caml/fail.h caml/major_gc.h caml/memory.h \
+ caml/mlvalues.h caml/shared_heap.h caml/roots.h caml/weak.h
+win32_npic.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/address_class.h caml/fail.h caml/io.h \
+ caml/platform.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/addrmap.h caml/domain.h caml/memory.h caml/alloc.h caml/misc.h \
+ caml/osdeps.h caml/signals.h caml/sys.h caml/config.h

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -27,7 +27,7 @@ BYTECODE_C_SOURCES := $(addsuffix .c, \
   floats str array io extern intern hash sys meta parsing gc_ctrl md5 obj \
   lexing callback debugger weak finalise custom dynlink \
   platform eventlog fiber shared_heap addrmap \
-  spacetime_byt afl $(UNIX_OR_WIN32) bigarray main domain)
+  spacetime_byt afl $(UNIX_OR_WIN32) bigarray main domain skiplist)
 
 NATIVE_C_SOURCES := $(addsuffix .c, \
   startup_aux startup_nat main fail_nat roots signals \
@@ -37,7 +37,7 @@ NATIVE_C_SOURCES := $(addsuffix .c, \
   globroots backtrace_nat backtrace dynlink_nat debugger meta \
   platform eventlog fiber shared_heap addrmap frame_descriptors \
   dynlink clambda_checks spacetime_nat spacetime_snapshot afl bigarray \
-  domain)
+  domain skiplist)
 
 # The other_files variable stores the list of files whose dependencies
 # should be computed by `make depend` although they do not need to be

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -37,6 +37,12 @@
 #define inline __inline
 #endif
 
+#if defined(_MSC_VER) && !defined(__cplusplus)
+#define Caml_inline static __inline
+#else
+#define Caml_inline static inline
+#endif
+
 #include "s.h"
 
 #ifdef BOOTSTRAPPING_FLEXLINK

--- a/runtime/caml/globroots.h
+++ b/runtime/caml/globroots.h
@@ -26,6 +26,10 @@
 void caml_scan_global_roots(scanning_action f, void* fdata);
 void caml_scan_global_young_roots(scanning_action f, void* fdata);
 
+#ifdef NATIVE_CODE
+void caml_register_dyn_global(void *v);
+#endif
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_GLOBROOTS_H */

--- a/runtime/caml/globroots.h
+++ b/runtime/caml/globroots.h
@@ -22,15 +22,9 @@
 
 #include "mlvalues.h"
 #include "roots.h"
-#include "memory.h"
 
-void caml_scan_global_roots(scanning_action f, void*);
-
-void caml_cleanup_deleted_roots(void);
-
-#ifdef NATIVE_CODE
-void caml_register_dyn_global(void *v);
-#endif
+void caml_scan_global_roots(scanning_action f, void* fdata);
+void caml_scan_global_young_roots(scanning_action f, void* fdata);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/skiplist.h
+++ b/runtime/caml/skiplist.h
@@ -1,0 +1,102 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*             Xavier Leroy, projet Cambium, INRIA Paris                  */
+/*                                                                        */
+/*   Copyright 2020 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+/* A dictionary data structure implemented as skip lists */
+
+/* Keys and associated data are natural-width integers (type [uintnat]).
+   Pointers can be used too, modulo conversion to [uintnat]. */
+
+#ifndef CAML_SKIPLIST_H
+#define CAML_SKIPLIST_H
+
+#ifdef CAML_INTERNALS
+
+#include "config.h"
+
+#define NUM_LEVELS 17
+
+/* The head of a skip list */
+
+struct skiplist {
+  struct skipcell * forward[NUM_LEVELS]; /* forward chaining */
+  int level;                    /* max level used */
+};
+
+/* The cells of a skip list */
+
+struct skipcell {
+  uintnat key;
+  uintnat data;
+#if (__STDC_VERSION__ >= 199901L)
+  struct skipcell * forward[];  /* variable-length array */
+#else
+  struct skipcell * forward[1]; /* variable-length array */
+#endif
+};
+
+/* Initialize a skip list, statically */
+#define SKIPLIST_STATIC_INITIALIZER { {0, }, 0 }
+
+/* Initialize a skip list, dynamically */
+extern void caml_skiplist_init(struct skiplist * sk);
+
+/* Search a skip list.
+   If [key] is found, store associated data in [*data] and return 1.
+   If [key] is not found, return 0 and leave [*data] unchanged. */
+extern int caml_skiplist_find(struct skiplist * sk, uintnat key,
+                              /*out*/ uintnat * data);
+
+/* Search the entry of the skip list that has the largest key less than
+   or equal to [k].
+   If such an entry exists, store its key in [*key], the associated data in
+   [*data], and return 1.
+   If no such entry exists (all keys in the skip list are strictly greater
+   than [k]), return 0 and leave [*key] and [*data] unchanged. */
+extern int caml_skiplist_find_below(struct skiplist * sk, uintnat k,
+                                    /*out*/ uintnat * key,
+                                    /*out*/ uintnat * data);
+
+/* Insertion in a skip list.
+   If [key] was already there, change the associated data and return 1.
+   If [key] was not there, insert new [key, data] binding and return 0. */
+extern int caml_skiplist_insert(struct skiplist * sk,
+                                uintnat key, uintnat data);
+
+/* Deletion in a skip list.
+   If [key] was there, remove it and return 1.
+   If [key] was not there, leave the skip list unchanged and return 0. */
+extern int caml_skiplist_remove(struct skiplist * sk, uintnat key);
+
+/* Empty an already initialized skip list. */
+extern void caml_skiplist_empty(struct skiplist * sk);
+
+/* Iterate over a skip list, in increasing order of keys.
+   [var] designates the current element.
+   [action] can refer to [var->key] and [var->data].
+   [action] can safely remove the current element, i.e. call
+   [caml_skiplist_remove] on [var->key].  The traversal will
+   continue with the skiplist element following the removed element.
+   Other operations performed over the skiplist during its traversal have
+   unspecified effects on the traversal. */
+
+#define FOREACH_SKIPLIST_ELEMENT(var,sk,action) \
+  { struct skipcell * var, * caml__next; \
+    for (var = (sk)->forward[0]; var != NULL; var = caml__next) \
+    { caml__next = (var)->forward[0]; action; } \
+  }
+
+#endif
+
+#endif

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -17,260 +17,166 @@
 
 /* Registration of global memory roots */
 
-#include "caml/memory.h"
-#include "caml/misc.h"
 #include "caml/mlvalues.h"
 #include "caml/roots.h"
 #include "caml/globroots.h"
-#include "caml/callback.h"
-#include "caml/platform.h"
-#include "caml/alloc.h"
-#include "caml/shared_heap.h"
-#ifdef NATIVE_CODE
-#include "caml/stack.h"
-#endif
+#include "caml/skiplist.h"
 
-/* A caml_root is in fact a value. We don't expose that fact outside
-   of this file so that C code doesn't attempt to directly modify it.
-   The value points to a block on the shared heap with the following
-   fields:
+/* The three global root lists.
+   Each is represented by a skip list with the key being the address
+   of the root.  (The associated data field is unused.) */
 
-    0: the actual root, as set by caml_modify_root
-    1: an integer flag stating whether this root has been deleted
-    2: the next root in roots_all
+struct skiplist caml_global_roots = SKIPLIST_STATIC_INITIALIZER;
+                  /* mutable roots, don't know whether old or young */
+struct skiplist caml_global_roots_young = SKIPLIST_STATIC_INITIALIZER;
+                  /* generational roots pointing to minor or major heap */
+struct skiplist caml_global_roots_old = SKIPLIST_STATIC_INITIALIZER;
+                  /* generational roots pointing to major heap */
 
-   The roots are not scanned during minor GC. Instead, since the root
-   blocks are all on the shared heap, pointers from roots to a minor
-   heap will be detected using the normal inter-generational pointer
-   mechanism. */
+/* The invariant of the generational roots is the following:
+   - If the global root contains a pointer to the minor heap, then the root is
+     in [caml_global_roots_young];
+   - If the global root contains a pointer to the major heap, then the root is
+     in [caml_global_roots_old] or in [caml_global_roots_young];
+   - Otherwise (the root contains a pointer outside of the heap or an integer),
+     then neither [caml_global_roots_young] nor [caml_global_roots_old] contain
+     it.
+*/
 
-static caml_plat_mutex roots_mutex = CAML_PLAT_MUTEX_INITIALIZER;
-static value roots_all = Val_unit;
+/* Insertion and deletion */
 
-CAMLexport caml_root caml_create_root(value init)
+Caml_inline void caml_insert_global_root(struct skiplist * list, value * r)
 {
-  CAMLparam1(init);
-  CAMLlocal1(v);
-  v = caml_alloc_shr(3, 0);
-  caml_initialize_field(v, 0, init);
-  caml_initialize_field(v, 1, Val_int(1));
-
-  caml_plat_lock(&roots_mutex);
-  caml_initialize_field(v, 2, roots_all);
-  roots_all = v;
-  caml_plat_unlock(&roots_mutex);
-
-  CAMLreturnT(caml_root, (caml_root)v);
+  caml_skiplist_insert(list, (uintnat) r, 0);
 }
-CAMLexport caml_root caml_create_root_noexc(value init)
+
+Caml_inline void caml_delete_global_root(struct skiplist * list, value * r)
 {
-  CAMLparam1(init);
-  CAMLlocal1(v);
-  v = caml_alloc_shr_noexc(3, 0);
-  if(v == (value)NULL) {
-    CAMLreturnT(caml_root, (caml_root)v);
-  }
-  caml_initialize_field(v, 0, init);
-  caml_initialize_field(v, 1, Val_int(1));
-
-  caml_plat_lock(&roots_mutex);
-  caml_initialize_field(v, 2, roots_all);
-  roots_all = v;
-  caml_plat_unlock(&roots_mutex);
-
-  CAMLreturnT(caml_root, (caml_root)v);
+  caml_skiplist_remove(list, (uintnat) r);
 }
 
-CAMLexport void caml_delete_root(caml_root root)
+/* Iterate a GC scanning action over a global root list */
+
+static void caml_iterate_global_roots(scanning_action f,
+                                      struct skiplist * rootlist, void* fdata)
 {
-  value v = (value)root;
-  Assert(root);
-  /* the root will be removed from roots_all and freed at the next GC */
-  caml_modify_field(v, 0, Val_unit);
-  caml_modify_field(v, 1, Val_int(0));
+  FOREACH_SKIPLIST_ELEMENT(e, rootlist, {
+      value * r = (value *) (e->key);
+      f(fdata, *r, r);
+    })
 }
 
-CAMLexport value caml_read_root(caml_root root)
+/* Register a global C root of the mutable kind */
+
+CAMLexport void caml_register_global_root(value *r)
 {
-  value v = (value)root;
-  value x;
-  Assert(root);
-  Assert(Hd_val(root));
-  Assert(Int_field(v,1) == 0 || Int_field(v,1) == 1);
-  caml_read_field(v, 0, &x);
-  return x;
+  CAMLassert (((intnat) r & 3) == 0);  /* compact.c demands this (for now) */
+  caml_insert_global_root(&caml_global_roots, r);
 }
 
-CAMLexport void caml_modify_root(caml_root root, value newv)
+/* Un-register a global C root of the mutable kind */
+
+CAMLexport void caml_remove_global_root(value *r)
 {
-  value v = (value)root;
-  Assert(root);
-  caml_modify_field(v, 0, newv);
+  caml_delete_global_root(&caml_global_roots, r);
 }
 
-static void scan_global_roots(scanning_action f, void* fdata)
+enum gc_root_class {
+  YOUNG,
+  OLD,
+  UNTRACKED
+};
+
+static enum gc_root_class classify_gc_root(value v)
 {
-  value r, newr;
-  caml_plat_lock(&roots_mutex);
-  r = roots_all;
-  caml_plat_unlock(&roots_mutex);
-
-  Assert(!Is_minor(r));
-  newr = r;
-  f(fdata, newr, &newr);
-  Assert(r == newr); /* GC should not move r, it is not young */
+  if(!Is_block(v)) return UNTRACKED;
+  if(Is_young(v)) return YOUNG;
+  return OLD;
 }
 
-void caml_cleanup_deleted_roots()
+/* Register a global C root of the generational kind */
+
+CAMLexport void caml_register_generational_global_root(value *r)
 {
-  value r, prev;
-  int first = 1;
-  caml_plat_lock(&roots_mutex);
+  CAMLassert (((intnat) r & 3) == 0);  /* compact.c demands this (for now) */
 
-  r = roots_all;
-  while (Is_block(r)) {
-    value next = Op_val(r)[2];
-    if (Int_field(r, 1) == 0) {
-      /* root was deleted, remove from list */
-      if (first) {
-        roots_all = next;
-      } else {
-        caml_modify_field(prev, 2, next);
-      }
-    }
-
-    prev = r;
-    first = 0;
-    r = next;
-  }
-
-  caml_plat_unlock(&roots_mutex);
-}
-
-#ifdef NATIVE_CODE
-
-/* Linked-list of natdynlink'd globals */
-
-typedef struct link {
-  void *data;
-  struct link *next;
-} link;
-
-static link *cons(void *data, link *tl) {
-  link *lnk = caml_stat_alloc(sizeof(link));
-  lnk->data = data;
-  lnk->next = tl;
-  return lnk;
-}
-
-#define iter_list(list,lnk) \
-  for (lnk = list; lnk != NULL; lnk = lnk->next)
-
-
-/* protected by roots_mutex */
-static link * caml_dyn_globals = NULL;
-
-void caml_register_dyn_global(void *v) {
-  caml_plat_lock(&roots_mutex);
-  caml_dyn_globals = cons((void*) v,caml_dyn_globals);
-  caml_plat_unlock(&roots_mutex);
-}
-
-static void scan_native_globals(scanning_action f, void* fdata)
-{
-  int i, j;
-  static link* dyn_globals;
-  value* glob;
-  link* lnk;
-
-  caml_plat_lock(&roots_mutex);
-  dyn_globals = caml_dyn_globals;
-  caml_plat_unlock(&roots_mutex);
-
-  /* The global roots */
-  for (i = 0; i <= caml_globals_inited && caml_globals[i] != 0; i++) {
-    for(glob = caml_globals[i]; *glob != 0; glob++) {
-      for (j = 0; j < Wosize_val(*glob); j++){
-        f(fdata, Op_val(*glob)[j], &Op_val(*glob)[j]);
-      }
-    }
-  }
-
-  /* Dynamic (natdynlink) global roots */
-  iter_list(dyn_globals, lnk) {
-    for(glob = (value *) lnk->data; *glob != 0; glob++) {
-      for (j = 0; j < Wosize_val(*glob); j++){
-        f(fdata, Op_val(*glob)[j], &Op_val(*glob)[j]);
-      }
-    }
-  }
-}
-
-#endif
-
-void caml_scan_global_roots(scanning_action f, void* fdata) {
-  /* FIXME KC: Needs to be done only once per major cycle. Currently, every
-   * domain scans global roots */
-  scan_global_roots(f, fdata);
-#ifdef NATIVE_CODE
-  scan_native_globals(f, fdata);
-#endif
-}
-
-/* linked list of registered global roots */
-typedef struct capi_global_roots {
-  void *v;
-  caml_root root;
-  struct capi_global_roots *next;
-} capi_global_roots;
-
-static capi_global_roots *cons_capi_roots(void *v, caml_root root, capi_global_roots *tl) {
-  capi_global_roots *dat = caml_stat_alloc(sizeof(capi_global_roots));
-  dat->v = v;
-  dat->root = root;
-  dat->next = tl;
-  return dat;
-}
-
-#define iter_capi_roots_list(list,dat) \
-  for (dat = list; dat != NULL; dat = dat->next)
-
-/* protected by roots_mutex */
-static capi_global_roots * caml_capi_global_roots = NULL;
-
-CAMLexport void caml_register_global_root (value *v) {
-  caml_root root = caml_create_root(*v);
-  caml_plat_lock(&roots_mutex);
-  caml_capi_global_roots = cons_capi_roots((void*) v, root, caml_capi_global_roots);
-  caml_plat_unlock(&roots_mutex);
-}
-
-CAMLexport void caml_remove_global_root (value *v) {
-  capi_global_roots* dat;
-  capi_global_roots** last;
-
-  caml_plat_lock(&roots_mutex);
-  last = &caml_capi_global_roots;
-  iter_capi_roots_list(caml_capi_global_roots, dat) {
-    if (dat->v == v) {
-      caml_delete_root(dat->root);
-      *last = dat->next;
-      caml_stat_free(dat);
+  switch(classify_gc_root(*r)) {
+    case YOUNG:
+      caml_insert_global_root(&caml_global_roots_young, r);
       break;
-    }
-    last = &dat->next;
+    case OLD:
+      caml_insert_global_root(&caml_global_roots_old, r);
+      break;
+    case UNTRACKED: break;
   }
-  caml_plat_unlock(&roots_mutex);
 }
 
-CAMLexport void caml_register_generational_global_root (value *v) {
-  caml_register_global_root(v);
+/* Un-register a global C root of the generational kind */
+
+CAMLexport void caml_remove_generational_global_root(value *r)
+{
+  switch(classify_gc_root(*r)) {
+    case OLD:
+      caml_delete_global_root(&caml_global_roots_old, r);
+      /* Fallthrough: the root can be in the young list while actually
+         being in the major heap. */
+    case YOUNG:
+      caml_delete_global_root(&caml_global_roots_young, r);
+      break;
+    case UNTRACKED: break;
+  }
 }
 
-CAMLexport void caml_remove_generational_global_root (value *v) {
-  caml_remove_global_root(v);
+/* Modify the value of a global C root of the generational kind */
+
+CAMLexport void caml_modify_generational_global_root(value *r, value newval)
+{
+  enum gc_root_class c;
+  /* See PRs #4704, #607 and #8656 */
+  switch(classify_gc_root(newval)) {
+    case YOUNG:
+      c = classify_gc_root(*r);
+      if(c == OLD)
+        caml_delete_global_root(&caml_global_roots_old, r);
+      if(c != YOUNG)
+        caml_insert_global_root(&caml_global_roots_young, r);
+      break;
+
+    case OLD:
+      /* If the old class is YOUNG, then we do not need to do
+         anything: It is OK to have a root in roots_young that
+         suddenly points to the old generation -- the next minor GC
+         will take care of that. */
+      if(classify_gc_root(*r) == UNTRACKED)
+        caml_insert_global_root(&caml_global_roots_old, r);
+      break;
+
+    case UNTRACKED:
+      caml_remove_generational_global_root(r);
+      break;
+  }
+
+  *r = newval;
 }
 
-CAMLexport void caml_modify_generational_global_root (value *r, value newval) {
-  caml_modify_field(*r, 0, newval);
+/* Scan all global roots */
+void caml_scan_global_roots(scanning_action f, void* fdata) {
+  caml_iterate_global_roots(f, &caml_global_roots, fdata);
+  caml_iterate_global_roots(f, &caml_global_roots_young, fdata);
+  caml_iterate_global_roots(f, &caml_global_roots_old, fdata);
+}
+
+/* Scan global roots for a minor collection */
+
+void caml_scan_global_young_roots(scanning_action f, void* fdata)
+{
+
+  caml_iterate_global_roots(f, &caml_global_roots, fdata);
+  caml_iterate_global_roots(f, &caml_global_roots_young, fdata);
+  /* Move young roots to old roots */
+  FOREACH_SKIPLIST_ELEMENT(e, &caml_global_roots_young, {
+      value * r = (value *) (e->key);
+      caml_insert_global_root(&caml_global_roots_old, r);
+    });
+  caml_skiplist_empty(&caml_global_roots_young);
 }

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -64,7 +64,7 @@ CAMLexport value caml_read_root(caml_root root)
 
 CAMLexport void caml_modify_root(caml_root root, value newv)
 {
-  caml_modify((value*)root, newv);
+  *((value*)root) = newv;
 }
 
 /* The three global root lists.
@@ -73,20 +73,6 @@ CAMLexport void caml_modify_root(caml_root root, value newv)
 
 struct skiplist caml_global_roots = SKIPLIST_STATIC_INITIALIZER;
                   /* mutable roots, don't know whether old or young */
-struct skiplist caml_global_roots_young = SKIPLIST_STATIC_INITIALIZER;
-                  /* generational roots pointing to minor or major heap */
-struct skiplist caml_global_roots_old = SKIPLIST_STATIC_INITIALIZER;
-                  /* generational roots pointing to major heap */
-
-/* The invariant of the generational roots is the following:
-   - If the global root contains a pointer to the minor heap, then the root is
-     in [caml_global_roots_young];
-   - If the global root contains a pointer to the major heap, then the root is
-     in [caml_global_roots_old] or in [caml_global_roots_young];
-   - Otherwise (the root contains a pointer outside of the heap or an integer),
-     then neither [caml_global_roots_young] nor [caml_global_roots_old] contain
-     it.
-*/
 
 /* Insertion and deletion */
 
@@ -123,7 +109,6 @@ CAMLexport void caml_register_global_root(value *r)
 {
   CAMLassert (((intnat) r & 3) == 0);  /* compact.c demands this (for now) */
   caml_insert_global_root(&caml_global_roots, r);
-  caml_modify(r, *r);
 }
 
 /* Un-register a global C root of the mutable kind */
@@ -139,76 +124,25 @@ enum gc_root_class {
   UNTRACKED
 };
 
-static enum gc_root_class classify_gc_root(value v)
-{
-  if(!Is_block(v)) return UNTRACKED;
-  if(Is_young(v)) return YOUNG;
-  return OLD;
-}
-
 /* Register a global C root of the generational kind */
 
 CAMLexport void caml_register_generational_global_root(value *r)
 {
-  CAMLassert (((intnat) r & 3) == 0);  /* compact.c demands this (for now) */
-
-  switch(classify_gc_root(*r)) {
-    case YOUNG:
-      caml_insert_global_root(&caml_global_roots_young, r);
-      break;
-    case OLD:
-      caml_insert_global_root(&caml_global_roots_old, r);
-      break;
-    case UNTRACKED: break;
-  }
+  caml_register_global_root(r);
 }
 
 /* Un-register a global C root of the generational kind */
 
 CAMLexport void caml_remove_generational_global_root(value *r)
 {
-  switch(classify_gc_root(*r)) {
-    case OLD:
-      caml_delete_global_root(&caml_global_roots_old, r);
-      /* Fallthrough: the root can be in the young list while actually
-         being in the major heap. */
-    case YOUNG:
-      caml_delete_global_root(&caml_global_roots_young, r);
-      break;
-    case UNTRACKED: break;
-  }
+  caml_remove_global_root(r);
 }
 
 /* Modify the value of a global C root of the generational kind */
 
 CAMLexport void caml_modify_generational_global_root(value *r, value newval)
 {
-  enum gc_root_class c;
-  /* See PRs #4704, #607 and #8656 */
-  switch(classify_gc_root(newval)) {
-    case YOUNG:
-      c = classify_gc_root(*r);
-      if(c == OLD)
-        caml_delete_global_root(&caml_global_roots_old, r);
-      if(c != YOUNG)
-        caml_insert_global_root(&caml_global_roots_young, r);
-      break;
-
-    case OLD:
-      /* If the old class is YOUNG, then we do not need to do
-         anything: It is OK to have a root in roots_young that
-         suddenly points to the old generation -- the next minor GC
-         will take care of that. */
-      if(classify_gc_root(*r) == UNTRACKED)
-        caml_insert_global_root(&caml_global_roots_old, r);
-      break;
-
-    case UNTRACKED:
-      caml_remove_generational_global_root(r);
-      break;
-  }
-
-  caml_modify(r, newval);
+  *r = newval;
 }
 
 #ifdef NATIVE_CODE
@@ -275,8 +209,6 @@ static void scan_native_globals(scanning_action f, void* fdata)
 /* Scan all global roots */
 void caml_scan_global_roots(scanning_action f, void* fdata) {
   caml_iterate_global_roots(f, &caml_global_roots, fdata);
-  caml_iterate_global_roots(f, &caml_global_roots_young, fdata);
-  caml_iterate_global_roots(f, &caml_global_roots_old, fdata);
 
   #ifdef NATIVE_CODE
   scan_native_globals(f, fdata);
@@ -287,14 +219,5 @@ void caml_scan_global_roots(scanning_action f, void* fdata) {
 
 void caml_scan_global_young_roots(scanning_action f, void* fdata)
 {
-
   caml_iterate_global_roots(f, &caml_global_roots, fdata);
-  caml_iterate_global_roots(f, &caml_global_roots_young, fdata);
-
-  /* Move young roots to old roots */
-  FOREACH_SKIPLIST_ELEMENT(e, &caml_global_roots_young, {
-      value * r = (value *) (e->key);
-      caml_insert_global_root(&caml_global_roots_old, r);
-    });
-  caml_skiplist_empty(&caml_global_roots_young);
 }

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -30,7 +30,7 @@ CAMLexport caml_root caml_create_root(value init)
 {
   CAMLparam1(init);
   
-  value* v = (value*)malloc(sizeof(value));
+  value* v = (value*)caml_stat_alloc(sizeof(value));
 
   *v = init;
 
@@ -42,10 +42,19 @@ CAMLexport caml_root caml_create_root(value init)
 CAMLexport caml_root caml_create_root_noexc(value init)
 {
   CAMLparam1(init);
+  
+  value* v = (value*)caml_stat_alloc_noexc(sizeof(value));
 
-  caml_root r = caml_create_root(init);
+  if( v == NULL ) {
+    CAMLdrop;
+    return NULL;
+  }
 
-  CAMLreturnT(caml_root, r);
+  *v = init;
+
+  caml_register_global_root(v);
+
+  CAMLreturnT(caml_root, (caml_root)v);
 }
 
 CAMLexport void caml_delete_root(caml_root root)
@@ -54,7 +63,7 @@ CAMLexport void caml_delete_root(caml_root root)
   Assert(root);
   /* the root will be removed from roots_all and freed at the next GC */
   caml_remove_global_root(v);
-  free(v);
+  caml_stat_free(v);
 }
 
 CAMLexport value caml_read_root(caml_root root)

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -123,7 +123,7 @@ CAMLexport void caml_register_global_root(value *r)
 {
   CAMLassert (((intnat) r & 3) == 0);  /* compact.c demands this (for now) */
   caml_insert_global_root(&caml_global_roots, r);
-  caml_initialize(r, *r);
+  caml_modify(r, *r);
 }
 
 /* Un-register a global C root of the mutable kind */

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -73,7 +73,20 @@ CAMLexport void caml_modify_root(caml_root root, value newv)
 
 struct skiplist caml_global_roots = SKIPLIST_STATIC_INITIALIZER;
                   /* mutable roots, don't know whether old or young */
+struct skiplist caml_global_roots_young = SKIPLIST_STATIC_INITIALIZER;
+                  /* generational roots pointing to minor or major heap */
+struct skiplist caml_global_roots_old = SKIPLIST_STATIC_INITIALIZER;
+                  /* generational roots pointing to major heap */
 
+/* The invariant of the generational roots is the following:
+   - If the global root contains a pointer to the minor heap, then the root is
+     in [caml_global_roots_young];
+   - If the global root contains a pointer to the major heap, then the root is
+     in [caml_global_roots_old] or in [caml_global_roots_young];
+   - Otherwise (the root contains a pointer outside of the heap or an integer),
+     then neither [caml_global_roots_young] nor [caml_global_roots_old] contain
+     it. */
+    
 /* Insertion and deletion */
 
 Caml_inline void caml_insert_global_root(struct skiplist * list, value * r)
@@ -124,24 +137,75 @@ enum gc_root_class {
   UNTRACKED
 };
 
+static enum gc_root_class classify_gc_root(value v)
+{
+  if(!Is_block(v)) return UNTRACKED;
+  if(Is_young(v)) return YOUNG;
+  return OLD;
+}
+
 /* Register a global C root of the generational kind */
 
 CAMLexport void caml_register_generational_global_root(value *r)
 {
-  caml_register_global_root(r);
+  CAMLassert (((intnat) r & 3) == 0);  /* compact.c demands this (for now) */
+
+  switch(classify_gc_root(*r)) {
+    case YOUNG:
+      caml_insert_global_root(&caml_global_roots_young, r);
+      break;
+    case OLD:
+      caml_insert_global_root(&caml_global_roots_old, r);
+      break;
+    case UNTRACKED: break;
+  }
 }
 
 /* Un-register a global C root of the generational kind */
 
 CAMLexport void caml_remove_generational_global_root(value *r)
 {
-  caml_remove_global_root(r);
+  switch(classify_gc_root(*r)) {
+    case OLD:
+      caml_delete_global_root(&caml_global_roots_old, r);
+      /* Fallthrough: the root can be in the young list while actually
+         being in the major heap. */
+    case YOUNG:
+      caml_delete_global_root(&caml_global_roots_young, r);
+      break;
+    case UNTRACKED: break;
+  }
 }
 
 /* Modify the value of a global C root of the generational kind */
 
 CAMLexport void caml_modify_generational_global_root(value *r, value newval)
 {
+  enum gc_root_class c;
+  /* See PRs #4704, #607 and #8656 */
+  switch(classify_gc_root(newval)) {
+    case YOUNG:
+      c = classify_gc_root(*r);
+      if(c == OLD)
+        caml_delete_global_root(&caml_global_roots_old, r);
+      if(c != YOUNG)
+        caml_insert_global_root(&caml_global_roots_young, r);
+      break;
+
+    case OLD:
+      /* If the old class is YOUNG, then we do not need to do
+         anything: It is OK to have a root in roots_young that
+         suddenly points to the old generation -- the next minor GC
+         will take care of that. */
+      if(classify_gc_root(*r) == UNTRACKED)
+        caml_insert_global_root(&caml_global_roots_old, r);
+      break;
+
+    case UNTRACKED:
+      caml_remove_generational_global_root(r);
+      break;
+  }
+
   *r = newval;
 }
 
@@ -209,6 +273,8 @@ static void scan_native_globals(scanning_action f, void* fdata)
 /* Scan all global roots */
 void caml_scan_global_roots(scanning_action f, void* fdata) {
   caml_iterate_global_roots(f, &caml_global_roots, fdata);
+  caml_iterate_global_roots(f, &caml_global_roots_young, fdata);
+  caml_iterate_global_roots(f, &caml_global_roots_old, fdata);
 
   #ifdef NATIVE_CODE
   scan_native_globals(f, fdata);
@@ -220,4 +286,16 @@ void caml_scan_global_roots(scanning_action f, void* fdata) {
 void caml_scan_global_young_roots(scanning_action f, void* fdata)
 {
   caml_iterate_global_roots(f, &caml_global_roots, fdata);
+  caml_iterate_global_roots(f, &caml_global_roots_young, fdata);
+  /* Move young roots to old roots */
+
+  caml_plat_lock(&roots_mutex);
+  FOREACH_SKIPLIST_ELEMENT(e, &caml_global_roots_young, {
+      value * r = (value *) (e->key);
+      caml_skiplist_insert(&caml_global_roots_old, (uintnat) r, 0);
+    });
+  caml_plat_unlock(&roots_mutex);
+
+  caml_skiplist_empty(&caml_global_roots_young);
 }
+  

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -28,6 +28,7 @@
 #include "caml/finalise.h"
 #include "caml/gc.h"
 #include "caml/gc_ctrl.h"
+#include "caml/globroots.h"
 #include "caml/major_gc.h"
 #include "caml/memory.h"
 #include "caml/minor_gc.h"
@@ -536,6 +537,13 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
 
   caml_gc_log ("Minor collection of domain %d starting", domain->state->id);
   caml_ev_begin("minor_gc");
+
+  caml_ev_begin("minor_gc/global_roots");
+  if( participating[0] == caml_domain_self() || !not_alone ) { // TODO: We should distribute this work
+    caml_scan_global_young_roots(oldify_one, &st);
+  }
+  caml_ev_end("minor_gc/global_roots");
+
   caml_ev_begin("minor_gc/remembered_set");
 
   int remembered_roots = 0;

--- a/runtime/skiplist.c
+++ b/runtime/skiplist.c
@@ -1,0 +1,206 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*             Xavier Leroy, projet Cambium, INRIA Paris                  */
+/*                                                                        */
+/*   Copyright 2020 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#define CAML_INTERNALS
+
+/* A dictionary data structure implemented as skip lists
+   (see William Pugh, "Skip lists: a probabilistic alternative to
+   balanced binary trees", Comm. ACM 33(6), 1990). */
+
+#include <stddef.h>
+#include "caml/config.h"
+#include "caml/memory.h"
+#include "caml/misc.h"
+#include "caml/skiplist.h"
+
+/* Size of struct skipcell, in bytes, without the forward array */
+#if (__STDC_VERSION__ >= 199901L)
+#define SIZEOF_SKIPCELL sizeof(struct skipcell)
+#else
+#define SIZEOF_SKIPCELL (sizeof(struct skipcell) - sizeof(struct skipcell *))
+#endif
+
+/* Generate a random level for a new node: 0 with probability 3/4,
+   1 with probability 3/16, 2 with probability 3/64, etc.
+   We use a simple linear congruential PRNG (see Knuth vol 2) instead
+   of random(), because we need exactly 32 bits of pseudo-random data
+   (i.e. 2 * (NUM_LEVELS - 1)).  Moreover, the congruential PRNG
+   is faster and guaranteed to be deterministic (to reproduce bugs). */
+
+static uint32_t random_seed = 0;
+
+static int random_level(void)
+{
+  uint32_t r;
+  int level = 0;
+
+  /* Linear congruence with modulus = 2^32, multiplier = 69069
+     (Knuth vol 2 p. 106, line 15 of table 1), additive = 25173. */
+  r = random_seed = random_seed * 69069 + 25173;
+  /* Knuth (vol 2 p. 13) shows that the least significant bits are
+     "less random" than the most significant bits with a modulus of 2^m,
+     so consume most significant bits first */
+  while ((r & 0xC0000000U) == 0xC0000000U) { level++; r = r << 2; }
+  CAMLassert(level < NUM_LEVELS);
+  return level;
+}
+
+/* Initialize a skip list */
+
+void caml_skiplist_init(struct skiplist * sk)
+{
+  int i;
+  for (i = 0; i < NUM_LEVELS; i++) sk->forward[i] = NULL;
+  sk->level = 0;
+}
+
+/* Search a skip list */
+
+int caml_skiplist_find(struct skiplist * sk, uintnat key, uintnat * data)
+{
+  int i;
+  struct skipcell ** e, * f;
+
+  e = sk->forward;
+  for (i = sk->level; i >= 0; i--) {
+    while (1) {
+      f = e[i];
+      if (f == NULL || f->key > key) break;
+      if (f->key == key) {
+        *data = f->data;
+        return 1;
+      }
+      e = f->forward;
+    }
+  }
+  return 0;
+}
+
+int caml_skiplist_find_below(struct skiplist * sk, uintnat k,
+                             uintnat * key, uintnat * data)
+{
+  int i;
+  struct skipcell ** e, * f, * last = NULL;
+
+  e = sk->forward;
+  for (i = sk->level; i >= 0; i--) {
+    while (1) {
+      f = e[i];
+      if (f == NULL || f->key > k) break;
+      last = f;
+      e = f->forward;
+    }
+  }
+  if (!last) {
+    return 0;
+  } else {
+    *key = last-> key; *data = last->data; return 1;
+  }
+}
+
+/* Insertion in a skip list */
+
+int caml_skiplist_insert(struct skiplist * sk,
+                         uintnat key, uintnat data)
+{
+  struct skipcell ** update[NUM_LEVELS];
+  struct skipcell ** e, * f;
+  int i, new_level;
+
+  /* Init "cursor" to list head */
+  e = sk->forward;
+  /* Find place to insert new node */
+  for (i = sk->level; i >= 0; i--) {
+    while (1) {
+      f = e[i];
+      if (f == NULL || f->key >= key) break;
+      e = f->forward;
+    }
+    update[i] = &e[i];
+  }
+  f = e[0];
+  /* If already present, update data */
+  if (f != NULL && f->key == key) {
+    f->data = data;
+    return 1;
+  }
+  /* Insert additional element, updating list level if necessary */
+  new_level = random_level();
+  if (new_level > sk->level) {
+    for (i = sk->level + 1; i <= new_level; i++)
+      update[i] = &sk->forward[i];
+    sk->level = new_level;
+  }
+  f = caml_stat_alloc(SIZEOF_SKIPCELL +
+                      (new_level + 1) * sizeof(struct skipcell *));
+  f->key = key;
+  f->data = data;
+  for (i = 0; i <= new_level; i++) {
+    f->forward[i] = *update[i];
+    *update[i] = f;
+  }
+  return 0;
+}
+
+/* Deletion in a skip list */
+
+int caml_skiplist_remove(struct skiplist * sk, uintnat key)
+{
+  struct skipcell ** update[NUM_LEVELS];
+  struct skipcell ** e, * f;
+  int i;
+
+  /* Init "cursor" to list head */
+  e = sk->forward;
+  /* Find element in list */
+  for (i = sk->level; i >= 0; i--) {
+    while (1) {
+      f = e[i];
+      if (f == NULL || f->key >= key) break;
+      e = f->forward;
+    }
+    update[i] = &e[i];
+  }
+  f = e[0];
+  /* If not found, nothing to do */
+  if (f == NULL || f->key != key) return 0;
+  /* Rebuild list without node */
+  for (i = 0; i <= sk->level; i++) {
+    if (*update[i] == f)
+      *update[i] = f->forward[i];
+  }
+  /* Reclaim list element */
+  caml_stat_free(f);
+  /* Down-correct list level */
+  while (sk->level > 0 &&
+         sk->forward[sk->level] == NULL)
+    sk->level--;
+  return 1;
+}
+
+/* Empty a skip list */
+
+void caml_skiplist_empty(struct skiplist * sk)
+{
+  struct skipcell * e, * next;
+  int i;
+
+  for (e = sk->forward[0]; e != NULL; e = next) {
+    next = e->forward[0];
+    caml_stat_free(e);
+  }
+  for (i = 0; i <= sk->level; i++) sk->forward[i] = NULL;
+  sk->level = 0;
+}

--- a/testsuite/tests/gc-roots/globroots.ml
+++ b/testsuite/tests/gc-roots/globroots.ml
@@ -74,6 +74,13 @@ end
 module TestClassic = Test(Classic)
 module TestGenerational = Test(Generational)
 
+external young2old : unit -> unit = "gb_young2old"
+let _ = young2old (); Gc.full_major ()
+
+external static2young : int * int -> (unit -> unit) -> int = "gb_static2young"
+let _ =
+  assert (static2young (1, 1) Gc.full_major == 0x42)
+
 let _ =
   let n =
     if Array.length Sys.argv < 2 then 10000 else int_of_string Sys.argv.(1) in

--- a/testsuite/tests/gc-roots/globrootsprim.c
+++ b/testsuite/tests/gc-roots/globrootsprim.c
@@ -13,57 +13,104 @@
 
 /* For testing global root registration */
 
+#define CAML_INTERNALS
+
 #include "caml/mlvalues.h"
 #include "caml/memory.h"
 #include "caml/alloc.h"
 #include "caml/gc.h"
+#include "caml/shared_heap.h"
+#include "caml/callback.h"
 
-struct block { value header; caml_root v; };
+struct block { value header; value v; };
 
-#define Root_val(v) *((caml_root*) Data_abstract_val(v))
+#define Block_val(v) ((struct block*) &((value*) v)[-1])
+#define Val_block(b) ((value) &((b)->v))
 
 value gb_get(value vblock)
 {
-  CAMLparam1 (vblock);
-  CAMLreturn (caml_read_root(Root_val(vblock)));
+  return Block_val(vblock)->v;
 }
 
 value gb_classic_register(value v)
 {
-  CAMLparam1(v);
-  CAMLlocal1(b);
-  caml_root r;
-  b = caml_alloc(1, Abstract_tag);
-  r = caml_create_root(v);
-  Root_val(b) = r;
-  CAMLreturn (b);
+  struct block * b = caml_stat_alloc(sizeof(struct block));
+  b->header = Make_header(1, 0, NOT_MARKABLE);
+  b->v = v;
+  caml_register_global_root(&(b->v));
+  return Val_block(b);
 }
 
 value gb_classic_set(value vblock, value newval)
 {
-  CAMLparam2(vblock, newval);
-  caml_modify_root(Root_val(vblock), newval);
-  CAMLreturn (Val_unit);
+  Block_val(vblock)->v = newval;
+  return Val_unit;
 }
 
 value gb_classic_remove(value vblock)
 {
-  CAMLparam1(vblock);
-  caml_delete_root(Root_val(vblock));
-  CAMLreturn (Val_unit);
+  caml_remove_global_root(&(Block_val(vblock)->v));
+  return Val_unit;
 }
 
 value gb_generational_register(value v)
 {
-  return gb_classic_register(v);
+  struct block * b = caml_stat_alloc(sizeof(struct block));
+  b->header = Make_header(1, 0, NOT_MARKABLE);
+  b->v = v;
+  caml_register_generational_global_root(&(b->v));
+  return Val_block(b);
 }
 
 value gb_generational_set(value vblock, value newval)
 {
-  return gb_classic_set(vblock, newval);
+  caml_modify_generational_global_root(&(Block_val(vblock)->v), newval);
+  return Val_unit;
 }
 
 value gb_generational_remove(value vblock)
 {
-  return gb_classic_remove(vblock);
+  caml_remove_generational_global_root(&(Block_val(vblock)->v));
+  return Val_unit;
+}
+
+value root;
+
+value gb_young2old(value _dummy) {
+  root = caml_alloc_small(1, 0);
+  caml_register_generational_global_root(&root);
+  caml_modify_generational_global_root(&root, caml_alloc_shr(10, String_tag));
+  Field(root, 0) = 0xFFFFFFFF;
+  caml_remove_generational_global_root(&root);
+  root += sizeof(value);
+  return Val_unit;
+}
+
+value gb_static2young(value static_value, value full_major) {
+  CAMLparam2 (static_value, full_major);
+  CAMLlocal1(v);
+  int i;
+
+  root = Val_unit;
+  caml_register_generational_global_root(&root);
+
+  /* Write a static value in the root. */
+  caml_modify_generational_global_root(&root, static_value);
+
+  /* Overwrite it with a young value. */
+  v = caml_alloc_small(1, 0);
+  Field(v, 0) = Val_long(0x42);
+  caml_modify_generational_global_root(&root, v);
+
+  /* Promote the young value */
+  caml_callback(full_major, Val_unit);
+
+  /* Fill the minor heap to make sure the old block is overwritten */
+  for(i = 0; i < 1000000; i++)
+    caml_alloc_small(1, 0);
+
+  v = Field(root, 0);
+  caml_remove_generational_global_root(&root);
+
+  CAMLreturn(v);
 }


### PR DESCRIPTION
This PR replaces the existing global roots implementation with one that incorporates most of trunk OCaml's `globroots`.

There's further work to be done on global roots.

1) This implementation places locks around the skip lists. We should have a per-domain skip lists and a global one for orphans when a domain is terminated. This would eliminate the need to lock when registering/removing a global root.

2) We should remove the existing `Caml_root` usage and them remove these functions from `globroots`. This would leave us in a position where the global roots implementation very closely matches trunk.