### PR TITLE
Major GC: scan global roots from one domain

### DIFF
--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -141,6 +141,7 @@ int caml_global_barrier_is_final(barrier_status);
 void caml_global_barrier_end(barrier_status);
 int caml_global_barrier_num_domains();
 int caml_domain_is_terminating(void);
+int caml_global_barrier_leave_when_done();
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -683,6 +683,11 @@ int caml_global_barrier_num_domains()
   return stw_request.num_domains;
 }
 
+int caml_global_barrier_leave_when_done()
+{
+  return stw_request.leave_when_done;
+}
+
 static void decrement_stw_domains_still_processing()
 {
   /* we check if we are the last to leave a stw section

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -919,6 +919,7 @@ static void cycle_all_domains_callback(struct domain* domain, void* unused,
   CAMLassert(atomic_load(&num_domains_to_mark) == 0);
   CAMLassert(atomic_load(&num_domains_to_sweep) == 0);
   CAMLassert(atomic_load(&num_domains_to_ephe_sweep) == 0);
+  CAMLassert(caml_global_barrier_leave_when_done() == 0);
 
   caml_empty_minor_heap_no_major_slice_from_stw(domain, (void*)0, participating_count, participating);
 

--- a/runtime/roots.c
+++ b/runtime/roots.c
@@ -48,7 +48,6 @@ void caml_do_roots (scanning_action f, void* fdata, struct domain* d, int do_fin
 {
   caml_do_local_roots(f, fdata, d->state->local_roots, d->state->current_stack, d->state->gc_regs);
   if (caml_scan_roots_hook != NULL) (*caml_scan_roots_hook)(f, fdata, d);
-  caml_scan_global_roots(f, fdata);
   caml_final_do_roots(f, fdata, d, do_final_val);
 
 }


### PR DESCRIPTION
As a first step towards parallelizing global roots scanning, this patch scans the global roots from only one domain in a major  cycle. Whichever domain reaches that point first carries on with scanning. Some benchmark results for this patch are below.

**Sequential Benchmarks - Normalised time**

![normalised](https://user-images.githubusercontent.com/13328130/108024993-abac8380-704b-11eb-87f6-3b6cf3ecb4a9.png)

**Parallel Benchmarks - Time**

![image](https://user-images.githubusercontent.com/13328130/108025242-26759e80-704c-11eb-9944-574e1be80fbe.png)

#### Micro Benchmarks

[`globroots_sp`](https://github.com/ocaml-bench/sandmark/blob/master/benchmarks/multicore-gcroots/globroots_sp.ml) - one domain does all the work in the benchmark, while other domains keep waiting on a channel. Domains other than parent domain do not perform any OCaml work, they do only GC work.

`n = 100000`, Time in seconds

| Domains | Old   | New  |
|---------|-------|------|
| 1       | 2.16  | 2.14 |
| 2       | 3.18  | 2.61 |
| 4       | 4.47  | 2.93 |
| 8       | 6.83  | 3.46 |
| 12      | 9.37  | 4.02 |
| 16      | 16.31 | 5.34 |
| 20      | 19.34 | 6.38 |
| 24      | 23    | 8.07 |


[`globroots_mp`](https://github.com/ocaml-bench/sandmark/blob/master/benchmarks/multicore-gcroots/globroots_mp.ml) - work is split equally among all domains. 

`n = 100000`, Time in seconds

| Domains | Old   | New  |
|---------|-------|------|
| 1       | 2.16  | 2.14 |
| 2       | 3.61  | 3.07 |
| 4       | 6.33  | 4.68 |
| 8       | 9.2   | 5.4  |
| 12      | 11.71 | 5.6  |
| 16      | 18.57 | 6.72 |
| 20      | 20.31 | 7.19 |
| 24      | 22.34 | 7.52 |

---

Ultimately, the aim is to parallelize global roots scanning in the major GC. Since we see a sizeable performance improvement in the micro benchmarks while scanning from one domain, it might be useful to add this, and it can act as a sequential baseline to measure the performance improvement of the upcoming parallel version.