### PR TITLE
Mark stack overflow backport

### DIFF
--- a/.depend
+++ b/.depend
@@ -1852,10 +1852,8 @@ bytecomp/printinstr.cmx : \
     bytecomp/printinstr.cmi
 bytecomp/printinstr.cmi : \
     bytecomp/instruct.cmi
-bytecomp/runtimedef.cmo :
-bytecomp/runtimedef.cmx :
 bytecomp/symtable.cmo : \
-    bytecomp/runtimedef.cmo \
+    lambda/runtimedef.cmi \
     typing/predef.cmi \
     utils/misc.cmi \
     bytecomp/meta.cmi \
@@ -1870,7 +1868,7 @@ bytecomp/symtable.cmo : \
     parsing/asttypes.cmi \
     bytecomp/symtable.cmi
 bytecomp/symtable.cmx : \
-    bytecomp/runtimedef.cmx \
+    lambda/runtimedef.cmx \
     typing/predef.cmx \
     utils/misc.cmx \
     bytecomp/meta.cmx \
@@ -2049,7 +2047,7 @@ asmcomp/asmlibrarian.cmx : \
     asmcomp/asmlibrarian.cmi
 asmcomp/asmlibrarian.cmi :
 asmcomp/asmlink.cmo : \
-    bytecomp/runtimedef.cmo \
+    lambda/runtimedef.cmi \
     utils/profile.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
@@ -2067,7 +2065,7 @@ asmcomp/asmlink.cmo : \
     asmcomp/asmgen.cmi \
     asmcomp/asmlink.cmi
 asmcomp/asmlink.cmx : \
-    bytecomp/runtimedef.cmx \
+    lambda/runtimedef.cmx \
     utils/profile.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
@@ -5615,7 +5613,6 @@ asmcomp/debug/reg_with_debug_info.cmx : \
 asmcomp/debug/reg_with_debug_info.cmi : \
     asmcomp/reg.cmi \
     middle_end/backend_var.cmi
-driver/compdynlink.cmi :
 driver/compenv.cmo : \
     utils/warnings.cmi \
     utils/profile.cmi \
@@ -5935,13 +5932,13 @@ driver/pparse.cmi : \
     parsing/parsetree.cmi
 toplevel/expunge.cmo : \
     bytecomp/symtable.cmi \
-    bytecomp/runtimedef.cmo \
+    lambda/runtimedef.cmi \
     utils/misc.cmi \
     typing/ident.cmi \
     bytecomp/bytesections.cmi
 toplevel/expunge.cmx : \
     bytecomp/symtable.cmx \
-    bytecomp/runtimedef.cmx \
+    lambda/runtimedef.cmx \
     utils/misc.cmx \
     typing/ident.cmx \
     bytecomp/bytesections.cmx

--- a/runtime/.depend
+++ b/runtime/.depend
@@ -236,7 +236,8 @@ major_gc_b.$(O): major_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
  caml/addrmap.h caml/domain.h caml/alloc.h caml/platform.h \
  caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h caml/finalise.h \
  caml/globroots.h caml/memory.h caml/mlvalues.h caml/platform.h \
- caml/roots.h caml/shared_heap.h caml/startup_aux.h caml/weak.h
+ caml/roots.h caml/shared_heap.h caml/startup_aux.h caml/weak.h \
+ caml/skiplist.h
 md5_b.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/md5.h \
@@ -678,7 +679,8 @@ major_gc_bd.$(O): major_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
  caml/addrmap.h caml/domain.h caml/alloc.h caml/platform.h \
  caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h caml/finalise.h \
  caml/globroots.h caml/memory.h caml/mlvalues.h caml/platform.h \
- caml/roots.h caml/shared_heap.h caml/startup_aux.h caml/weak.h
+ caml/roots.h caml/shared_heap.h caml/startup_aux.h caml/weak.h \
+ caml/skiplist.h
 md5_bd.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/md5.h \
