### PR TITLE
Systhread lifecycle rework

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -258,7 +258,9 @@ static void caml_thread_remove_info(caml_thread_t th)
 
   th->next->prev = th->prev;
   th->prev->next = th->next;
-  caml_stat_free(th->current_stack);
+  caml_free_stack(th->current_stack);
+  caml_delete_root(th->backtrace_last_exn);
+  caml_stat_free(th);
   return;
 }
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -293,19 +293,26 @@ static void caml_thread_reinitialize(void)
 }
 
 CAMLprim value caml_thread_initialize(value unit);
+static void caml_thread_initialize_domain();
 
 /* To initialize the thread machinery on a newly created domain. */
 /* FIXME(engil): it may be better to just initialize the machinery for every */
 /* domain at startup */
-
 static void caml_thread_domain_start_hook(void) {
-  caml_thread_initialize(Val_unit);
+  caml_thread_initialize_domain();
 }
 
-CAMLprim value caml_thread_initialize(value unit)   /* ML */
-{
-  CAMLparam0();
+static void caml_thread_domain_stop_hook(void) {
+  // This hook will clean up the initial domain's thread descriptor.
+  // The assumption is that it is the only remaining link in the threading chain
+  // (as every other threads either go through caml_thread_stop or
+  // caml_c_thread_unregister.)
+  caml_stat_free(Current_thread);
+  Current_thread = NULL;
+}
 
+static void caml_thread_initialize_domain()
+{
   caml_thread_t new_thread;
 
   st_masterlock_init(&Thread_main_lock);
@@ -321,23 +328,35 @@ CAMLprim value caml_thread_initialize(value unit)   /* ML */
   new_thread->exit_buf = &caml_termination_jmpbuf;
   #endif
 
-  // Hooks setup, if caml_scan_roots_hook is set, it was done already
-  // by another domain.
-  if (caml_scan_roots_hook != caml_thread_scan_roots) {
-    prev_scan_roots_hook = caml_scan_roots_hook;
-    caml_scan_roots_hook = caml_thread_scan_roots;
-    caml_enter_blocking_section_hook = caml_thread_enter_blocking_section;
-    caml_leave_blocking_section_hook = caml_thread_leave_blocking_section;
-    caml_domain_start_hook = caml_thread_domain_start_hook;
-  };
-
   st_tls_newkey(&Thread_key);
   st_tls_set(Thread_key, (void *) new_thread);
 
   All_threads = new_thread;
   Current_thread = new_thread;
 
+  return;
+}
+
+// This setup function is called as an entrypoint to the Thread module.
+// This will setup the global variables and hooks for systhreads
+// cooperate with the runtime system, after initializing
+// the thread chaining.
+CAMLprim value caml_thread_initialize(value unit)   /* ML */
+{
+  CAMLparam0();
+
+  // We first initialize the thread chaining.
+  caml_thread_initialize_domain();
+
+  prev_scan_roots_hook = caml_scan_roots_hook;
+  caml_scan_roots_hook = caml_thread_scan_roots;
+  caml_enter_blocking_section_hook = caml_thread_enter_blocking_section;
+  caml_leave_blocking_section_hook = caml_thread_leave_blocking_section;
+  caml_domain_start_hook = caml_thread_domain_start_hook;
+  caml_domain_stop_hook = caml_thread_domain_stop_hook;
+
   st_atfork(caml_thread_reinitialize);
+
 
   CAMLreturn(Val_unit);
 }

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -274,6 +274,8 @@ static void caml_thread_reinitialize(void)
   th = Current_thread->next;
   while (th != Current_thread) {
     next = th->next;
+    caml_free_stack(th->current_stack);
+    caml_delete_root(th->backtrace_last_exn);
     caml_stat_free(th);
     th = next;
   }

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -473,7 +473,7 @@ CAMLexport int caml_c_thread_unregister(void)
   st_tls_set(Thread_key, NULL);
   /* Remove thread info block from list of threads, and free it */
   caml_thread_remove_info(th);
-  Current_thread = Current_thread->next;
+  Current_thread = All_threads;
   caml_thread_restore_runtime_state();
   /* Release the runtime */
   st_masterlock_release(&Thread_main_lock);

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -94,6 +94,7 @@ CAMLextern void (*caml_enter_blocking_section_hook)(void);
 CAMLextern void (*caml_leave_blocking_section_hook)(void);
 
 CAMLextern void (*caml_domain_start_hook)(void);
+CAMLextern void (*caml_domain_stop_hook)(void);
 
 void caml_init_domains(uintnat minor_heap_size);
 void caml_init_domain_self(int);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -477,6 +477,11 @@ static void install_backup_thread (dom_internal* di)
   }
 }
 
+static void caml_domain_stop_default(void)
+{
+  return;
+}
+
 static void caml_domain_start_default(void)
 {
   return;
@@ -484,6 +489,9 @@ static void caml_domain_start_default(void)
 
 CAMLexport void (*caml_domain_start_hook)(void) =
    caml_domain_start_default;
+
+CAMLexport void (*caml_domain_stop_hook)(void) =
+   caml_domain_stop_default;
 
 static void domain_terminate();
 
@@ -1225,6 +1233,8 @@ static void domain_terminate()
 
   caml_gc_log("Domain terminating");
   caml_ev_pause(EV_PAUSE_YIELD);
+  // Before wrapping up further, we run the termination hook
+  caml_domain_stop_hook();
   caml_delete_root(domain_state->dls_root);
   s->terminating = 1;
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1233,8 +1233,6 @@ static void domain_terminate()
 
   caml_gc_log("Domain terminating");
   caml_ev_pause(EV_PAUSE_YIELD);
-  // Before wrapping up further, we run the termination hook
-  caml_domain_stop_hook();
   caml_delete_root(domain_state->dls_root);
   s->terminating = 1;
 
@@ -1282,6 +1280,8 @@ static void domain_terminate()
   }
 
   caml_stat_free(domain_state->final_info);
+  // run the domain termination hook
+  caml_domain_stop_hook();
   caml_stat_free(domain_state->ephe_info);
   caml_teardown_major_gc();
   caml_teardown_shared_heap(domain_state->shared_heap);


### PR DESCRIPTION
After investigating something with #433, I triggered a series of bugs with systhreads when forcibly linked with the spawn_burn testcase.
This led me to a goose chase where I ended up having to rethink a bit more clearly the initialization situation for systhreads.
This PR is relatively cleanly split up on a per duty basis, and address the following issues:

- General resource handling and freeing up descriptors and stacks
- Addressing general concerns and bugs in how systhreads is initialized.

This PR also addresses #409, that shouldn't be an issue after this.
I recommend reading the associated commit messages, they contain all the information on what is being changed, and why.
There is one obvious change to the runtime, adding a new hook on domain termination (systhreads already adding a domain startup hook as well.). Reading the commit messages will clear up why, and there may be a better approach but this is my solution so far.
The testsuite now runs fine, and my initial testcase at the root of these issues also passes fine now.
General ecosystems tests did not show any regression. (with dune and softwares known to work with our systhreads implementation.)