### PR TITLE
Remove caml_context push/pop on stack switch

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -65,6 +65,7 @@ struct caml_thread_struct {
   int backtrace_pos;
   code_t * backtrace_buffer;
   caml_root backtrace_last_exn;
+  value * gc_regs;
   value * gc_regs_buckets;
   value ** gc_regs_slot;
   void * exn_handler;
@@ -126,8 +127,8 @@ static void caml_thread_scan_roots(scanning_action action, void *fdata, struct d
       (*action)(fdata, th->descr, &th->descr);
 
       if (th != Current_thread) {
-	if (th->current_stack != NULL)
-	  caml_do_local_roots(action, fdata, th->local_roots, th->current_stack, 0);
+        if (th->current_stack != NULL)
+	        caml_do_local_roots(action, fdata, th->local_roots, th->current_stack, th->gc_regs);
       }
       th = th->next;
     } while (th != Current_thread);
@@ -143,6 +144,7 @@ void caml_thread_save_runtime_state(void)
 {
   Current_thread->current_stack = Caml_state->current_stack;
   Current_thread->c_stack = Caml_state->c_stack;
+  Current_thread->gc_regs = Caml_state->gc_regs;
   Current_thread->gc_regs_buckets = Caml_state->gc_regs_buckets;
   Current_thread->gc_regs_slot = Caml_state->gc_regs_slot;
   Current_thread->exn_handler = Caml_state->exn_handler;
@@ -161,6 +163,7 @@ void caml_thread_restore_runtime_state(void)
 {
   Caml_state->current_stack = Current_thread->current_stack;
   Caml_state->c_stack = Current_thread->c_stack;
+  Caml_state->gc_regs = Current_thread->gc_regs;
   Caml_state->gc_regs_buckets = Current_thread->gc_regs_buckets;
   Caml_state->gc_regs_slot = Current_thread->gc_regs_slot;
   Caml_state->exn_handler = Current_thread->exn_handler;

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -163,16 +163,6 @@
           DW_OP_breg + DW_REG_rsp, Cstack_sp, DW_OP_deref, \
           DW_OP_plus_uconst, (PUSHED) + 8 /* retaddr */
 
-/* Switch from OCaml to C stack. Also builds a context at
- * the bottom of the OCaml stack. Clobbers %r10, %r11.
- * PUSHED is the number of bytes already pushed by this function.
- * It is used to compute the backtrace. */
-#define SWITCH_OCAML_TO_C(PUSHED) \
-    /* Build caml_context at the bottom of the stack */ \
-    /*  pushq   $0 ; CFI_ADJUST(8); */ \
-    /*  PUSH_EXN_HANDLER; */ \
-        SWITCH_OCAML_TO_C_NO_CTXT(PUSHED)
-
 /* Switch from C to OCaml stack.  Clobbers %r11. */
 #define SWITCH_C_TO_OCAML_NO_CTXT \
     /* Assert that %rsp == Caml_state->c_stack &&
@@ -183,14 +173,6 @@
         movq    Cstack_sp(%rsp), %rsp; \
         .cfi_restore_state
 
-/* Switch from C to OCaml stack. Also pops the context
- * from the bottom of the OCaml stack. Clobbers %r10 and %r11. */
-#define SWITCH_C_TO_OCAML \
-        SWITCH_C_TO_OCAML_NO_CTXT; \
-    /* Pop the caml_context from the bottom of stack */ \
-    /*  POP_EXN_HANDLER; */ \
-    /*  popq    %r11; CFI_ADJUST(-8); */
-
 /* Load Caml_state->exn_handler into %rsp and restores prior exn_handler. Clobbers %r10 and %r11. */
 #define RESTORE_EXN_HANDLER_OCAML \
         movq    Caml_state(exn_handler), %rsp; \
@@ -199,10 +181,6 @@
 
 /* Switch between OCaml stacks. Clobbers %r10 and %r11. Expects target stack in %r10. */
 #define SWITCH_OCAML_STACKS \
-    /* Build caml_context at the bottom of the stack, \
-       saving the exception pointer of the source stack */ \
-    /*  pushq   $0 ; CFI_ADJUST(8); */ \
-    /*  PUSH_EXN_HANDLER; */ \
     /* Save OCaml SP and exn_handler in the stack slot */ \
         movq    Caml_state(current_stack), %r11; \
         movq    %rsp, Stack_sp(%r11); \
@@ -213,12 +191,9 @@
         movq    Caml_state(current_stack), %r10; \
         movq    Stack_sp(%r10), %rsp; \
         .cfi_def_cfa_offset 8 ; /* FIXME */ \
-    /* restore exn_handler */ \
+    /* restore exn_handler in new stack */ \
         movq    Stack_exception(%r10), %r11; \
-        movq    %r11, Caml_state(exn_handler); \
-    /* Pop the caml_context from the bottom of stack */ \
-    /*  POP_EXN_HANDLER; */ \
-    /*  popq    %r11; CFI_ADJUST(-8) */
+        movq    %r11, Caml_state(exn_handler)
 
 /******************************************************************************/
 /* Save and restore all callee-save registers on stack.
@@ -630,7 +605,7 @@ LBL(caml_c_call):
         C arguments         : %rdi, %rsi, %rdx, %rcx, %r8, and %r9
         C function          : %rax */
     /* Switch from OCaml to C */
-        SWITCH_OCAML_TO_C(0)
+        SWITCH_OCAML_TO_C_NO_CTXT(0)
     /* Make the alloc ptr available to the C code */
         movq    %r15, Caml_state(young_ptr)
     /* Call the function (address in %rax) */
@@ -638,7 +613,7 @@ LBL(caml_c_call):
     /* Prepare for return to OCaml */
         movq    Caml_state(young_ptr), %r15
     /* Load ocaml stack and restore global variables */
-        SWITCH_C_TO_OCAML
+        SWITCH_C_TO_OCAML_NO_CTXT
     /* Return to OCaml caller */
         ret
 CFI_ENDPROC
@@ -652,12 +627,12 @@ CFI_STARTPROC
         C function          : %rax
         C stack args        : begin=%r13 end=%r12 */
     /* Switch from OCaml to C */
-        SWITCH_OCAML_TO_C(0)
+        SWITCH_OCAML_TO_C_NO_CTXT(0)
     /* we use %rbp (otherwise unused) to enable backtraces */
         movq    %rsp, %rbp
         .cfi_escape DW_CFA_def_cfa_expression, 5, \
           DW_OP_breg + DW_REG_rbp, Cstack_sp, DW_OP_deref, \
-          DW_OP_plus_uconst, 16 /* caml_context */ + 8 /* ret addr */
+          DW_OP_plus_uconst,  8 /* ret addr */
     /* Make the alloc ptr available to the C code */
         movq    %r15, Caml_state(young_ptr)
     /* Copy arguments from OCaml to C stack */
@@ -675,7 +650,7 @@ LBL(106):
     /* Prepare for return to OCaml */
         movq    Caml_state(young_ptr), %r15
     /* Load ocaml stack and restore global variables */
-        SWITCH_C_TO_OCAML
+        SWITCH_C_TO_OCAML_NO_CTXT
     /* Return to OCaml caller */
         ret
 CFI_ENDPROC
@@ -723,9 +698,7 @@ LBL(caml_start_program):
         subq    $16, %r10
         lea     LBL(109)(%rip), %r11
         movq    %r11, 8(%r10)
-    /* load the previous context exn_handler so that copying stacks works */
-    /*  movq    Caml_state(current_stack), %r11 */
-    /*  movq    Stack_sp(%r11), %r11 */
+    /* link in the previous exn_handler so that copying stacks works */
         movq    Caml_state(exn_handler), %r11
         movq    %r11, 0(%r10)
         movq    %r10, Caml_state(exn_handler)
@@ -822,9 +795,6 @@ CFI_STARTPROC
     /* Discard the C stack pointer and reset to ocaml stack */
         movq    Caml_state(current_stack), %r10
         movq    Stack_sp(%r10), %rsp         /* FIXME: CFI */
-    /* Pop the caml_context and raise exn in OCaml */
-    /*  POP_EXN_HANDLER */
-    /*  popq    %r10 */
         jmp LBL(caml_raise_exn)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_raise_exception))
@@ -952,9 +922,6 @@ CFI_STARTPROC
         andq    $-2, %rax       /* %rax = Ptr_val(%rax) */
         movq    %rdi, %r12      /* Save arg (callee-saved) */
         movq    %rax, %rdi
-    /* Build caml_context at the bottom of the stack */
-    /*  pushq   $0 ; CFI_ADJUST(8); */
-    /*  PUSH_EXN_HANDLER */
     /* save old stack pointer and exception handler */
         movq    Caml_state(current_stack), %rax
         movq    Caml_state(exn_handler), %r10
@@ -970,9 +937,7 @@ CFI_STARTPROC
         leaq    -32(%rax), %r11
         leaq    LBL(fiber_exn_handler)(%rip), %r10
         movq    %r10, 8(%r11)
-    /* load the previous context exn_handler so that copying stacks works */
-    /*  movq    %rax, 0(%r11) */
-    /*  movq    %r11, Caml_state(exn_handler) */
+    /* link the previous exn_handler so that copying stacks works */
         movq    Stack_exception(%rdi), %r10
         movq    %r10, 0(%r11)
         movq    %r11, Caml_state(exn_handler)
@@ -982,7 +947,7 @@ CFI_STARTPROC
         .cfi_escape DW_CFA_def_cfa_expression, 3+3+2, \
           DW_OP_breg + DW_REG_rsp, 32 /* exn */ + Handler_parent, DW_OP_deref,\
           DW_OP_plus_uconst, Stack_sp, DW_OP_deref,\
-          DW_OP_plus_uconst, /* 16 sizeof caml_context */ + 8 /* ret addr */
+          DW_OP_plus_uconst, 8 /* ret addr */
         movq    %r12, %rax /* first argument */
         callq   *(%rbx) /* closure in %rbx (second argument) */
 LBL(frame_runstack):
@@ -1002,9 +967,6 @@ LBL(frame_runstack):
         movq    %r13, %rsp
         .cfi_restore_state
         movq    %r12, %rax
-    /* Pop the caml_context from the bottom of the stack */
-    /*  POP_EXN_HANDLER */
-    /*  popq    %r10; CFI_ADJUST(-8) */
 
     /* Invoke handle_value (or handle_exn) */
         jmp     *(%rbx)

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -203,12 +203,19 @@
        saving the exception pointer of the source stack */ \
         pushq   $0 ; CFI_ADJUST(8); \
         PUSH_EXN_HANDLER; \
-    /* Save OCaml SP in the stack slot */ \
+    /* Save OCaml SP and exn_handler in the stack slot */ \
         movq    Caml_state(current_stack), %r11; \
         movq    %rsp, Stack_sp(%r11); \
-        movq    %r10, Caml_state(current_stack) ; \
+        movq    %r10, Caml_state(current_stack); /* free up r10 */ \
+        movq    Caml_state(exn_handler), %r10; \
+        movq    %r10, Stack_exception(%r11); \
+    /* switch stacks */ \
+        movq    Caml_state(current_stack), %r10; \
         movq    Stack_sp(%r10), %rsp; \
         .cfi_def_cfa_offset 24 ; /* FIXME */ \
+    /* restore exn_handler */ \
+        movq    Stack_exception(%r10), %r11; \
+        movq    %r11, Caml_state(exn_handler); \
     /* Pop the caml_context from the bottom of stack */ \
         POP_EXN_HANDLER; \
         popq    %r11; CFI_ADJUST(-8)
@@ -330,7 +337,8 @@ G(caml_hot__code_end):
 
 /* struct stack_info */
 #define Stack_sp                 0
-#define Stack_handler            8
+#define Stack_exception          8
+#define Stack_handler            16
 
 /* struct stack_handler */
 #define Handler_value(REG)       0(REG)
@@ -705,7 +713,8 @@ LBL(caml_start_program):
     /* Load the OCaml stack. */
         movq    Caml_state(current_stack), %r11
         movq    Stack_sp(%r11), %r10
-    /* Store the stack pointer to allow DWARF unwind */
+    /* Store the stack pointer to allow DWARF unwind and
+       gc_regs for callbacks during a GC */
         subq    $16, %r10
         movq    %rsp, 0(%r10)
         movq    Caml_state(gc_regs), %r11

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -578,12 +578,14 @@ LBL(caml_allocN):
 LBL(call_gc_and_retry_alloc):
         addq    %rax, %r15
         SAVE_ALL_REGS
+        movq    %r15, Caml_state(gc_regs)
         pushq   %r15; CFI_ADJUST(8)
         PUSH_EXN_HANDLER
         SWITCH_OCAML_TO_C_NO_CTXT(16)
         C_call (GCALL(caml_garbage_collection))
         SWITCH_C_TO_OCAML_NO_CTXT
         POP_EXN_HANDLER
+        movq    Caml_state(gc_regs), %r15
         popq    %r15; CFI_ADJUST(-8)
         RESTORE_ALL_REGS
         jmp     LBL(caml_allocN)
@@ -594,12 +596,14 @@ FUNCTION(G(caml_call_poll))
 CFI_STARTPROC
 LBL(caml_call_poll):
         SAVE_ALL_REGS
+        movq    %r15, Caml_state(gc_regs)
         pushq   %r15; CFI_ADJUST(8)
         PUSH_EXN_HANDLER
         SWITCH_OCAML_TO_C_NO_CTXT(16)
         C_call (GCALL(caml_garbage_collection))
         SWITCH_C_TO_OCAML_NO_CTXT
         POP_EXN_HANDLER
+        movq    Caml_state(gc_regs), %r15
         popq    %r15; CFI_ADJUST(-8)
         RESTORE_ALL_REGS
         ret
@@ -704,6 +708,8 @@ LBL(caml_start_program):
     /* Store the stack pointer to allow DWARF unwind */
         subq    $16, %r10
         movq    %rsp, 0(%r10)
+        movq    Caml_state(gc_regs), %r11
+        movq    %r11, 8(%r10)
     /* Build a handler for exceptions raised in OCaml on the OCaml stack. */
         subq    $16, %r10
         lea     LBL(109)(%rip), %r11
@@ -725,8 +731,12 @@ LBL(108):
     /* pop exn handler */
         movq    0(%rsp), %r11
         movq    %r11, Caml_state(exn_handler)
-        leaq    32(%rsp), %r10
-1:  /* Update alloc ptr */
+        leaq    16(%rsp), %r10
+1:  /* restore GC regs */
+        movq    8(%r10), %r11
+        movq    %r11, Caml_state(gc_regs)
+        addq    $16, %r10
+    /* Update alloc ptr */
         movq    %r15, Caml_state(young_ptr)
     /* Return to C stack. */
         movq    Caml_state(current_stack), %r11
@@ -746,7 +756,7 @@ LBL(109):
     /* Mark the bucket as an exception result and return it */
         orq     $2, %rax
         /* exn handler already popped here */
-        leaq    16(%rsp), %r10
+        movq    %rsp, %r10
         jmp     1b
 CFI_ENDPROC
 ENDFUNCTION(G(caml_start_program))

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -169,9 +169,9 @@
  * It is used to compute the backtrace. */
 #define SWITCH_OCAML_TO_C(PUSHED) \
     /* Build caml_context at the bottom of the stack */ \
-        pushq   $0 ; CFI_ADJUST(8); \
-        PUSH_EXN_HANDLER; \
-        SWITCH_OCAML_TO_C_NO_CTXT((PUSHED) + 16)
+    /*  pushq   $0 ; CFI_ADJUST(8); */ \
+    /*  PUSH_EXN_HANDLER; */ \
+        SWITCH_OCAML_TO_C_NO_CTXT(PUSHED)
 
 /* Switch from C to OCaml stack.  Clobbers %r11. */
 #define SWITCH_C_TO_OCAML_NO_CTXT \
@@ -188,8 +188,8 @@
 #define SWITCH_C_TO_OCAML \
         SWITCH_C_TO_OCAML_NO_CTXT; \
     /* Pop the caml_context from the bottom of stack */ \
-        POP_EXN_HANDLER; \
-        popq    %r11; CFI_ADJUST(-8); \
+    /*  POP_EXN_HANDLER; */ \
+    /*  popq    %r11; CFI_ADJUST(-8); */
 
 /* Load Caml_state->exn_handler into %rsp and restores prior exn_handler. Clobbers %r10 and %r11. */
 #define RESTORE_EXN_HANDLER_OCAML \
@@ -201,8 +201,8 @@
 #define SWITCH_OCAML_STACKS \
     /* Build caml_context at the bottom of the stack, \
        saving the exception pointer of the source stack */ \
-        pushq   $0 ; CFI_ADJUST(8); \
-        PUSH_EXN_HANDLER; \
+    /*  pushq   $0 ; CFI_ADJUST(8); */ \
+    /*  PUSH_EXN_HANDLER; */ \
     /* Save OCaml SP and exn_handler in the stack slot */ \
         movq    Caml_state(current_stack), %r11; \
         movq    %rsp, Stack_sp(%r11); \
@@ -212,13 +212,13 @@
     /* switch stacks */ \
         movq    Caml_state(current_stack), %r10; \
         movq    Stack_sp(%r10), %rsp; \
-        .cfi_def_cfa_offset 24 ; /* FIXME */ \
+        .cfi_def_cfa_offset 8 ; /* FIXME */ \
     /* restore exn_handler */ \
         movq    Stack_exception(%r10), %r11; \
         movq    %r11, Caml_state(exn_handler); \
     /* Pop the caml_context from the bottom of stack */ \
-        POP_EXN_HANDLER; \
-        popq    %r11; CFI_ADJUST(-8)
+    /*  POP_EXN_HANDLER; */ \
+    /*  popq    %r11; CFI_ADJUST(-8) */
 
 /******************************************************************************/
 /* Save and restore all callee-save registers on stack.
@@ -587,14 +587,14 @@ LBL(call_gc_and_retry_alloc):
         addq    %rax, %r15
         SAVE_ALL_REGS
         movq    %r15, Caml_state(gc_regs)
-        pushq   %r15; CFI_ADJUST(8)
-        PUSH_EXN_HANDLER
-        SWITCH_OCAML_TO_C_NO_CTXT(16)
+        /* pushq   %r15; CFI_ADJUST(8) */
+        /* PUSH_EXN_HANDLER */
+        SWITCH_OCAML_TO_C_NO_CTXT(0)
         C_call (GCALL(caml_garbage_collection))
         SWITCH_C_TO_OCAML_NO_CTXT
-        POP_EXN_HANDLER
+        /* POP_EXN_HANDLER */
         movq    Caml_state(gc_regs), %r15
-        popq    %r15; CFI_ADJUST(-8)
+        /* popq    %r15; CFI_ADJUST(-8) */
         RESTORE_ALL_REGS
         jmp     LBL(caml_allocN)
 CFI_ENDPROC
@@ -605,14 +605,14 @@ CFI_STARTPROC
 LBL(caml_call_poll):
         SAVE_ALL_REGS
         movq    %r15, Caml_state(gc_regs)
-        pushq   %r15; CFI_ADJUST(8)
-        PUSH_EXN_HANDLER
-        SWITCH_OCAML_TO_C_NO_CTXT(16)
+        /* pushq   %r15; CFI_ADJUST(8) */
+        /* PUSH_EXN_HANDLER */
+        SWITCH_OCAML_TO_C_NO_CTXT(0)
         C_call (GCALL(caml_garbage_collection))
         SWITCH_C_TO_OCAML_NO_CTXT
-        POP_EXN_HANDLER
+        /* POP_EXN_HANDLER */
         movq    Caml_state(gc_regs), %r15
-        popq    %r15; CFI_ADJUST(-8)
+        /* popq    %r15; CFI_ADJUST(-8) */
         RESTORE_ALL_REGS
         ret
 CFI_ENDPROC
@@ -724,8 +724,9 @@ LBL(caml_start_program):
         lea     LBL(109)(%rip), %r11
         movq    %r11, 8(%r10)
     /* load the previous context exn_handler so that copying stacks works */
-        movq    Caml_state(current_stack), %r11
-        movq    Stack_sp(%r11), %r11
+    /*  movq    Caml_state(current_stack), %r11 */
+    /*  movq    Stack_sp(%r11), %r11 */
+        movq    Caml_state(exn_handler), %r11
         movq    %r11, 0(%r10)
         movq    %r10, Caml_state(exn_handler)
     /* Switch stacks and call the OCaml code */
@@ -822,8 +823,8 @@ CFI_STARTPROC
         movq    Caml_state(current_stack), %r10
         movq    Stack_sp(%r10), %rsp         /* FIXME: CFI */
     /* Pop the caml_context and raise exn in OCaml */
-        POP_EXN_HANDLER
-        popq    %r10
+    /*  POP_EXN_HANDLER */
+    /*  popq    %r10 */
         jmp LBL(caml_raise_exn)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_raise_exception))
