### PR TITLE
Fix issue 421: stack overflow on scan stack

### DIFF
--- a/testsuite/tests/effects/evenodd.ml
+++ b/testsuite/tests/effects/evenodd.ml
@@ -1,0 +1,15 @@
+(* TEST
+ *)
+
+effect E : unit
+
+let rec even n =
+  if n = 0 then true
+  else try odd (n-1) with effect E _ -> assert false
+and odd n =
+  if n = 0 then false
+  else even (n-1)
+
+let _ =
+  let n = 1_000_000 in
+  Printf.printf "even %d is %B\n%!" n (even n)

--- a/testsuite/tests/effects/evenodd.reference
+++ b/testsuite/tests/effects/evenodd.reference
@@ -1,0 +1,1 @@
+even 1000000 is true


### PR DESCRIPTION
This PR fixes #421.

`caml_scan_stack` was structured in a way that can lead to a stack overflow when there is a deep nesting of fibers. This PR alters `caml_scan_stack` to be expressed as a `while` loop. 