@@ -1114,7 +1116,8 @@ major_gc_bi.$(O): major_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
  caml/addrmap.h caml/domain.h caml/alloc.h caml/platform.h \
  caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h caml/finalise.h \
  caml/globroots.h caml/memory.h caml/mlvalues.h caml/platform.h \
- caml/roots.h caml/shared_heap.h caml/startup_aux.h caml/weak.h
+ caml/roots.h caml/shared_heap.h caml/startup_aux.h caml/weak.h \
+ caml/skiplist.h
 md5_bi.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/md5.h \
@@ -1550,7 +1553,8 @@ major_gc_bpic.$(O): major_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
  caml/addrmap.h caml/domain.h caml/alloc.h caml/platform.h \
  caml/eventlog.h caml/fail.h caml/fiber.h caml/roots.h caml/finalise.h \
  caml/globroots.h caml/memory.h caml/mlvalues.h caml/platform.h \
- caml/roots.h caml/shared_heap.h caml/startup_aux.h caml/weak.h
+ caml/roots.h caml/shared_heap.h caml/startup_aux.h caml/weak.h \
+ caml/skiplist.h
 md5_bpic.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/byte_domain_state.tbl caml/fail.h caml/md5.h \
@@ -1971,7 +1975,7 @@ major_gc_n.$(O): major_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
  caml/alloc.h caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h \
  caml/roots.h caml/finalise.h caml/globroots.h caml/memory.h \
  caml/mlvalues.h caml/platform.h caml/roots.h caml/shared_heap.h \
- caml/startup_aux.h caml/weak.h
+ caml/startup_aux.h caml/weak.h caml/skiplist.h
 md5_n.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/fail.h caml/md5.h caml/io.h caml/platform.h \
@@ -2384,7 +2388,7 @@ major_gc_nd.$(O): major_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
  caml/alloc.h caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h \
  caml/roots.h caml/finalise.h caml/globroots.h caml/memory.h \
  caml/mlvalues.h caml/platform.h caml/roots.h caml/shared_heap.h \
- caml/startup_aux.h caml/weak.h
+ caml/startup_aux.h caml/weak.h caml/skiplist.h
 md5_nd.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/fail.h caml/md5.h caml/io.h caml/platform.h \
@@ -2791,7 +2795,7 @@ major_gc_ni.$(O): major_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
  caml/alloc.h caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h \
  caml/roots.h caml/finalise.h caml/globroots.h caml/memory.h \
  caml/mlvalues.h caml/platform.h caml/roots.h caml/shared_heap.h \
- caml/startup_aux.h caml/weak.h
+ caml/startup_aux.h caml/weak.h caml/skiplist.h
 md5_ni.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/fail.h caml/md5.h caml/io.h caml/platform.h \
@@ -3198,7 +3202,7 @@ major_gc_npic.$(O): major_gc.c caml/addrmap.h caml/mlvalues.h caml/config.h \
  caml/alloc.h caml/platform.h caml/eventlog.h caml/fail.h caml/fiber.h \
  caml/roots.h caml/finalise.h caml/globroots.h caml/memory.h \
  caml/mlvalues.h caml/platform.h caml/roots.h caml/shared_heap.h \
- caml/startup_aux.h caml/weak.h
+ caml/startup_aux.h caml/weak.h caml/skiplist.h
 md5_npic.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/camlatomic.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/fail.h caml/md5.h caml/io.h caml/platform.h \

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -34,6 +34,7 @@
 #include "caml/shared_heap.h"
 #include "caml/startup_aux.h"
 #include "caml/weak.h"
+#include "caml/skiplist.h"
 
 /* NB the MARK_STACK_INIT_SIZE must be larger than the number of objects
    that can be in a pool, see POOL_WSIZE */
@@ -1355,141 +1356,33 @@ static struct pool* find_pool_to_rescan()
   return p;
 }
 