@@ -952,11 +953,14 @@ CFI_STARTPROC
         movq    %rdi, %r12      /* Save arg (callee-saved) */
         movq    %rax, %rdi
     /* Build caml_context at the bottom of the stack */
-        pushq   $0 ; CFI_ADJUST(8);
-        PUSH_EXN_HANDLER
-    /* Load new stack pointer into %r11 and set parent */
+    /*  pushq   $0 ; CFI_ADJUST(8); */
+    /*  PUSH_EXN_HANDLER */
+    /* save old stack pointer and exception handler */
         movq    Caml_state(current_stack), %rax
+        movq    Caml_state(exn_handler), %r10
         movq    %rsp, Stack_sp(%rax)
+        movq    %r10, Stack_exception(%rax)
+    /* Load new stack pointer and set parent */
         movq    Stack_handler(%rdi), %rcx
         movq    %rax, Handler_parent(%rcx)
         movq    %rdi, Caml_state(current_stack)
@@ -967,7 +971,10 @@ CFI_STARTPROC
         leaq    LBL(fiber_exn_handler)(%rip), %r10
         movq    %r10, 8(%r11)
     /* load the previous context exn_handler so that copying stacks works */
-        movq    %rax, 0(%r11)
+    /*  movq    %rax, 0(%r11) */
+    /*  movq    %r11, Caml_state(exn_handler) */
+        movq    Stack_exception(%rdi), %r10
+        movq    %r10, 0(%r11)
         movq    %r11, Caml_state(exn_handler)
     /* Switch to the new stack */
         movq    %r11, %rsp
