### PR TITLE
Respect ASM_CFI_SUPPORTED flag in amd64

### DIFF
--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -191,7 +191,7 @@
 /* Load Caml_state->exn_handler into %rsp and restores prior exn_handler. Clobbers %r10 and %r11. */
 #define RESTORE_EXN_HANDLER_OCAML \
         movq    Caml_state(exn_handler), %rsp; \
-        CFI_DEF_CFA_OFFSET(16) \
+        CFI_DEF_CFA_OFFSET(16); \
         POP_EXN_HANDLER
 
 /* Switch between OCaml stacks. Clobbers %r12.
@@ -205,7 +205,7 @@
     /* switch stacks */ \
         movq    %r10, Caml_state(current_stack); \
         movq    Stack_sp(%r10), %rsp; \
-        CFI_DEF_CFA_OFFSET(8) \
+        CFI_DEF_CFA_OFFSET(8); \
     /* restore exn_handler for new stack */ \
         movq    Stack_exception(%r10), %r12; \
         movq    %r12, Caml_state(exn_handler)

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -86,13 +86,24 @@
 #define CFI_ENDPROC .cfi_endproc
 #define CFI_ADJUST(n) .cfi_adjust_cfa_offset n
 #define CFI_OFFSET(r, n) .cfi_offset r, n
+#define CFI_DEF_CFA_OFFSET(n) .cfi_def_cfa_offset n
+#define CFI_DEF_CFA_REGISTER(r) .cfi_def_cfa_register r
 #define CFI_SAME_VALUE(r) .cfi_same_value r
+#define CFI_SIGNAL_FRAME .cfi_signal_frame
+#define CFI_REMEMBER_STATE .cfi_remember_state
+#define CFI_RESTORE_STATE .cfi_restore_state
 #else
 #define CFI_STARTPROC
 #define CFI_ENDPROC
 #define CFI_ADJUST(n)
 #define CFI_OFFSET(r, n)
+#define CFI_DEF_CFA_OFFSET(n)
+#define CFI_DEF_CFA_REGISTER(r)
 #define CFI_SAME_VALUE(r)
+#define CFI_SIGNAL_FRAME
+#define CFI_REMEMBER_STATE
+#define CFI_RESTORE_STATE
+
 #endif
 
 #ifdef DEBUG
@@ -146,6 +157,15 @@
 /* Switch from OCaml to C stack. Clobbers %r10, %r11.
  * PUSHED is the number of bytes already pushed by this function.
  * It is used to compute the backtrace. */
+#ifdef ASM_CFI_SUPPORTED
+#define SWITCH_OCAML_TO_C_NO_CTXT_CFI(PUSHED) \
+        CFI_REMEMBER_STATE;                                \
+        .cfi_escape DW_CFA_def_cfa_expression, 5,          \
+          DW_OP_breg + DW_REG_rsp, Cstack_sp, DW_OP_deref, \
+          DW_OP_plus_uconst, (PUSHED) + 8 /* retaddr */
+#else
+#define SWITCH_OCAML_TO_C_NO_CTXT_CFI(PUSHED)
+#endif
 #define SWITCH_OCAML_TO_C_NO_CTXT(PUSHED)                  \
     /* Fill in Caml_state->current_stack->sp */            \
         movq    Caml_state(current_stack), %r10;           \
@@ -156,10 +176,7 @@
         movq    %r10, Cstack_stack(%r11);                  \
     /* Switch to C stack */                                \
         movq    %r11, %rsp;                                \
-        .cfi_remember_state;                               \
-        .cfi_escape DW_CFA_def_cfa_expression, 5,          \
-          DW_OP_breg + DW_REG_rsp, Cstack_sp, DW_OP_deref, \
-          DW_OP_plus_uconst, (PUSHED) + 8 /* retaddr */
+        SWITCH_OCAML_TO_C_NO_CTXT_CFI(PUSHED)
 
 /* Switch from C to OCaml stack.  Clobbers %r11. */
 #define SWITCH_C_TO_OCAML_NO_CTXT \
@@ -169,12 +186,12 @@
                  movq Caml_state(current_stack), %r11; movq Stack_sp(%r11), %r11; \
                  cmpq %r11, Cstack_sp(%rsp); je 8f; int3; 8:) \
         movq    Cstack_sp(%rsp), %rsp; \
-        .cfi_restore_state
+        CFI_RESTORE_STATE
 
 /* Load Caml_state->exn_handler into %rsp and restores prior exn_handler. Clobbers %r10 and %r11. */
 #define RESTORE_EXN_HANDLER_OCAML \
         movq    Caml_state(exn_handler), %rsp; \
-        .cfi_def_cfa_offset 16; \
+        CFI_DEF_CFA_OFFSET(16) \
         POP_EXN_HANDLER
 
 /* Switch between OCaml stacks. Clobbers %r12.
@@ -188,7 +205,7 @@
     /* switch stacks */ \
         movq    %r10, Caml_state(current_stack); \
         movq    Stack_sp(%r10), %rsp; \
-        .cfi_def_cfa_offset 8; \
+        CFI_DEF_CFA_OFFSET(8) \
     /* restore exn_handler for new stack */ \
         movq    Stack_exception(%r10), %r12; \
         movq    %r12, Caml_state(exn_handler)
@@ -447,7 +464,7 @@ G(caml_system__code_begin):
 
 FUNCTION(G(caml_call_realloc_stack))
 CFI_STARTPROC
-        .cfi_signal_frame
+        CFI_SIGNAL_FRAME
         SAVE_ALL_REGS
         movq    8(%rsp), C_ARG_1 /* argument */
         SWITCH_OCAML_TO_C_NO_CTXT(0)
