### PR TITLE
Collect gc stats on domain termination

### DIFF
--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -85,6 +85,7 @@ struct gc_stats {
   struct heap_stats major_heap;
 };
 void caml_sample_gc_stats(struct gc_stats* buf);
+void caml_sample_gc_collect(caml_domain_state *domain);
 
 /* Forces finalisation of all heap-allocated values,
    disregarding both local and global roots.

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1270,6 +1270,7 @@ static void domain_terminate()
     }
     caml_plat_unlock(&s->lock);
   }
+  caml_sample_gc_collect(domain_state);
 
   caml_stat_free(domain_state->final_info);
   caml_stat_free(domain_state->ephe_info);


### PR DESCRIPTION
Gc stats are collected at the end of a major cycle (when all participants go through `cycle_all_domains_callbacks`).
This means that if a domain terminates long before the next major cycle, the domain's latest allocations/promotion/else stats won't be accounted for.
While this may be a minor annoyance in a regular context, when the program does very little major gc (or none at all), this may cause various kind of inconsistencies in the results provided by the sampled stats.
The fix is simply to collect the statistics on domain termination.

I am willing to rename `caml_sample_gc_collect` in my patch, I think `collect` may be a bit of a confusing term. (at least in the overall GC terminology book.)
I also think the placement should be fine in the domain's termination lifecycle, but a second look wouldn't hurt.