### PR TITLE
Avoid an allocating C call when switching stacks with continue

### DIFF
--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -909,7 +909,7 @@ CFI_STARTPROC
         movq    %rsi, Handler_parent(%rcx)
         SWITCH_OCAML_STACKS
         jmp     *(%rbx)
-2:      LEA_VAR(caml_exn_Continuation_in_use, %rax)
+2:      LEA_VAR(caml_exn_Continuation_already_taken, %rax)
         jmp LBL(caml_raise_exn)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_resume))

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -896,6 +896,9 @@ CFI_STARTPROC
     /* %rax -> stack, %rbx -> fun, %rdi -> arg */
         leaq    -1(%rax), %r10  /* %r10 (new stack) = Ptr_val(%rax) */
         movq    %rdi, %rax      /* %rax := argument to function in %rbx */
+    /*  check if stack null, then already used */
+        testq   %r10, %r10
+        jz      2f
     /* Find end of list of stacks and add current */
         movq    %r10, %rsi
 1:      movq    Stack_handler(%rsi), %rcx
@@ -906,6 +909,8 @@ CFI_STARTPROC
         movq    %rsi, Handler_parent(%rcx)
         SWITCH_OCAML_STACKS
         jmp     *(%rbx)
+2:      LEA_VAR(caml_exn_Continuation_in_use, %rax)
+        jmp LBL(caml_raise_exn)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_resume))
 

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -40,7 +40,7 @@
 #define ASSERT_FAILURE_EXN 10   /* "Assert_failure" */
 #define UNDEFINED_RECURSIVE_MODULE_EXN 11 /* "Undefined_recursive_module" */
 #define UNHANDLED_EXN 12        /* "Unhandled" */
-#define CONTINUATION_IN_USE_EXN 13        /* "Continuation_in_use" */
+#define CONTINUATION_ALREADY_TAKEN_EXN 13 /* "Continuation_already_taken" */
 
 #ifdef POSIX_SIGNALS
 struct longjmp_buffer {
@@ -147,6 +147,10 @@ CAMLnoreturn_end;
 
 CAMLnoreturn_start
 CAMLextern void caml_raise_sys_blocked_io (void)
+CAMLnoreturn_end;
+
+CAMLnoreturn_start
+CAMLextern void caml_raise_continuation_already_taken (void)
 CAMLnoreturn_end;
 
 #ifdef __cplusplus

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -40,6 +40,7 @@
 #define ASSERT_FAILURE_EXN 10   /* "Assert_failure" */
 #define UNDEFINED_RECURSIVE_MODULE_EXN 11 /* "Undefined_recursive_module" */
 #define UNHANDLED_EXN 12        /* "Unhandled" */
+#define CONTINUATION_IN_USE_EXN 13        /* "Continuation_in_use" */
 
 #ifdef POSIX_SIGNALS
 struct longjmp_buffer {

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -207,6 +207,13 @@ CAMLexport void caml_raise_sys_blocked_io(void)
                                 SYS_BLOCKED_IO));
 }
 
