### PR TITLE
Collect GC stats at the end of minor collection and remove double buffering of gc sampled stats.

### DIFF
--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -85,6 +85,7 @@ struct gc_stats {
   struct heap_stats major_heap;
 };
 void caml_sample_gc_stats(struct gc_stats* buf);
+void caml_sample_gc_collect(caml_domain_state *domain);
 
 /* Forces finalisation of all heap-allocated values,
    disregarding both local and global roots.

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1270,6 +1270,7 @@ static void domain_terminate()
     }
     caml_plat_unlock(&s->lock);
   }
+  caml_sample_gc_collect(domain_state);
 
   caml_stat_free(domain_state->final_info);
   caml_stat_free(domain_state->ephe_info);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -780,12 +780,7 @@ intnat ephe_sweep (struct domain* d, intnat budget)
   return budget;
 }
 
-/* double-buffered sampled GC stats.
-   At the end of GC cycle N, domains update sampled_gc_stats[N&1],
-   but requests to Gc.stats() read from sampled_gc_stats[!(N&1)].
-   That way, Gc.stats() returns the statistics atomically sampled
-   at the end of the most recently completed GC cycle */
-static struct gc_stats sampled_gc_stats[2][Max_domains];
+static struct gc_stats sampled_gc_stats[Max_domains];
 
 void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
 {
@@ -818,14 +813,13 @@ void caml_sample_gc_stats(struct gc_stats* buf)
   /* we read from the buffers that are not currently being
      written to. that way, we pick up the numbers written
      at the end of the most recently completed GC cycle */
-  int phase = ! (caml_major_cycles_completed & 1);
   int i;
   intnat pool_max = 0, large_max = 0;
   struct domain* domain_self = caml_domain_self ();
   int my_id = domain_self->state->id;
 
   for (i=0; i<Max_domains; i++) {
-    struct gc_stats* s = &sampled_gc_stats[phase][i];
+    struct gc_stats* s = &sampled_gc_stats[i];
     struct heap_stats* h = &s->major_heap;
     if (i != my_id) {
       buf->minor_words += s->minor_words;
@@ -857,8 +851,7 @@ void caml_sample_gc_stats(struct gc_stats* buf)
 /* update GC stats for this given domain */
 inline void caml_sample_gc_collect(caml_domain_state* domain)
 {
-  int stats_phase = caml_major_cycles_completed & 1;
-  struct gc_stats* stats = &sampled_gc_stats[stats_phase][domain->id];
+  struct gc_stats* stats = &sampled_gc_stats[domain->id];
 
   stats->minor_words = domain->stat_minor_words;
   stats->promoted_words = domain->stat_promoted_words;
@@ -884,8 +877,6 @@ static void cycle_all_domains_callback(struct domain* domain, void* unused,
   caml_empty_minor_heap_no_major_slice_from_stw(domain, (void*)0, participating_count, participating);
 
   caml_ev_begin("major_gc/stw");
-
-  caml_sample_gc_collect(domain->state);
 
   {
     /* Cycle major heap */

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -810,9 +810,6 @@ void caml_remove_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
 void caml_sample_gc_stats(struct gc_stats* buf)
 {
   memset(buf, 0, sizeof(*buf));
-  /* we read from the buffers that are not currently being
-     written to. that way, we pick up the numbers written
-     at the end of the most recently completed GC cycle */
   int i;
   intnat pool_max = 0, large_max = 0;
   struct domain* domain_self = caml_domain_self ();

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -725,6 +725,9 @@ static void caml_stw_empty_minor_heap_no_major_slice (struct domain* domain, voi
   caml_gc_log("running stw empty_minor_heap_promote");
   caml_empty_minor_heap_promote(domain, participating_count, participating, not_alone);
 
+  /* collect gc stats before leaving the barrier */
+  caml_sample_gc_collect(domain->state);
+
   if( not_alone ) {
     caml_ev_begin("minor_gc/leave_barrier");
     SPIN_WAIT {


### PR DESCRIPTION
This PR is an extension of #433.
The target is to remove the use of double buffering in GC stats collection, leveraging on the barrier present during minor collection in the parallel_minor_gc schema.
Double buffering could cause inconsistencies in stats, depending the cycle on which a program ends. (when using `OCAMLRUNPARAM=v=0x400`)
I tried went through reading the stat collection process and remap how it would behave with this patch and it seems like a much consistent setup. (@ctk21 maybe could spot more potential inconsistencies.)

I ran the sequential bench suite on it, here's the time result, normalize against stock OCaml.

![sequential_minor_gc_sample_normalize_stock_time](https://user-images.githubusercontent.com/146049/100462801-14c6cf80-30cb-11eb-9cea-ffa47d1eaf95.png)

I don't see any significant slowdown (noise, at best), I have some parallel results as well that do not show any further slowdown. 

Edit: the graph I showed was the wrong one, I updated it.