### PR TITLE
Replace caml_root API with global roots

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -64,7 +64,7 @@ struct caml_thread_struct {
   struct longjmp_buffer *exit_buf;
   int backtrace_pos;
   code_t * backtrace_buffer;
-  caml_root backtrace_last_exn;
+  value backtrace_last_exn;
   value * gc_regs;
   value * gc_regs_buckets;
   value ** gc_regs_slot;
@@ -217,7 +217,8 @@ static caml_thread_t caml_thread_new_info(void)
   th->exit_buf = NULL;
   th->backtrace_pos = 0;
   th->backtrace_buffer = NULL;
-  th->backtrace_last_exn = caml_create_root(Val_unit);
+  th->backtrace_last_exn = Val_unit;
+  caml_register_global_root(&th->backtrace_last_exn);
   th->domain_id = d->state->id;
 
   #ifndef NATIVE_CODE
@@ -259,7 +260,7 @@ static void caml_thread_remove_info(caml_thread_t th)
   th->next->prev = th->prev;
   th->prev->next = th->next;
   caml_free_stack(th->current_stack);
-  caml_delete_root(th->backtrace_last_exn);
+  caml_remove_global_root(&th->backtrace_last_exn);
   caml_stat_free(th);
   return;
 }
@@ -275,7 +276,7 @@ static void caml_thread_reinitialize(void)
   while (th != Current_thread) {
     next = th->next;
     caml_free_stack(th->current_stack);
-    caml_delete_root(th->backtrace_last_exn);
+    caml_remove_global_root(&th->backtrace_last_exn);
     caml_stat_free(th);
     th = next;
   }

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -42,10 +42,11 @@ CAMLprim value caml_record_backtrace(value vflag)
     Caml_state->backtrace_active = flag;
     Caml_state->backtrace_pos = 0;
     if (flag) {
-      Caml_state->backtrace_last_exn = caml_create_root(Val_unit);
+      Caml_state->backtrace_last_exn = Val_unit;
+      caml_register_global_root(&Caml_state->backtrace_last_exn);
     } else {
-      caml_delete_root(Caml_state->backtrace_last_exn);
-      Caml_state->backtrace_last_exn = NULL;
+      caml_remove_global_root(&Caml_state->backtrace_last_exn);
+      // Caml_state->backtrace_last_exn = NULL;
     }
   }
   return Val_unit;
@@ -173,8 +174,8 @@ CAMLprim value caml_restore_raw_backtrace(value exn, value backtrace)
 
   caml_domain_state* domain_state = Caml_state;
 
