### PR TITLE
Fiber stack cache (v2)

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -196,7 +196,7 @@ typedef uint64_t uintnat;
 
 /* Number of words used in the control structure at the start of a stack
    (see fiber.h) */
-#define Stack_ctx_words 4
+#define Stack_ctx_words 5
 
 /* Default maximum size of the stack (words). */
 #define Max_stack_def (1024 * 1024)

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -38,6 +38,7 @@ DOMAIN_STATE(struct c_stack_link*, c_stack)
 /* The C stack associated with this domain. Used by this domain to perform external calls. */
 
 DOMAIN_STATE(struct stack_info**, stack_cache)
+/* This is a list of freelist buckets of stacks */
 
 DOMAIN_STATE(value*, gc_regs_buckets)
 

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -43,6 +43,8 @@ DOMAIN_STATE(value**, gc_regs_slot)
 DOMAIN_STATE(struct c_stack_link*, c_stack)
 /* The C stack associated with this domain. Used by this domain to perform external calls. */
 
+DOMAIN_STATE(struct stack_cache*, stack_cache)
+
 DOMAIN_STATE(struct caml_minor_tables*, minor_tables)
 
 DOMAIN_STATE(struct mark_stack*, mark_stack)

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -43,7 +43,7 @@ DOMAIN_STATE(value**, gc_regs_slot)
 DOMAIN_STATE(struct c_stack_link*, c_stack)
 /* The C stack associated with this domain. Used by this domain to perform external calls. */
 
-DOMAIN_STATE(struct stack_cache*, stack_cache)
+DOMAIN_STATE(struct stack_info**, stack_cache)
 
 DOMAIN_STATE(struct caml_minor_tables*, minor_tables)
 

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -34,16 +34,16 @@ DOMAIN_STATE(struct stack_info*, current_stack)
 DOMAIN_STATE(void*, exn_handler)
 /* Pointer into into the current stack */
 
+DOMAIN_STATE(struct c_stack_link*, c_stack)
+/* The C stack associated with this domain. Used by this domain to perform external calls. */
+
+DOMAIN_STATE(struct stack_info**, stack_cache)
+
 DOMAIN_STATE(value*, gc_regs_buckets)
 
 DOMAIN_STATE(value*, gc_regs)
 
 DOMAIN_STATE(value**, gc_regs_slot)
-
-DOMAIN_STATE(struct c_stack_link*, c_stack)
-/* The C stack associated with this domain. Used by this domain to perform external calls. */
-
-DOMAIN_STATE(struct stack_info**, stack_cache)
 
 DOMAIN_STATE(struct caml_minor_tables*, minor_tables)
 

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -76,17 +76,13 @@ struct c_stack_link {
 
 #define NUM_STACK_SIZE_CLASSES 5
 
-struct stack_cache {
-  struct stack_info* pool[NUM_STACK_SIZE_CLASSES];
-};
-
 /* The table of global identifiers */
 extern caml_root caml_global_data;
 
 #define Trap_pc(tp) ((tp)[0])
 #define Trap_link(tp) ((tp)[1])
 
-struct stack_cache* caml_init_stack_cache (void);
+struct stack_info** caml_alloc_stack_cache (void);
 struct stack_info* caml_alloc_main_stack (uintnat init_size);
 void caml_scan_stack(scanning_action f, void* fdata, struct stack_info* stack, value* v_gc_regs);
 /* try to grow the stack until at least required_size words are available.

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -27,13 +27,13 @@ struct stack_info {
 #endif
   struct stack_handler* handler;
 
-  /* [size_class] is a multiple of [caml_fiber_wsz] if pooled. If unpooled, it
-   * is [-1].
+  /* [size_bucket] is a pointer to a bucket in Caml->stack_cache if this
+   * size is pooled. If unpooled, it is NULL.
    *
-   * Stacks may be unpooled if either the stack size is not a multiple of
+   * Stacks may be unpooled if either the stack size is not 2**N multiple of
    * [caml_fiber_wsz] (may be the case in debug mode) or the stack is bigger
    * than pooled sizes. */
-  intnat size_class;
+  struct stack_info** size_bucket;
   uintnat magic;
 };
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -274,15 +274,19 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
       goto reallocate_minor_heap_failure;
     }
 
