### PR TITLE
Move from travis to Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,37 @@
+name: main
+
+on: [push, pull_request]
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+  # Ensure that make distclean can be run from an empty tree
+    # - name: distclean
+    #   run: |
+    #     MAKE_ARG=-j make distclean
+    - name: configure tree
+      run: |
+        MAKE_ARG=-j XARCH=x64 bash -xe tools/ci/actions/runner.sh configure
+    - name: Build
+      run: |
+        MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build
+    - name: Run the testsuite
+      run: |
+        OCAMLRUNPARAM=v=0,V=1 USE_RUNTIME=d bash -xe tools/ci/actions/runner.sh test
+  macos:
+    runs-on: macos-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: configure tree
+      run: |
+        MAKE_ARG=-j XARCH=x64 bash -xe tools/ci/actions/runner.sh configure
+    - name: Build
+      run: |
+        MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build
+    - name: Run the testsuite
+      run: |
+        bash -xe tools/ci/actions/runner.sh test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,6 @@ jobs:
             os: ubuntu-latest
           - name: macos
             os: macos-latest
-          - name: macos-debug
-            os: macos-latest
-            env: OCAMLRUNPARAM=v=0,V=1 USE_RUNTIME=d
 
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,35 +3,32 @@ name: main
 on: [push, pull_request]
 
 jobs:
-  linux:
-    runs-on: ubuntu-latest
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: linux-debug
+            os: ubuntu-latest
+            env: OCAMLRUNPARAM=v=0,V=1 USE_RUNTIME=d
+          - name: linux
+            os: ubuntu-latest
+          - name: macos
+            os: macos-latest
+          - name: macos-debug
+            os: macos-latest
+            env: OCAMLRUNPARAM=v=0,V=1 USE_RUNTIME=d
+
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-  # Ensure that make distclean can be run from an empty tree
-    # - name: distclean
-    #   run: |
-    #     MAKE_ARG=-j make distclean
-    - name: configure tree
-      run: |
-        MAKE_ARG=-j XARCH=x64 bash -xe tools/ci/actions/runner.sh configure
-    - name: Build
-      run: |
-        MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build
-    - name: Run the testsuite
-      run: |
-        OCAMLRUNPARAM=v=0,V=1 USE_RUNTIME=d bash -xe tools/ci/actions/runner.sh test
-  macos:
-    runs-on: macos-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: configure tree
-      run: |
-        MAKE_ARG=-j XARCH=x64 bash -xe tools/ci/actions/runner.sh configure
-    - name: Build
-      run: |
-        MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build
-    - name: Run the testsuite
-      run: |
-        bash -xe tools/ci/actions/runner.sh test
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: configure tree
+        run: |
+          MAKE_ARG=-j XARCH=x64 bash -xe tools/ci/actions/runner.sh configure
+      - name: Build
+        run: |
+          MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build
+      - name: Run the testsuite
+        run: |
+          ${{ matrix.env }} bash -xe tools/ci/actions/runner.sh test

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,3 @@ script:
 # For speed, only run a few compiler/OS combinations
 matrix:
   include:
-  - compiler: gcc
-    os: linux
-    env:
-    - USE_RUNTIME: d
-    - OCAMLRUNPARAM: v=0,V=1
-  - compiler: clang
-    os: osx

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*              Anil Madhavapeddy, OCaml Labs                             *
+#*                                                                        *
+#*   Copyright 2014 Institut National de Recherche en Informatique et     *
+#*     en Automatique.                                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+set -xe
+
+PREFIX=~/local
+
+MAKE="make $MAKE_ARG"
+SHELL=dash
+
+export PATH=$PREFIX/bin:$PATH
+
+Configure () {
+  mkdir -p $PREFIX
+  cat<<EOF
+------------------------------------------------------------------------
+This test builds the OCaml compiler distribution with your pull request
+and runs its testsuite.
+Failing to build the compiler distribution, or testsuite failures are
+critical errors that must be understood and fixed before your pull
+request can be merged.
+------------------------------------------------------------------------
+EOF
+
+  configure_flags="\
+    --prefix=$PREFIX \
+    --enable-debug-runtime \
+    $CONFIG_ARG"
+
+  case $XARCH in
+  x64)
+    ./configure $configure_flags
+    ;;
+  i386)
+    ./configure --build=x86_64-pc-linux-gnu --host=i386-linux \
+      CC='gcc -m32' AS='as --32' ASPP='gcc -m32 -c' \
+      PARTIALLD='ld -r -melf_i386' \
+      $configure_flags
+    ;;
+  *)
+    echo unknown arch
+    exit 1
+    ;;
+  esac
+}
+
+Build () {
+  $MAKE world.opt
+}
+
+Test () {
+  echo Running the testsuite
+  $MAKE -C testsuite all-enabled
+  cd ..
+}
+
+API_Docs () {
+  echo Ensuring that all library documentation compiles
+  $MAKE -C ocamldoc html_doc pdf_doc texi_doc
+}
+
+Install () {
+  $MAKE install
+}
+
+Checks () {
+  if fgrep 'SUPPORTS_SHARED_LIBRARIES=true' Makefile.config &>/dev/null ; then
+    echo Check the code examples in the manual
+    $MAKE manual-pregen
+  fi
+  # check_all_arches checks tries to compile all backends in place,
+  # we would need to redo (small parts of) world.opt afterwards to
+  # use the compiler again
+  $MAKE check_all_arches
+  # Ensure that .gitignore is up-to-date - this will fail if any untreacked or
+  # altered files exist.
+  test -z "$(git status --porcelain)"
+  # check that the 'clean' target also works
+  $MAKE clean
+  $MAKE -C manual clean
+  # check that the `distclean` target definitely cleans the tree
+  $MAKE distclean
+  # Check the working tree is clean
+  test -z "$(git status --porcelain)"
+  # Check that there are no ignored files
+  test -z "$(git ls-files --others -i --exclude-standard)"
+}
+
+CheckManual () {
+      cat<<EOF
+--------------------------------------------------------------------------
+This test checks the global structure of the reference manual
+(e.g. missing chapters).
+--------------------------------------------------------------------------
+EOF
+  # we need some of the configuration data provided by configure
+  ./configure
+  $MAKE check-stdlib check-case-collision -C manual/tests
+
+}
+
+case $1 in
+configure) Configure;;
+build) Build;;
+test) Test;;
+api-docs) API_Docs;;
+install) Install;;
+other-checks) Checks;;
+*) echo "Unknown CI instruction: $1"
+   exit 1;;
+esac


### PR DESCRIPTION
This PR aims to reuse the bits from upstream to enable Github actions in our repository.
See: https://github.com/ocaml/ocaml/pull/10043/files

I tried to reuse as many things as possible from the PR to avoid diverging trees, however upstream's CI setup does not include such things as macos testing (I believe it is done in Inria's CI currently?), so I baked it in.

I did not do it very properly, I think the same result could be achieved with a matrix in the action config, but the current setup runs the CI properly on my own branch, we can refine from here. (see https://github.com/Engil/ocaml-multicore/actions/runs/472531411).

I included Linux run (with debug runtime) and macos run (with debug runtime off) for now¸ on x86_64 only.