+CAMLexport void caml_raise_continuation_already_taken(void)
+{
+  check_global_data("Continuation_already_taken");
+  caml_raise_constant(Field_imm(caml_read_root(caml_global_data),
+                                CONTINUATION_ALREADY_TAKEN_EXN));
+}
+
 value caml_raise_if_exception(value res)
 {
   if (Is_exception_result(res)) caml_raise(Extract_exception(res));

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -48,7 +48,8 @@ extern caml_generated_constant
   caml_exn_Stack_overflow,
   caml_exn_Assert_failure,
   caml_exn_Undefined_recursive_module,
-  caml_exn_Unhandled;
+  caml_exn_Unhandled,
+  caml_exn_Continuation_in_use;
 
 /* Exception raising */
 

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -49,7 +49,7 @@ extern caml_generated_constant
   caml_exn_Assert_failure,
   caml_exn_Undefined_recursive_module,
   caml_exn_Unhandled,
-  caml_exn_Continuation_in_use;
+  caml_exn_Continuation_already_taken;
 
 /* Exception raising */
 
@@ -177,6 +177,11 @@ void caml_raise_not_found(void)
 void caml_raise_sys_blocked_io(void)
 {
   caml_raise_constant((value) caml_exn_Sys_blocked_io);
+}
+
+void caml_raise_continuation_already_taken(void)
+{
+  caml_raise_constant((value) caml_exn_Continuation_already_taken);
 }
 
 value caml_raise_if_exception(value res)

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -439,7 +439,7 @@ CAMLprim value caml_continuation_use (value cont)
 {
   value v = caml_continuation_use_noexc(cont);
   if (v == Val_ptr(NULL))
-    caml_invalid_argument("continuation already taken");
+    caml_raise_continuation_already_taken();
   return v;
 }
 

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -1289,7 +1289,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
 do_resume: {
       struct stack_info* stk = Ptr_val(accu);
       if (stk == NULL) {
-         accu = Field_imm(caml_read_root(caml_global_data), CONTINUATION_IN_USE_EXN);
+         accu = Field_imm(caml_read_root(caml_global_data), CONTINUATION_ALREADY_TAKEN_EXN);
          goto raise_exception;
       }
       while (Stack_parent(stk) != NULL) stk = Stack_parent(stk);

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -1288,6 +1288,10 @@ value caml_interprete(code_t prog, asize_t prog_size)
 
 do_resume: {
       struct stack_info* stk = Ptr_val(accu);
+      if (stk == NULL) {
+         accu = Field_imm(caml_read_root(caml_global_data), CONTINUATION_IN_USE_EXN);
+         goto raise_exception;
+      }
       while (Stack_parent(stk) != NULL) stk = Stack_parent(stk);
       Stack_parent(stk) = Caml_state->current_stack;
 

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -46,13 +46,13 @@ exception Undefined_recursive_module = Undefined_recursive_module
 (* Effects *)
 
 type ('a, 'b) stack
-external take_cont : ('a, 'b) continuation -> ('a, 'b) stack = "caml_continuation_use"
+external take_cont_noexc : ('a, 'b) continuation -> ('a, 'b) stack = "caml_continuation_use_noexc" [@@noalloc]
 external resume : ('a, 'b) stack -> ('c -> 'a) -> 'c -> 'b = "%resume"
 
 let continue k v =
-  resume (take_cont k) (fun x -> x) v
+  resume (take_cont_noexc k) (fun x -> x) v
 let discontinue k e =
-  resume (take_cont k) (fun e -> raise e) e
+  resume (take_cont_noexc k) (fun e -> raise e) e
 
 external perform : 'a eff -> 'a = "%perform"
 

--- a/testsuite/tests/effects/test8.ml
+++ b/testsuite/tests/effects/test8.ml
@@ -12,7 +12,7 @@ let _ =
         print_endline "intercepting request..";
         continue k (perform E)
   with
-  | Invalid_argument s -> Printf.printf "raised Invalid_argument \"%s\"\n" s
+  | Continuation_in_use -> Printf.printf "raised Continuation_in_use\n"
   | effect E k ->
       let k' = Obj.clone_continuation k in
       continue k "";

--- a/testsuite/tests/effects/test8.ml
+++ b/testsuite/tests/effects/test8.ml
@@ -12,7 +12,7 @@ let _ =
         print_endline "intercepting request..";
         continue k (perform E)
   with
-  | Continuation_in_use -> Printf.printf "raised Continuation_in_use\n"
+  | Continuation_already_taken -> Printf.printf "raised Continuation_already_taken\n"
   | effect E k ->
       let k' = Obj.clone_continuation k in
       continue k "";

--- a/testsuite/tests/effects/test8.reference
+++ b/testsuite/tests/effects/test8.reference
@@ -1,3 +1,3 @@
 intercepting request..
 Hello
-raised Continuation_in_use
+raised Continuation_already_taken

--- a/testsuite/tests/effects/test8.reference
+++ b/testsuite/tests/effects/test8.reference
@@ -1,3 +1,3 @@
 intercepting request..
 Hello
-raised Invalid_argument "continuation already taken"
+raised Continuation_in_use

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -104,6 +104,7 @@ and ident_assert_failure = ident_create "Assert_failure"
 and ident_undefined_recursive_module =
         ident_create "Undefined_recursive_module"
 and ident_unhandled = ident_create "Unhandled"
+and ident_continuation_in_use = ident_create "Continuation_in_use"
 
 let all_predef_exns = [
   ident_match_failure;
@@ -119,6 +120,7 @@ let all_predef_exns = [
   ident_assert_failure;
   ident_undefined_recursive_module;
   ident_unhandled;
+  ident_continuation_in_use;
 ]
 
 let path_match_failure = Pident ident_match_failure
@@ -241,6 +243,7 @@ let common_initial_env add_type add_extension empty_env =
   add_extension ident_undefined_recursive_module
                          [newgenty (Ttuple[type_string; type_int; type_int])] (
   add_extension ident_unhandled [] (
+  add_extension ident_continuation_in_use [] (
   add_type ident_int64 decl_abstr (
   add_type ident_int32 decl_abstr (
   add_type ident_nativeint decl_abstr (
@@ -259,7 +262,7 @@ let common_initial_env add_type add_extension empty_env =
   add_type ident_int decl_abstr_imm (
   add_type ident_extension_constructor decl_abstr (
   add_type ident_floatarray decl_abstr (
-    empty_env)))))))))))))))))))))))))))))))
+    empty_env))))))))))))))))))))))))))))))))
 
 let build_initial_env add_type add_exception empty_env =
   let common = common_initial_env add_type add_exception empty_env in

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -104,7 +104,7 @@ and ident_assert_failure = ident_create "Assert_failure"
 and ident_undefined_recursive_module =
         ident_create "Undefined_recursive_module"
 and ident_unhandled = ident_create "Unhandled"
-and ident_continuation_in_use = ident_create "Continuation_in_use"
+and ident_continuation_already_taken = ident_create "Continuation_already_taken"
 
 let all_predef_exns = [
   ident_match_failure;
@@ -120,7 +120,7 @@ let all_predef_exns = [
   ident_assert_failure;
   ident_undefined_recursive_module;
   ident_unhandled;
-  ident_continuation_in_use;
+  ident_continuation_already_taken;
 ]
 
 let path_match_failure = Pident ident_match_failure
@@ -243,7 +243,7 @@ let common_initial_env add_type add_extension empty_env =
   add_extension ident_undefined_recursive_module
                          [newgenty (Ttuple[type_string; type_int; type_int])] (
   add_extension ident_unhandled [] (
-  add_extension ident_continuation_in_use [] (
+  add_extension ident_continuation_already_taken [] (
   add_type ident_int64 decl_abstr (
   add_type ident_int32 decl_abstr (
   add_type ident_nativeint decl_abstr (


### PR DESCRIPTION
This PR avoids an allocating C `caml_c_call` when using `continue`.

It refactors `caml_continuation_use` to add `caml_continuation_use_noexc` which does not throw an exception. We introduce a new `Continuation_in_use` exception and check for a null stack in `resume`. The upshot is that we no longer need a `caml_c_call` to call `caml_continuation_use_noexc`. 

Performance is incrementally better:
<img width="999" alt="Screenshot 2020-11-13 at 16 09 08" src="https://user-images.githubusercontent.com/1682628/99093688-b974e780-25ca-11eb-80a5-92ec343ee558.png">