@@ -975,16 +982,18 @@ CFI_STARTPROC
         .cfi_escape DW_CFA_def_cfa_expression, 3+3+2, \
           DW_OP_breg + DW_REG_rsp, 32 /* exn */ + Handler_parent, DW_OP_deref,\
           DW_OP_plus_uconst, Stack_sp, DW_OP_deref,\
-          DW_OP_plus_uconst, 16 /* sizeof caml_context */ + 8 /* ret addr */
+          DW_OP_plus_uconst, /* 16 sizeof caml_context */ + 8 /* ret addr */
         movq    %r12, %rax /* first argument */
         callq   *(%rbx) /* closure in %rbx (second argument) */
 LBL(frame_runstack):
         leaq    32(%rsp), %r11 /* SP with exn handler popped */
         movq    Handler_value(%r11), %rbx
-1:  /* Switch back to parent stack and free current */
+1:  /* Switch back to parent stack, restore exception handler and free current */
         movq    Handler_parent(%r11), %r10
         movq    Caml_state(current_stack), %rdi
         movq    %r10, Caml_state(current_stack)
+        movq    Stack_exception(%r10), %r11
+        movq    %r11, Caml_state(exn_handler)
         movq    Stack_sp(%r10), %r13 /* saved across C call */
         movq    %rax, %r12 /* save %rax across C call */
         movq    Caml_state(c_stack), %rsp
