### PR TITLE
Allow C++ to use caml/camlatomic.h

### DIFF
--- a/runtime/caml/camlatomic.h
+++ b/runtime/caml/camlatomic.h
@@ -13,6 +13,10 @@
    the subset of C11 atomics needed by the OCaml runtime
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(HAS_STDATOMIC_H)
 #include <stdatomic.h>
 #define ATOMIC_UINTNAT_INIT(x) (x)
@@ -50,5 +54,8 @@ typedef struct { intnat repr; } atomic_intnat;
 #error "C11 atomics are unavailable on this platform. See camlatomic.h"
 #endif
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CAML_ATOMIC_H */


### PR DESCRIPTION
Failure in `ubpf.0.1`:
```
- (cd _build/default/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -fPIC -std=c++11 -Iubpf_c/ubpf/vm/inc -g -I /home/opam/.opam/4.10.0+multicore+no-effect-syntax/lib/ocaml -I ubpf_c -o ubpf_stubs.o -c ubpf_stubs.cpp)
- In file included from /usr/include/c++/10/memory:85,
-                  from cxx_wrapped.h:37,
-                  from ubpf_stubs.cpp:10:
- /usr/include/c++/10/bits/shared_ptr_atomic.h:76:58: error: macro "atomic_is_lock_free" passed 2 arguments, but takes just 1
-    76 |     atomic_is_lock_free(const __shared_ptr<_Tp, _Lp>* __p)
-       |                                                          ^
- In file included from /home/opam/.opam/4.10.0+multicore+no-effect-syntax/lib/ocaml/caml/camlatomic.h:17,
-                  from /home/opam/.opam/4.10.0+multicore+no-effect-syntax/lib/ocaml/caml/misc.h:33,
-                  from /home/opam/.opam/4.10.0+multicore+no-effect-syntax/lib/ocaml/caml/mlvalues.h:23,
-                  from ubpf_stubs.cpp:4:
- /usr/lib/gcc/x86_64-linux-gnu/10/include/stdatomic.h:96: note: macro "atomic_is_lock_free" defined here
-    96 | #define atomic_is_lock_free(OBJ) __atomic_is_lock_free (sizeof (*(OBJ)), (OBJ))
-       | 
[...]
```