-    Caml_state->current_stack =
+    domain_state->current_stack =
         caml_alloc_main_stack(Stack_size / sizeof(value));
-    if(Caml_state->current_stack == NULL) {
+    if(domain_state->current_stack == NULL) {
       goto alloc_main_stack_failure;
     }
 
     domain_state->dls_root = caml_create_root_noexc(Val_unit);
-    if(Caml_state->dls_root == NULL) {
+    if(domain_state->dls_root == NULL) {
       goto create_root_failure;
+    }
+    domain_state->stack_cache = caml_init_stack_cache();
+    if(Caml_state->stack_cache == NULL) {
+      goto create_stack_cache_failure;
     }
 
     domain_state->backtrace_buffer = NULL;
@@ -292,8 +296,10 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
 #endif
     goto domain_init_complete;
 
+create_stack_cache_failure:
+  caml_delete_root(domain_state->dls_root);
 create_root_failure:
-  caml_free_stack(Caml_state->current_stack);
+  caml_free_stack(domain_state->current_stack);
 alloc_main_stack_failure:
 reallocate_minor_heap_failure:
   caml_teardown_major_gc();

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -274,19 +274,20 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
       goto reallocate_minor_heap_failure;
     }
 
-    domain_state->current_stack =
-        caml_alloc_main_stack(Stack_size / sizeof(value));
-    if(domain_state->current_stack == NULL) {
-      goto alloc_main_stack_failure;
-    }
-
     domain_state->dls_root = caml_create_root_noexc(Val_unit);
     if(domain_state->dls_root == NULL) {
       goto create_root_failure;
     }
+
     domain_state->stack_cache = caml_alloc_stack_cache();
     if(domain_state->stack_cache == NULL) {
       goto create_stack_cache_failure;
+    }
+
+    domain_state->current_stack =
+        caml_alloc_main_stack(Stack_size / sizeof(value));
+    if(domain_state->current_stack == NULL) {
+      goto alloc_main_stack_failure;
     }
 
     domain_state->backtrace_buffer = NULL;
@@ -296,11 +297,11 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
 #endif
     goto domain_init_complete;
 
+  caml_free_stack(domain_state->current_stack);
+alloc_main_stack_failure:
 create_stack_cache_failure:
   caml_delete_root(domain_state->dls_root);
 create_root_failure:
-  caml_free_stack(domain_state->current_stack);
-alloc_main_stack_failure:
 reallocate_minor_heap_failure:
   caml_teardown_major_gc();
 init_major_gc_failure:

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -284,8 +284,8 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
     if(domain_state->dls_root == NULL) {
       goto create_root_failure;
     }
-    domain_state->stack_cache = caml_init_stack_cache();
-    if(Caml_state->stack_cache == NULL) {
+    domain_state->stack_cache = caml_alloc_stack_cache();
+    if(domain_state->stack_cache == NULL) {
       goto create_stack_cache_failure;
     }
 

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -75,7 +75,7 @@ static struct stack_info* alloc_size_class_stack_noexc(mlsize_t wosize, intnat s
   if (size_class >= 0 && Caml_state->stack_cache[size_class] != NULL) {
     stack = Caml_state->stack_cache[size_class];
     CAMLassert(stack->size_class == size_class);
-    Caml_state->stack_cache[size_class] = stack->handler->parent;
+    Caml_state->stack_cache[size_class] = (struct stack_info*)stack->exception_ptr;
     hand = stack->handler;
   } else {
     /* couldn't get a cached stack, so have to create one */
@@ -422,7 +422,7 @@ void caml_free_stack (struct stack_info* stack)
   memset(stack, 0x42, (char*)stack->handler - (char*)stack);
 #endif
   if (stack->size_class != -1) {
-    stack->handler->parent = Caml_state->stack_cache[stack->size_class];
+    stack->exception_ptr = (void*)Caml_state->stack_cache[stack->size_class];
     Caml_state->stack_cache[stack->size_class] = stack;
   } else {
     caml_stat_free(stack);

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -74,8 +74,8 @@ static struct stack_info* alloc_size_class_stack_noexc(mlsize_t wosize, struct s
 
   if (size_bucket != NULL && *size_bucket != NULL) {
     stack = *size_bucket;
-    CAMLassert(stack->size_bucket == stack_cache_bucket(wosize));
     *size_bucket = (struct stack_info*)stack->exception_ptr;
+    CAMLassert(stack->size_bucket == stack_cache_bucket(wosize));
     hand = stack->handler;
   } else {
     /* couldn't get a cached stack, so have to create one */
@@ -418,13 +418,16 @@ void caml_free_stack (struct stack_info* stack)
 {
   CAMLnoalloc;
   CAMLassert(stack->magic == 42);
-#ifdef DEBUG
-  memset(stack, 0x42, (char*)stack->handler - (char*)stack);
-#endif
   if (stack->size_bucket != NULL) {
     stack->exception_ptr = (void*)(*stack->size_bucket);
     *stack->size_bucket = stack;
+#ifdef DEBUG
+    memset(Stack_base(stack), 0x42, (Stack_high(stack)-Stack_base(stack))*sizeof(value));
+#endif
   } else {
+#ifdef DEBUG
+    memset(stack, 0x42, (char*)stack->handler - (char*)stack);
+#endif
     caml_stat_free(stack);
   }
 }

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -74,18 +74,13 @@ static struct stack_info* alloc_stack_noexc(mlsize_t wosize, value hval, value h
   CAML_STATIC_ASSERT(sizeof(struct stack_handler) % sizeof(value) == 0);
 
   size_class = stack_size_class (wosize);
-  if (size_class >= 0) {
-    if (Caml_state->stack_cache[size_class] == NULL) {
-      stack = alloc_for_stack(wosize);
-      stack->size_class = size_class;
-    } else {
-      stack = Caml_state->stack_cache[size_class];
-      CAMLassert(stack->size_class == size_class);
-      Caml_state->stack_cache[size_class] = stack->handler->parent;
-    }
+  if (size_class >= 0 && Caml_state->stack_cache[size_class] != NULL) {
+    stack = Caml_state->stack_cache[size_class];
+    CAMLassert(stack->size_class == size_class);
+    Caml_state->stack_cache[size_class] = stack->handler->parent;
   } else {
     stack = alloc_for_stack(wosize);
-    stack->size_class = -1;
+    stack->size_class = size_class;
   }
   if (stack == NULL) {
     return NULL;

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -51,14 +51,15 @@ static inline struct stack_info* alloc_for_stack (mlsize_t wosize)
 static inline intnat stack_size_class (mlsize_t wosize)
 {
   intnat size_class = 0;
+  mlsize_t size_class_wsz = caml_fiber_wsz;
 
-  if (wosize % caml_fiber_wsz != 0)
-    return -1;
-  wosize = wosize / caml_fiber_wsz;
+  /* wosize is size_class N iff wosize == caml_fiber_wsz * 2**N */
   do {
-    if ((wosize = wosize >> 1) == 0)
+    if (wosize == size_class_wsz)
       return size_class;
-  } while(size_class++ < NUM_STACK_SIZE_CLASSES);
+    ++size_class;
+    size_class_wsz += size_class_wsz;
+  } while (size_class < NUM_STACK_SIZE_CLASSES);
 
   return -1;
 }


### PR DESCRIPTION
This PR adds stack caching for fiber stacks, it builds on #420.

Compared with #420 this implementation:
 - avoids indirections out of `struct stack_info` when managing the stack cache
 - more efficiently calculates the cache freelist bucket for a given stack size (avoiding calculation completely when allocating a fresh stack)
 - only initializes what it needs when it takes things out of the cache to return the stack
 - fixes up a bunch of bugs in the testsuite (DEBUG memset, order of initialization)