@@ -994,8 +1003,9 @@ LBL(frame_runstack):
         .cfi_restore_state
         movq    %r12, %rax
     /* Pop the caml_context from the bottom of the stack */
-        POP_EXN_HANDLER
-        popq    %r10; CFI_ADJUST(-8)
+    /*  POP_EXN_HANDLER */
+    /*  popq    %r10; CFI_ADJUST(-8) */
+
     /* Invoke handle_value (or handle_exn) */
         jmp     *(%rbx)
 LBL(fiber_exn_handler):

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -56,8 +56,6 @@ static frame_descr * caml_next_frame_descriptor(caml_frame_descrs fds, uintnat *
         return NULL;
       }
       *sp += sizeof(value); /* return address */
-          /* sizeof(struct caml_context) */ /* context */
-          /*+ sizeof(value); */ /* return address */
     }
   }
 }

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -55,8 +55,9 @@ static frame_descr * caml_next_frame_descriptor(caml_frame_descrs fds, uintnat *
         *pc = 0;
         return NULL;
       }
-      *sp += sizeof(struct caml_context) /* context */
-          + sizeof(value); /* return address */
+      *sp += sizeof(value); /* return address */
+          /* sizeof(struct caml_context) */ /* context */
+          /*+ sizeof(value); */ /* return address */
     }
   }
 }

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -196,7 +196,7 @@ typedef uint64_t uintnat;
 
 /* Number of words used in the control structure at the start of a stack
    (see fiber.h) */