-struct pool_count {
-  struct pool* pool;
-  int occurs;
-};
-
-static int pool_count_cmp(const void* a, const void* b)
-{
-  const struct pool_count* p = a;
-  const struct pool_count* q = b;
-  return p->occurs - q->occurs;
-}
-
 static void mark_stack_prune (struct mark_stack* stk)
 {
-  struct addrmap t = ADDRMAP_INIT;
-  int count = 0, entry;
-  addrmap_iterator i;
-  uintnat mark_stack_count = stk->count;
+  uintnat entry, mark_stack_count = stk->count, final_count = mark_stack_count * 0.25;
   mark_entry* mark_stack = stk->stack;
 
-  /* space used by the computations below */
-  uintnat table_max = mark_stack_count / 100;
-  if (table_max < 1000) table_max = 1000;
-
-  /* amount of space we want to free up */
-  int entries_to_free = (uintnat)(mark_stack_count * 0.20);
-
-  /* We compress the mark stack by removing all of the objects from a
-     subset of pools, which are rescanned later. For efficiency, we
-     want to select those pools which occur most frequently, so that
-     we need to rescan as few pools as possible. However, we do not
-     have space to build a complete histogram.
-
-     Using ~1% of the mark stack's space, we can find all of the
-     elements that occur at least 100 times using the Misra-Gries
-     heavy hitter algorithm (see J. Misra and D. Gries, "Finding
-     repeated elements", 1982). */
-
-  for (entry = 0; entry < mark_stack_count; entry++) {
-    struct pool* pool = caml_pool_of_shared_block(mark_stack[entry].block);
+  struct skiplist chunk_sklist = SKIPLIST_STATIC_INITIALIZER;
+  /* Insert used pools into skiplist */
+  for(entry = mark_stack_count - 1; entry > final_count; entry--){
+    mark_entry me = mark_stack[entry];
+    struct pool* pool = caml_pool_of_shared_block(me.block);
     if (!pool) continue;
-    value p = (value)pool;
-    if (caml_addrmap_contains(&t, p)) {
-      /* if it's already present, increase the count */
-      (*caml_addrmap_insert_pos(&t, p)) ++;
-    } else if (count < table_max) {
-      /* if there's space, insert it with count 1 */
-      *caml_addrmap_insert_pos(&t, p) = 1;
-      count++;
-    } else {
-      /* otherwise, decrease all entries by 1 */
-      struct addrmap s = ADDRMAP_INIT;
-      int scount = 0;
-      for (i = caml_addrmap_iterator(&t);
-           caml_addrmap_iter_ok(&t, i);
-           i = caml_addrmap_next(&t, i)) {
-        value k = caml_addrmap_iter_key(&t, i);
-        value v = caml_addrmap_iter_value(&t, i);
-        if (v > 1) {
-          *caml_addrmap_insert_pos(&s, k) = v - 1;
-          scount++;
-        }
-      }
-      caml_addrmap_clear(&t);
-      t = s;
-      count = scount;
+    caml_skiplist_insert(&chunk_sklist, (uintnat)pool, 
+    (uintnat)pool + sizeof(pool));
+  }
+  /* Traverse through entire skiplist and put it into pools to rescan */
+  FOREACH_SKIPLIST_ELEMENT(e, &chunk_sklist, {
+    if(Caml_state->pools_to_rescan_len == Caml_state->pools_to_rescan_count){
+      Caml_state->pools_to_rescan_len = Caml_state->pools_to_rescan_len * 2 + 128;
+      Caml_state->pools_to_rescan =
+        caml_stat_resize(Caml_state->pools_to_rescan, Caml_state->pools_to_rescan_len * sizeof(struct pool *));
     }
-  }
+    Caml_state->pools_to_rescan[Caml_state->pools_to_rescan_count++] = (struct pool*) (e->key);;
+  });
 
-  /* t now contains all pools that occur at least 100 times.
-     If no pools occur at least 100 times, t is some arbitrary subset of pools.
-     Next, we get an accurate count of the occurrences of the pools in t */
-
-  for (i = caml_addrmap_iterator(&t);
-       caml_addrmap_iter_ok(&t, i);
-       i = caml_addrmap_next(&t, i)) {
-    *caml_addrmap_iter_val_pos(&t, i) = 0;
-  }
-  for (entry = 0; entry < mark_stack_count; entry++) {
-    value p = (value)caml_pool_of_shared_block(mark_stack[entry].block);
-    if (p && caml_addrmap_contains(&t, p))
-      (*caml_addrmap_insert_pos(&t, p))++;
-  }
-
-  /* Next, find a subset of those pools that covers enough entries */
-
-  struct pool_count* pools = caml_stat_alloc(count * sizeof(struct pool_count));
-  int pos = 0;
-  for (i = caml_addrmap_iterator(&t);
-       caml_addrmap_iter_ok(&t, i);
-       i = caml_addrmap_next(&t, i)) {
-    struct pool_count* p = &pools[pos++];
-    p->pool = (struct pool*)caml_addrmap_iter_key(&t, i);
-    p->occurs = (int)caml_addrmap_iter_value(&t, i);
-  }
-  CAMLassert(pos == count);
-  caml_addrmap_clear(&t);
-
-  qsort(pools, count, sizeof(struct pool_count), &pool_count_cmp);
-
-  int start = count, total = 0;
-  while (start > 0 && total < entries_to_free) {
-    start--;
-    total += pools[start].occurs;
-  }
-
-
-
-  for (i = start; i < count; i++) {
-    *caml_addrmap_insert_pos(&t, (value)pools[i].pool) = 1;
-  }
-  int out = 0;
-  for (entry = 0; entry < mark_stack_count; entry++) {
-    mark_entry e = mark_stack[entry];
-    value p = (value)caml_pool_of_shared_block(e.block);
-    if (!(p && caml_addrmap_contains(&t, p))) {
-      mark_stack[out++] = e;
-    }
-  }
-  stk->count = out;
-
-  caml_gc_log("Mark stack overflow. Postponing %d pools (%.1f%%, leaving %d).",
-              count-start, 100. * (double)total / (double)mark_stack_count,
-              (int)stk->count);
-
-
-  /* Add the pools to rescan to domain's pools to rescan list */
-    for (i = start; i < count; i++) {
-      if (Caml_state->pools_to_rescan_count == Caml_state->pools_to_rescan_len) {
-        Caml_state->pools_to_rescan_len = Caml_state->pools_to_rescan_len * 2 + 128;
-        Caml_state->pools_to_rescan =
-          caml_stat_resize(Caml_state->pools_to_rescan, Caml_state->pools_to_rescan_len * sizeof(struct pool*));
-      }
-      Caml_state->pools_to_rescan[Caml_state->pools_to_rescan_count++] = pools[i].pool;
-    }
+  caml_gc_log("Mark stack overflow. Postponing %d pools", Caml_state->pools_to_rescan_count);
+  /* empty mark stack */
+  stk->count = final_count;
 }
 
 int caml_init_major_gc(caml_domain_state* d) {


### PR DESCRIPTION
This patch removes the existing mark stack overflow and adds an implementation that is closer to trunk OCaml. Three fourth of the mark stack is cleared, all the pools storing those removed entries are added to `pools_to_rescan`. Pools in `pools_to_rescan` are marked later during a major slice. The pools are added to a skiplist first to eliminate any duplicate values.

Sandmark results for macro-benchmarks are below:
![image](https://user-images.githubusercontent.com/13328130/98505308-e8175900-227e-11eb-8a94-520d83ec839a.png)
![image](https://user-images.githubusercontent.com/13328130/98505326-f1a0c100-227e-11eb-9b96-0987900c0d24.png)

Results of the micro-benchamrk `finalise` measuring performance difference in mark stack overflow:

![image](https://user-images.githubusercontent.com/13328130/98505501-51976780-227f-11eb-9684-4246772e78ca.png)
![image](https://user-images.githubusercontent.com/13328130/98505511-578d4880-227f-11eb-8f19-b4d92328c1e7.png)

Normalised major collections against `parallel_minor_gc` on this branch:
![image](https://user-images.githubusercontent.com/13328130/98505546-6e339f80-227f-11eb-84ff-4d54a9820e46.png)