-  if (domain_state->backtrace_last_exn != NULL)
-    caml_modify_root (domain_state->backtrace_last_exn, exn);
+  // if (domain_state->backtrace_last_exn != NULL)
+  domain_state->backtrace_last_exn = exn;
 
   bt_size = Wosize_val(backtrace);
   if(bt_size > BACKTRACE_BUFFER_SIZE){

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -235,9 +235,9 @@ int caml_alloc_backtrace_buffer(void){
 
 void caml_stash_backtrace(value exn, value * sp, int reraise)
 {
-  if (exn != caml_read_root(Caml_state->backtrace_last_exn) || !reraise) {
+  if (exn != Caml_state->backtrace_last_exn || !reraise) {
     Caml_state->backtrace_pos = 0;
-    caml_modify_root(Caml_state->backtrace_last_exn, exn);
+    caml_modify_generational_global_root(&Caml_state->backtrace_last_exn, exn);
   }
 
   if (Caml_state->backtrace_buffer == NULL &&

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -79,9 +79,9 @@ void caml_stash_backtrace(value exn, uintnat pc, char * sp, char* trapsp)
   caml_domain_state* domain_state = Caml_state;
   caml_frame_descrs fds;
 
-  if (exn != caml_read_root(domain_state->backtrace_last_exn)) {
+  if (exn != domain_state->backtrace_last_exn) {
     domain_state->backtrace_pos = 0;
-    caml_modify_root(domain_state->backtrace_last_exn, exn);
+    domain_state->backtrace_last_exn = exn;
   }
 
   if (Caml_state->backtrace_buffer == NULL &&

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -260,7 +260,7 @@ CAMLexport value caml_callbackN (value closure, int narg, value args[])
 /* Naming of OCaml values */
 
 struct named_value {
-  caml_root val;
+  value val;
   struct named_value * next;
   char name[1];
 };
@@ -292,7 +292,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
   caml_plat_lock(&named_value_lock);
   for (nv = named_value_table[h]; nv != NULL; nv = nv->next) {
     if (strcmp(name, nv->name) == 0) {
-      caml_modify_root(nv->val, val);
+      caml_modify_generational_global_root(&nv->val, val);
       found = 1;
       break;
     }
@@ -301,7 +301,8 @@ CAMLprim value caml_register_named_value(value vname, value val)
     nv = (struct named_value *)
       caml_stat_alloc(sizeof(struct named_value) + namelen);
     memcpy(nv->name, name, namelen + 1);
-    nv->val = caml_create_root(val);
+    nv->val = val;
+    caml_register_generational_global_root(&nv->val);
     nv->next = named_value_table[h];
     named_value_table[h] = nv;
   }
@@ -312,18 +313,17 @@ CAMLprim value caml_register_named_value(value vname, value val)
 CAMLexport const value* caml_named_value(char const *name)
 {
   struct named_value * nv;
-  caml_root ret = NULL;
   caml_plat_lock(&named_value_lock);
   for (nv = named_value_table[hash_value_name(name)];
        nv != NULL;
        nv = nv->next) {
     if (strcmp(name, nv->name) == 0){
-      ret = nv->val;
-      break;
+      caml_plat_unlock(&named_value_lock);
+      return &nv->val;
     }
   }
   caml_plat_unlock(&named_value_lock);
-  return Op_val(ret);
+  return NULL;
 }
 
 CAMLexport int caml_get_callback_depth ()

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -84,7 +84,7 @@ DOMAIN_STATE(intnat, backtrace_active)
 
 DOMAIN_STATE(code_t*, backtrace_buffer)
 
-DOMAIN_STATE(caml_root, backtrace_last_exn)
+DOMAIN_STATE(value, backtrace_last_exn)
 
 DOMAIN_STATE(intnat, compare_unordered)
 

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -113,7 +113,7 @@ DOMAIN_STATE(struct pool**, pools_to_rescan)
 DOMAIN_STATE(int, pools_to_rescan_len)
 DOMAIN_STATE(int, pools_to_rescan_count)
 
-DOMAIN_STATE(caml_root, dls_root)
+DOMAIN_STATE(value, dls_root)
 
 /*****************************************************************************/
 /* GC stats (see gc_ctrl.c and the Gc module) */

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -77,7 +77,7 @@ struct c_stack_link {
 #define NUM_STACK_SIZE_CLASSES 5
 
 /* The table of global identifiers */
-extern caml_root caml_global_data;
+extern value caml_global_data;
 
 #define Trap_pc(tp) ((tp)[0])
 #define Trap_link(tp) ((tp)[1])

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -33,7 +33,7 @@
 int caml_debugger_in_use = 0;
 uintnat caml_event_count;
 int caml_debugger_fork_mode = 1; /* parent by default */
-caml_root marshal_flags;
+value marshal_flags;
 
 #if !defined(HAS_SOCKETS) || defined(NATIVE_CODE)
 
@@ -181,7 +181,8 @@ void caml_debugger_init(void)
   flags = caml_alloc(2, Tag_cons);
   Store_field(flags, 0, Val_int(1)); /* Marshal.Closures */
   Store_field(flags, 1, Val_emptylist);
-  marshal_flags = caml_create_root(flags);
+  marshal_flags = flags;
+  caml_register_generational_global_root(&marshal_flags);
 
   a = caml_secure_getenv(T("CAML_DEBUG_SOCKET"));
   address = a ? caml_stat_strdup_of_os(a) : NULL;
@@ -266,7 +267,7 @@ static void safe_output_value(struct channel *chan, value val)
   saved_external_raise = Caml_state->external_raise;
   if (sigsetjmp(raise_buf.buf, 0) == 0) {
     Caml_state->external_raise = &exception_ctx;
-    caml_output_val(chan, val, caml_read_root(marshal_flags));
+    caml_output_val(chan, val, marshal_flags);
   } else {
     /* Send wrong magic number, will cause [caml_input_value] to fail */
     caml_really_putblock(chan, "\000\000\000\000", 4);

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -538,7 +538,7 @@ void caml_debugger(enum event_kind event, value param)
       break;
     case REQ_GET_GLOBAL:
       i = caml_getword(dbg_in);
-      putval(dbg_out, Field_imm(caml_read_root(caml_global_data), i));
+      putval(dbg_out, Field_imm(caml_global_data, i));
       caml_flush(dbg_out);
       break;
     case REQ_GET_ACCU:

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -276,9 +276,6 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
 
     domain_state->dls_root = Val_unit;
     caml_register_generational_global_root(&domain_state->dls_root);
-    if(&domain_state->dls_root == NULL) {
-      goto create_root_failure;
-    }
 
     domain_state->stack_cache = caml_alloc_stack_cache();
     if(domain_state->stack_cache == NULL) {
@@ -302,7 +299,6 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
 alloc_main_stack_failure:
 create_stack_cache_failure:
   caml_remove_generational_global_root(&domain_state->dls_root);
-create_root_failure:
 reallocate_minor_heap_failure:
   caml_teardown_major_gc();
 init_major_gc_failure:

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -101,7 +101,7 @@ CAMLexport void caml_raise_with_string(value tag, char const *msg)
 */
 static void check_global_data(char const *exception_name)
 {
-  if (caml_global_data == 0 || !Is_block(caml_read_root(caml_global_data))) {
+  if (caml_global_data == 0 || !Is_block(caml_global_data)) {
     fprintf(stderr, "Fatal error: exception %s during initialisation\n", exception_name);
     exit(2);
   }
@@ -109,7 +109,7 @@ static void check_global_data(char const *exception_name)
 
 static void check_global_data_param(char const *exception_name, char const *msg)
 {
-  if (caml_global_data == 0 || !Is_block(caml_read_root(caml_global_data))) {
+  if (caml_global_data == 0 || !Is_block(caml_global_data)) {
     fprintf(stderr, "Fatal error: exception %s(\"%s\")\n", exception_name, msg);
     exit(2);
   }
@@ -118,7 +118,7 @@ static void check_global_data_param(char const *exception_name, char const *msg)
 static inline value caml_get_failwith_tag (char const *msg)
 {
   check_global_data_param("Failure", msg);
-  return Field_imm(caml_read_root(caml_global_data), FAILURE_EXN);
+  return Field_imm(caml_global_data, FAILURE_EXN);
 }
 
 CAMLexport void caml_failwith (char const *msg)
@@ -137,7 +137,7 @@ CAMLexport void caml_failwith_value (value msg)
 static inline value caml_get_invalid_argument_tag (char const *msg)
 {
   check_global_data_param("Invalid_argument", msg);
-  return Field_imm(caml_read_root(caml_global_data), INVALID_EXN);
+  return Field_imm(caml_global_data, INVALID_EXN);
 }
 
 CAMLexport void caml_invalid_argument (char const *msg)
@@ -161,56 +161,56 @@ CAMLexport void caml_array_bound_error(void)
 CAMLexport void caml_raise_out_of_memory(void)
 {
   check_global_data("Out_of_memory");
-  caml_raise_constant(Field_imm(caml_read_root(caml_global_data),
+  caml_raise_constant(Field_imm(caml_global_data,
                                 OUT_OF_MEMORY_EXN));
 }
 
 CAMLexport void caml_raise_stack_overflow(void)
 {
   check_global_data("Stack_overflow");
-  caml_raise_constant(Field_imm(caml_read_root(caml_global_data),
+  caml_raise_constant(Field_imm(caml_global_data,
                                 STACK_OVERFLOW_EXN));
 }
 
 CAMLexport void caml_raise_sys_error(value msg)
 {
   check_global_data_param("Sys_error", String_val(msg));
-  caml_raise_with_arg(Field_imm(caml_read_root(caml_global_data),
+  caml_raise_with_arg(Field_imm(caml_global_data,
                                 SYS_ERROR_EXN), msg);
 }
 
 CAMLexport void caml_raise_end_of_file(void)
 {
   check_global_data("End_of_file");
-  caml_raise_constant(Field_imm(caml_read_root(caml_global_data),
+  caml_raise_constant(Field_imm(caml_global_data,
                                 END_OF_FILE_EXN));
 }
 
 CAMLexport void caml_raise_zero_divide(void)
 {
   check_global_data("Division_by_zero");
-  caml_raise_constant(Field_imm(caml_read_root(caml_global_data),
+  caml_raise_constant(Field_imm(caml_global_data,
                                 ZERO_DIVIDE_EXN));
 }
 
 CAMLexport void caml_raise_not_found(void)
 {
   check_global_data("Not_found");
-  caml_raise_constant(Field_imm(caml_read_root(caml_global_data),
+  caml_raise_constant(Field_imm(caml_global_data,
                                 NOT_FOUND_EXN));
 }
 
 CAMLexport void caml_raise_sys_blocked_io(void)
 {
   check_global_data("Sys_blocked_io");
-  caml_raise_constant(Field_imm(caml_read_root(caml_global_data),
+  caml_raise_constant(Field_imm(caml_global_data,
                                 SYS_BLOCKED_IO));
 }
 
 CAMLexport void caml_raise_continuation_already_taken(void)
 {
   check_global_data("Continuation_already_taken");
-  caml_raise_constant(Field_imm(caml_read_root(caml_global_data),
+  caml_raise_constant(Field_imm(caml_global_data,
                                 CONTINUATION_ALREADY_TAKEN_EXN));
 }
 
@@ -228,11 +228,11 @@ int caml_is_special_exception(value exn) {
 
   value f;
 
-  if (caml_global_data == 0 || !Is_block(caml_read_root(caml_global_data))) {
+  if (caml_global_data == 0 || !Is_block(caml_global_data)) {
     return 0;
   }
 
-  f = caml_read_root(caml_global_data);
+  f = caml_global_data;
   return exn == Field_imm(f, MATCH_FAILURE_EXN)
       || exn == Field_imm(f, ASSERT_FAILURE_EXN)
       || exn == Field_imm(f, UNDEFINED_RECURSIVE_MODULE_EXN);

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -227,7 +227,7 @@ void caml_maybe_expand_stack ()
 
 #else /* End NATIVE_CODE, begin BYTE_CODE */
 
-caml_root caml_global_data;
+value caml_global_data;
 
 CAMLprim value caml_alloc_stack(value hval, value hexn, value heff)
 {

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -275,7 +275,8 @@ value caml_interprete(code_t prog, asize_t prog_size)
                    Val_bytecode(raise_unhandled_code));
     raise_unhandled = raise_unhandled_closure;
     caml_register_generational_global_root(&raise_unhandled);
-    caml_global_data = caml_create_root(Val_unit);
+    caml_global_data = Val_unit;
+    caml_register_generational_global_root(&caml_global_data);
     caml_init_callbacks();
     return Val_unit;
   }
@@ -692,7 +693,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       *--sp = accu;
       /* Fallthrough */
     Instruct(GETGLOBAL):
-      accu = Field_imm(caml_read_root(caml_global_data), *pc);
+      accu = Field_imm(caml_global_data, *pc);
       pc++;
       Next;
 
@@ -700,7 +701,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       *--sp = accu;
       /* Fallthrough */
     Instruct(GETGLOBALFIELD): {
-      accu = Field_imm(caml_read_root(caml_global_data), *pc);
+      accu = Field_imm(caml_global_data, *pc);
       pc++;
       Accu_field(*pc);
       pc++;
@@ -708,7 +709,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
     }
 
     Instruct(SETGLOBAL):
-      caml_modify_field(caml_read_root(caml_global_data), *pc, accu);
+      caml_modify_field(caml_global_data, *pc, accu);
       accu = Val_unit;
       pc++;
       Next;
@@ -1290,7 +1291,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
 do_resume: {
       struct stack_info* stk = Ptr_val(accu);
       if (stk == NULL) {
-         accu = Field_imm(caml_read_root(caml_global_data), CONTINUATION_ALREADY_TAKEN_EXN);
+         accu = Field_imm(caml_global_data, CONTINUATION_ALREADY_TAKEN_EXN);
          goto raise_exception;
       }
       while (Stack_parent(stk) != NULL) stk = Stack_parent(stk);
@@ -1324,7 +1325,7 @@ do_resume: {
       struct stack_info* parent_stack = Stack_parent(old_stack);
 
       if (parent_stack == NULL) {
-        accu = Field_imm(caml_read_root(caml_global_data), UNHANDLED_EXN);
+        accu = Field_imm(caml_global_data, UNHANDLED_EXN);
         goto raise_exception;
       }
 
@@ -1369,7 +1370,7 @@ do_resume: {
       if (parent == NULL) {
         accu = caml_continuation_use(cont);
         resume_fn = raise_unhandled;
-        resume_arg = Field_imm(caml_read_root(caml_global_data), UNHANDLED_EXN);
+        resume_arg = Field_imm(caml_global_data, UNHANDLED_EXN);
         goto do_resume;
       }
 

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -221,7 +221,7 @@ sp is a local copy of the global variable Caml_state->extern_sp. */
 static __thread intnat caml_bcodcount;
 #endif
 
-static caml_root raise_unhandled;
+static value raise_unhandled;
 
 /* The interpreter itself */
 value caml_interprete(code_t prog, asize_t prog_size)
@@ -273,7 +273,8 @@ value caml_interprete(code_t prog, asize_t prog_size)
     value raise_unhandled_closure =
       caml_alloc_1(Closure_tag,
                    Val_bytecode(raise_unhandled_code));
-    raise_unhandled = caml_create_root(raise_unhandled_closure);
+    raise_unhandled = raise_unhandled_closure;
+    caml_register_generational_global_root(&raise_unhandled);
     caml_global_data = caml_create_root(Val_unit);
     caml_init_callbacks();
     return Val_unit;
@@ -1367,7 +1368,7 @@ do_resume: {
 
       if (parent == NULL) {
         accu = caml_continuation_use(cont);
-        resume_fn = caml_read_root(raise_unhandled);
+        resume_fn = raise_unhandled;
         resume_arg = Field_imm(caml_read_root(caml_global_data), UNHANDLED_EXN);
         goto do_resume;
       }

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -39,7 +39,7 @@
 
 CAMLprim value caml_get_global_data(value unit)
 {
-  return caml_read_root(caml_global_data);
+  return caml_global_data;
 }
 
 CAMLprim value caml_get_section_table(value unit)
@@ -166,7 +166,7 @@ CAMLprim value caml_realloc_global(value size)
   CAMLparam1(size);
   CAMLlocal2(old_global_data, new_global_data);
   mlsize_t requested_size, actual_size, i;
-  old_global_data = caml_read_root(caml_global_data);
+  old_global_data = caml_global_data;
 
   requested_size = Long_val(size);
   actual_size = Wosize_val(old_global_data);
@@ -181,7 +181,7 @@ CAMLprim value caml_realloc_global(value size)
     for (i = actual_size; i < requested_size; i++){
       caml_initialize_field(new_global_data, i, Val_long(0));
     }
-    caml_modify_root(caml_global_data, new_global_data);
+    caml_modify_generational_global_root(&caml_global_data, new_global_data);
   }
   CAMLreturn (Val_unit);
 }

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -355,7 +355,7 @@ CAMLexport void caml_main(char_os **argv)
   /* Load the globals */
   caml_seek_section(fd, &trail, "DATA");
   chan = caml_open_descriptor_in(fd);
-  caml_modify_root(caml_global_data, caml_input_val(chan));
+  caml_modify_generational_global_root(&caml_global_data, caml_input_val(chan));
   caml_close_channel(chan); /* this also closes fd */
   caml_stat_free(trail.section);
   /* Initialize system libraries */
@@ -435,7 +435,7 @@ CAMLexport value caml_startup_code_exn(
   /* Use the builtin table of primitives */
   caml_build_primitive_table_builtin();
   /* Load the globals */
-  caml_modify_root(caml_global_data, caml_input_value_from_block(data, data_size));
+  caml_modify_generational_global_root(&caml_global_data, caml_input_value_from_block(data, data_size));
   caml_minor_collection(); /* ensure all globals are in major heap */
   /* Record the sections (for caml_get_section_table in meta.c) */
   caml_init_section_table(section_table, section_table_size);

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -382,7 +382,7 @@ CAMLprim value caml_sys_getenv(value var)
   return val;
 }
 
-static caml_root main_argv;
+static value main_argv;
 
 CAMLprim value caml_sys_get_argv(value unit)
 {
@@ -390,19 +390,19 @@ CAMLprim value caml_sys_get_argv(value unit)
   CAMLlocal2 (exe_name, res);
   exe_name = caml_copy_string_of_os(caml_params->exe_name);
   res = caml_alloc_small(2, 0);
-  caml_initialize_field(res, 0, exe_name);
-  caml_initialize_field(res, 1, caml_read_root(main_argv));
+  Field(res, 0) = exe_name;
+  Field(res, 1) = main_argv;
   CAMLreturn(res);
 }
 
 CAMLprim value caml_sys_argv(value unit)
 {
-  return caml_read_root(main_argv);
+  return main_argv;
 }
 
 CAMLprim value caml_sys_modify_argv(value new_argv)
 {
-  caml_modify_root(main_argv, new_argv);
+  caml_modify_generational_global_root(&main_argv, new_argv);
   return Val_unit;
 }
 
@@ -413,7 +413,6 @@ CAMLprim value caml_sys_executable_name(value unit)
 
 void caml_sys_init(char_os * exe_name, char_os **argv)
 {
-  value v;
 #ifdef _WIN32
   /* Initialises the caml_win32_* globals on Windows with the version of
      Windows which is running */
@@ -423,9 +422,9 @@ void caml_sys_init(char_os * exe_name, char_os **argv)
 #endif
 #endif
   caml_init_exe_name(exe_name);
-  v = caml_alloc_array((void *)caml_copy_string_of_os,
+  main_argv = caml_alloc_array((void *)caml_copy_string_of_os,
                        (char const **) argv);
-  main_argv = caml_create_root(v);
+  caml_register_generational_global_root(&main_argv);
 }
 
 #ifdef _WIN32


### PR DESCRIPTION
This is one of the patches towards #424. In this one, variables of type `caml_root` are converted to `value` type and they are registered as global root or generational global root depending on the variable. 

There's one more item of type `caml_root` in `domain_startup_params`, `callback` which also needs to be converted to `value`, after which `caml_root` API can be removed entirely. I'm currently working on this and shall update the patch when it's done.