-#define Stack_ctx_words 3
+#define Stack_ctx_words 4
 
 /* Default maximum size of the stack (words). */
 #define Max_stack_def (1024 * 1024)

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -36,10 +36,12 @@ DOMAIN_STATE(void*, exn_handler)
 
 DOMAIN_STATE(value*, gc_regs_buckets)
 
-DOMAIN_STATE(struct c_stack_link*, c_stack)
-/* The C stack associated with this domain. Used by this domain to perform external calls. */
+DOMAIN_STATE(value*, gc_regs)
 
 DOMAIN_STATE(value**, gc_regs_slot)
+
+DOMAIN_STATE(struct c_stack_link*, c_stack)
+/* The C stack associated with this domain. Used by this domain to perform external calls. */
 
 DOMAIN_STATE(struct caml_minor_tables*, minor_tables)
 

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -71,7 +71,7 @@ extern caml_root caml_global_data;
 #define Trap_link(tp) ((tp)[1])
 
 struct stack_info* caml_alloc_main_stack (uintnat init_size);
-void caml_scan_stack(scanning_action f, void* fdata, struct stack_info* stack);
+void caml_scan_stack(scanning_action f, void* fdata, struct stack_info* stack, value* v_gc_regs);
 /* try to grow the stack until at least required_size words are available.
    returns nonzero on success */
 int caml_try_realloc_stack (asize_t required_size);

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -20,8 +20,10 @@ struct stack_handler {
 struct stack_info {
 #ifdef NATIVE_CODE
   void* sp;
+  void* exception_ptr;
 #else
   value* sp;
+  value* exception_ptr;
 #endif
   struct stack_handler* handler;
   uintnat magic;

--- a/runtime/caml/roots.h
+++ b/runtime/caml/roots.h
@@ -26,8 +26,10 @@ CAMLextern void (*caml_scan_roots_hook)(scanning_action, void*, struct domain*);
 
 void caml_do_roots (scanning_action f, void* data, struct domain* d,
                     int do_final_val);
-void caml_do_local_roots(scanning_action f, void* data, struct caml__roots_block* local_roots,
-                         struct stack_info *current_stack, int do_final_val);
+void caml_do_local_roots(scanning_action f, void* data,
+						struct caml__roots_block* local_roots,
+                        struct stack_info *current_stack,
+                        value * v_gc_regs);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -93,7 +93,6 @@ static inline void scan_stack_frames(scanning_action f, void* fdata, struct stac
   struct caml_context* context;
   caml_frame_descrs fds = caml_get_frame_descrs();
 
-  if (stack->sp == Stack_high(stack)) return;
   sp = (char*)stack->sp;
 
 next_chunk:
@@ -102,7 +101,6 @@ next_chunk:
   regs = context->gc_regs;
   sp += sizeof(struct caml_context);
 
-  if (sp == (char*)Stack_high(stack)) return;
   retaddr = *(uintnat*)sp;
   sp += sizeof(value);
 

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -76,7 +76,7 @@ void caml_get_stack_sp_pc (struct stack_info* stack, char** sp /* out */, uintna
 {
   char* p = (char*)stack->sp;
 
-  p += sizeof(struct caml_context) + sizeof(value);
+  p += /*sizeof(struct caml_context)*/ + sizeof(value);
   *sp = p;
   *pc = Saved_return_address(*sp);
 }
@@ -98,7 +98,7 @@ static inline void scan_stack_frames(scanning_action f, void* fdata, struct stac
 next_chunk:
   if (sp == (char*)Stack_high(stack)) return;
 
-  sp += sizeof(struct caml_context);
+  /*sp += sizeof(struct caml_context);*/
   retaddr = *(uintnat*)sp;
   sp += sizeof(value);
 
@@ -395,10 +395,8 @@ CAMLprim value caml_clone_continuation (value cont)
 #ifdef NATIVE_CODE
     {
       /* rewrite exception pointer in the caml context on the new stack */
-      value* exn_start =
-        Stack_high(target) - (Stack_high(source) - (value*)source->sp);
-      rewrite_exception_stack(source, (value**)exn_start, target);
-      target->exception_ptr = *(value**)exn_start;
+      target->exception_ptr = source->exception_ptr;
+      rewrite_exception_stack(source, (value**)&target->exception_ptr, target);
     }
 #endif
     target->sp = Stack_high(target) - stack_used;

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -53,6 +53,7 @@ static struct stack_info* alloc_stack_noexc(mlsize_t wosize, value hval, value h
   hand->parent = NULL;
   stack->handler = hand;
   stack->sp = (value*)hand;
+  stack->exception_ptr = NULL;
   stack->magic = 42;
   CAMLassert(Stack_high(stack) - Stack_base(stack) == wosize ||
              Stack_high(stack) - Stack_base(stack) == wosize + 1);
@@ -393,10 +394,11 @@ CAMLprim value caml_clone_continuation (value cont)
            stack_used * sizeof(value));
 #ifdef NATIVE_CODE
     {
-      /* pull out the exception pointer from the caml context on the stack */
+      /* rewrite exception pointer in the caml context on the new stack */
       value* exn_start =
         Stack_high(target) - (Stack_high(source) - (value*)source->sp);
       rewrite_exception_stack(source, (value**)exn_start, target);
+      target->exception_ptr = *(value**)exn_start;
     }
 #endif
     target->sp = Stack_high(target) - stack_used;

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -76,7 +76,7 @@ void caml_get_stack_sp_pc (struct stack_info* stack, char** sp /* out */, uintna
 {
   char* p = (char*)stack->sp;
 
-  p += /*sizeof(struct caml_context)*/ + sizeof(value);
+  p += sizeof(value);
   *sp = p;
   *pc = Saved_return_address(*sp);
 }
@@ -98,7 +98,6 @@ static inline void scan_stack_frames(scanning_action f, void* fdata, struct stac
 next_chunk:
   if (sp == (char*)Stack_high(stack)) return;
 
-  /*sp += sizeof(struct caml_context);*/
   retaddr = *(uintnat*)sp;
   sp += sizeof(value);
 
@@ -130,9 +129,9 @@ next_chunk:
     } else {
       /* This marks the top of an ML stack chunk. Move sp to the previous stack
        * chunk. This includes skipping over the trap frame (2 words). */
-      sp += 2 * sizeof(value);
+      sp += 2 * sizeof(value); /* trap frame */
       regs = *(value**)sp;
-      sp += 2 * sizeof(value);
+      sp += 2 * sizeof(value); /* DWARF and gc_regs */
       goto next_chunk;
     }
   }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -641,7 +641,7 @@ void caml_darken_cont(value cont)
             With_status_hd(hd, NOT_MARKABLE))) {
       value stk = Op_val(cont)[0];
       if (Ptr_val(stk) != NULL)
-        caml_scan_stack(&caml_darken, 0, Ptr_val(stk));
+        caml_scan_stack(&caml_darken, 0, Ptr_val(stk), 0);
       atomic_store_explicit(
         Hp_atomic_val(cont),
         With_status_hd(hd, global.MARKED),

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -292,7 +292,7 @@ static void oldify_one (void* st_v, value v, value *p)
       struct stack_info* stk = Ptr_val(stack_value);
       Op_val(result)[0] = Val_ptr(stk);
       if (stk != NULL) {
-        caml_scan_stack(&oldify_one, st, stk);
+        caml_scan_stack(&oldify_one, st, stk, 0);
       }
     }
     else
@@ -656,7 +656,7 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
 #endif
 
   caml_ev_begin("minor_gc/local_roots");
-  caml_do_local_roots(&oldify_one, &st, domain->state->local_roots, domain->state->current_stack, 0);
+  caml_do_local_roots(&oldify_one, &st, domain->state->local_roots, domain->state->current_stack, domain->state->gc_regs);
   if (caml_scan_roots_hook != NULL) (*caml_scan_roots_hook)(&oldify_one, &st, domain);
   caml_ev_begin("minor_gc/local_roots/promote");
   oldify_mopup (&st, 0);

--- a/runtime/roots.c
+++ b/runtime/roots.c
@@ -46,7 +46,7 @@ CAMLexport void (*caml_scan_roots_hook)(scanning_action, void* fdata, struct dom
 
 void caml_do_roots (scanning_action f, void* fdata, struct domain* d, int do_final_val)
 {
-  caml_do_local_roots(f, fdata, d->state->local_roots, d->state->current_stack, do_final_val);
+  caml_do_local_roots(f, fdata, d->state->local_roots, d->state->current_stack, d->state->gc_regs);
   if (caml_scan_roots_hook != NULL) (*caml_scan_roots_hook)(f, fdata, d);
   caml_scan_global_roots(f, fdata);
   caml_final_do_roots(f, fdata, d, do_final_val);
@@ -54,7 +54,9 @@ void caml_do_roots (scanning_action f, void* fdata, struct domain* d, int do_fin
 }
 
 CAMLexport void caml_do_local_roots (scanning_action f, void* fdata,
-                                     struct caml__roots_block *local_roots, struct stack_info *current_stack,  int do_final_val)
+                                     struct caml__roots_block *local_roots,
+                                     struct stack_info *current_stack,
+                                     value * v_gc_regs)
 {
   struct caml__roots_block *lr;
   int i, j;
@@ -70,5 +72,5 @@ CAMLexport void caml_do_local_roots (scanning_action f, void* fdata,
       }
     }
   }
-  caml_scan_stack(f, fdata, current_stack);
+  caml_scan_stack(f, fdata, current_stack, v_gc_regs);
 }

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -672,7 +672,7 @@ static void verify_object(struct heap_verify_state* st, value v) {
   if (Tag_val(v) == Cont_tag) {
     struct stack_info* stk = Ptr_val(Op_val(v)[0]);
     if (stk != NULL)
-      caml_scan_stack(verify_push, st, stk);
+      caml_scan_stack(verify_push, st, stk, 0);
   } else if (Tag_val(v) < No_scan_tag) {
     int i;
     for (i = 0; i < Wosize_val(v); i++) {


### PR DESCRIPTION
This PR removes the `caml_context` push/pop on stack switches; both ocaml-ocaml and ocaml-c switches. The motivation is to remove the slightly orthogonal usages of `caml_context`; in some places it is being used to communicate `gc_regs` in others the exception stack. It may speed things up (for example `caml_c_call` no longer has a push/pop sequence for `caml_context`), but the real hope is it makes the implementation a bit easier to understand and also to communicate.

There are couple of changes in this:
 - the second commit moves `gc_regs` to being stored in `Caml_state` in the same way that stock ocaml uses `gc_regs`; this enables the removal of the `gc_regs` usage of `caml_context`.
 - the third commit adds an `exception_ptr` field to `stack_info`; this also adds the assembly to save and restore that field. 
 - the forth commit removes the `caml_context` usage and uses the `gc_regs` & `exception_ptr` as introduced earlier.

This brings us closer to upstream ocaml (_we might want to add a cleanup commit that refactors to use the name `caml_context` in the same meaning as for upstream to wrap the DWARF + gc_regs as constructed in `caml_start_program`_).