@@ -536,7 +553,7 @@ ENDFUNCTION(G(caml_alloc3))
 
 FUNCTION(G(caml_allocN))
 CFI_STARTPROC
-        .cfi_signal_frame
+        CFI_SIGNAL_FRAME
 LBL(caml_allocN):
         subq    %rax, %r15
         cmpq    Caml_state(young_limit), %r15
@@ -575,7 +592,7 @@ ENDFUNCTION(G(caml_call_poll))
 
 FUNCTION(G(caml_c_call))
 CFI_STARTPROC
-        .cfi_signal_frame
+        CFI_SIGNAL_FRAME
 LBL(caml_c_call):
     /* Arguments:
         C arguments         : %rdi, %rsi, %rdx, %rcx, %r8, and %r9
@@ -597,7 +614,7 @@ ENDFUNCTION(G(caml_c_call))
 
 FUNCTION(G(caml_c_call_stack_args))
 CFI_STARTPROC
-        .cfi_signal_frame
+        CFI_SIGNAL_FRAME
     /* Arguments:
         C arguments         : %rdi, %rsi, %rdx, %rcx, %r8, and %r9
         C function          : %rax
@@ -606,9 +623,11 @@ CFI_STARTPROC
         SWITCH_OCAML_TO_C_NO_CTXT(0)
     /* we use %rbp (otherwise unused) to enable backtraces */
         movq    %rsp, %rbp
+#ifdef ASM_CFI_SUPPORTED
         .cfi_escape DW_CFA_def_cfa_expression, 5, \
           DW_OP_breg + DW_REG_rbp, Cstack_sp, DW_OP_deref, \
           DW_OP_plus_uconst,  8 /* ret addr */
+#endif
     /* Make the alloc ptr available to the C code */
         movq    %r15, Caml_state(young_ptr)
     /* Copy arguments from OCaml to C stack */
@@ -638,7 +657,7 @@ ENDFUNCTION(G(caml_c_call_stack_args))
 
 FUNCTION(G(caml_start_program))
 CFI_STARTPROC
-        .cfi_signal_frame
+        CFI_SIGNAL_FRAME
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
     /* Load Caml_state into r14 (was passed as an argument from C) */
@@ -680,11 +699,13 @@ LBL(caml_start_program):
         movq    %r10, Caml_state(exn_handler)
     /* Switch stacks and call the OCaml code */
         movq    %r10, %rsp
-        .cfi_remember_state
+#ifdef ASM_CFI_SUPPORTED
+        CFI_REMEMBER_STATE
         .cfi_escape DW_CFA_def_cfa_expression, 3 + 2, \
           DW_OP_breg + DW_REG_rsp, 16, DW_OP_deref,\
           DW_OP_plus_uconst, \
              24 /* struct c_stack_link */ + 6*8 /* callee save regs */ + 8 /* ret addr */
+#endif
         call    *%r12
 LBL(108):
     /* pop exn handler */
@@ -701,7 +722,7 @@ LBL(108):
         movq    Caml_state(current_stack), %r11
         movq    %r10, Stack_sp(%r11)
         movq    Caml_state(c_stack), %rsp
-        .cfi_restore_state
+        CFI_RESTORE_STATE
     /* Pop the struct c_stack_link */
         movq    Cstack_prev(%rsp), %r10
         movq    %r10, Caml_state(c_stack)
@@ -901,7 +922,7 @@ ENDFUNCTION(G(caml_resume))
    then invoke either the value or exception handler */
 FUNCTION(G(caml_runstack))
 CFI_STARTPROC
-        .cfi_signal_frame
+        CFI_SIGNAL_FRAME
     /* %rax -> stack, %rbx -> fun, %rdi -> arg */
         andq    $-2, %rax       /* %rax = Ptr_val(%rax) */
     /* save old stack pointer and exception handler */
@@ -925,11 +946,13 @@ CFI_STARTPROC
         movq    %r11, Caml_state(exn_handler)
     /* Switch to the new stack */
         movq    %r11, %rsp
-        .cfi_remember_state
+#ifdef ASM_CFI_SUPPORTED
+        CFI_REMEMBER_STATE
         .cfi_escape DW_CFA_def_cfa_expression, 3+3+2, \
           DW_OP_breg + DW_REG_rsp, 32 /* exn */ + Handler_parent, DW_OP_deref,\
           DW_OP_plus_uconst, Stack_sp, DW_OP_deref,\
           DW_OP_plus_uconst, 8 /* ret addr */
+#endif
         movq    %rdi, %rax /* first argument */
         callq   *(%rbx) /* closure in %rbx (second argument) */
 LBL(frame_runstack):
@@ -943,15 +966,15 @@ LBL(frame_runstack):
         movq    %r11, Caml_state(exn_handler)
     /* free old stack by switching directly to c_stack; is a no-alloc call */
         movq    Stack_sp(%r10), %r13 /* saved across C call */
-        .cfi_restore_state
-        .cfi_remember_state
-        .cfi_def_cfa_register DW_REG_r13
+        CFI_RESTORE_STATE
+        CFI_REMEMBER_STATE
+        CFI_DEF_CFA_REGISTER(DW_REG_r13)
         movq    %rax, %r12 /* save %rax across C call */
         movq    Caml_state(c_stack), %rsp
         call    GCALL(caml_free_stack)
     /* switch directly to parent stack with correct return */
         movq    %r13, %rsp
-        .cfi_restore_state
+        CFI_RESTORE_STATE
         movq    %r12, %rax
 
     /* Invoke handle_value (or handle_exn) */


### PR DESCRIPTION
This PR makes sure that all the CFI directives in amd64 are correctly guarded by `ASM_CFI_SUPPORTED`. This makes `--disable-cfi` work. 

Fixes #452.