### PR TITLE
Fix stdatomic.h when used inside C++ for good

### DIFF
--- a/runtime/caml/camlatomic.h
+++ b/runtime/caml/camlatomic.h
@@ -14,14 +14,22 @@
  */
 
 #ifdef __cplusplus
-extern "C" {
-#endif
 
-#if defined(HAS_STDATOMIC_H)
+extern "C++" {
+#include <atomic>
+using namespace std;
+#define ATOMIC_UINTNAT_INIT(x) (x)
+typedef atomic<uintnat> atomic_uintnat;
+typedef atomic<intnat> atomic_intnat;
+}
+
+#elif defined(HAS_STDATOMIC_H)
+
 #include <stdatomic.h>
 #define ATOMIC_UINTNAT_INIT(x) (x)
 typedef _Atomic uintnat atomic_uintnat;
 typedef _Atomic intnat atomic_intnat;
+
 #elif defined(__GNUC__)
 
 /* Support for versions of gcc which have built-in atomics but do not
@@ -52,10 +60,6 @@ typedef struct { intnat repr; } atomic_intnat;
 
 #else
 #error "C11 atomics are unavailable on this platform. See camlatomic.h"
-#endif
-
-#ifdef __cplusplus
-}
 #endif
 
 #endif /* CAML_ATOMIC_H */


### PR DESCRIPTION
stdatomic.h is not compatible when included in C++ code. To fix this issue the atomic header has to be used instead, the two interfaces should be moderatly compatible. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60932 for more details. extern "C++" is here to prevent extern "C" used in user code to take over and invalidates the definitions inside the atomic header.

cc @dra27 do you think there would be any issue on Windows?

This fixes build failures for at least `upbf.0.1` and `libsvm.0.10.0` but I'm guessing this unlocks a substantial number of other projects too.