### PR TITLE
Fixing remarking to be safe with parallel domains

### DIFF
--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -143,8 +143,9 @@ int caml_global_barrier_num_domains();
 int caml_domain_is_terminating(void);
 
 struct pool;
-void push_pool_remark_to_domain(struct domain* dom, struct pool* p);
-struct pool* pop_pool_remark_for_domain(struct domain* domain);
+void caml_push_pool_remark_to_domain(struct domain* dom, struct pool* p);
+struct pool* caml_pop_pool_remark_for_domain(struct domain* domain);
+int caml_remark_stack_count_for_domain(struct domain* domain);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -142,6 +142,10 @@ void caml_global_barrier_end(barrier_status);
 int caml_global_barrier_num_domains();
 int caml_domain_is_terminating(void);
 
+struct pool;
+void push_pool_remark_to_domain(struct domain* dom, struct pool* p);
+struct pool* pop_pool_remark_for_domain(struct domain* domain);
+
 #endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -109,10 +109,6 @@ DOMAIN_STATE(int, id)
 
 DOMAIN_STATE(int, unique_id)
 
-DOMAIN_STATE(struct pool**, pools_to_rescan)
-DOMAIN_STATE(int, pools_to_rescan_len)
-DOMAIN_STATE(int, pools_to_rescan_count)
-
 DOMAIN_STATE(caml_root, dls_root)
 
 /*****************************************************************************/

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -48,6 +48,8 @@ intnat caml_major_collection_slice (intnat);
 void caml_finish_sweeping(void);
 void caml_finish_marking (void);
 uintnat caml_get_num_domains_to_mark(void);
+uintnat caml_atomic_incr_num_domains_to_remark(void);
+uintnat caml_atomic_decr_num_domains_to_remark(void);
 int caml_init_major_gc(caml_domain_state*);
 void caml_teardown_major_gc(void);
 void caml_darken(void*, value, value* ignored);

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -23,7 +23,10 @@ uintnat caml_top_heap_words(struct caml_heap_state*);
 uintnat caml_heap_blocks(struct caml_heap_state*);
 
 struct pool* caml_pool_of_shared_block(value v);
-struct domain* caml_owner_of_shared_block(value v);
+struct domain* caml_owner_of_pool(struct pool* p);
+
+void caml_acquire_pool_adoption_lock();
+void caml_release_pool_adoption_lock();
 
 void caml_shared_unpin(value v);
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -490,29 +490,27 @@ static void realloc_mark_stack (struct mark_stack* stk)
   mark_entry* new;
   uintnat mark_stack_bsize = stk->size * sizeof(mark_entry);
 
-  caml_gc_log ("Growing mark stack to %"ARCH_INTNAT_PRINTF_FORMAT"uk bytes\n",
-               (intnat) mark_stack_bsize * 2 / 1024);
+  if ( mark_stack_bsize < caml_heap_size(Caml_state->shared_heap) / 32) {
+    caml_gc_log ("Growing mark stack to %"ARCH_INTNAT_PRINTF_FORMAT"uk bytes\n",
+                 (intnat) mark_stack_bsize * 2 / 1024);
 
-  new = (mark_entry*) caml_stat_resize_noexc ((char*) stk->stack,
-                                              2 * mark_stack_bsize);
-  if (new != NULL) {
-    stk->stack = new;
-    stk->size *= 2;
-    return;
+    new = (mark_entry*) caml_stat_resize_noexc ((char*) stk->stack,
+                                                2 * mark_stack_bsize);
+    if (new != NULL) {
+      stk->stack = new;
+      stk->size *= 2;
+      return;
+    }
+
+    caml_gc_log ("No room for growing mark stack. Pruning..\n");
   }
 
-  caml_fatal_error("No room for growing mark stack.\n");
-  /* TODO: re-enable mark stack prune when safe to remark a pool
-    from a foreign domain which is also allocating from that pool
-   */
-  if (0) {
-    caml_gc_log ("Mark stack size is %"ARCH_INTNAT_PRINTF_FORMAT"u"
-                "bytes (> 32 * major heap size of this domain %"
-                ARCH_INTNAT_PRINTF_FORMAT"u bytes. Pruning..\n",
-                mark_stack_bsize,
-                caml_heap_size(Caml_state->shared_heap));
-    mark_stack_prune(stk);
-  }
+  caml_gc_log ("Mark stack size is %"ARCH_INTNAT_PRINTF_FORMAT"u"
+              "bytes (> 32 * major heap size of this domain %"
+              ARCH_INTNAT_PRINTF_FORMAT"u bytes. Pruning..\n",
+              mark_stack_bsize,
+              caml_heap_size(Caml_state->shared_heap));
+  mark_stack_prune(stk);
 }
 
 static void mark_stack_push(struct mark_stack* stk, value block,

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1239,7 +1239,7 @@ static intnat major_collection_slice(intnat howmuch,
 
 mark_again:
   while (budget > 0) {
-    if (!domain_state->marking_done) {
+    if (!domain_state->marking_done || check_if_remarking_needed()) {
       if (!was_marking) {
         if (log_events) caml_ev_begin("major_gc/mark");
         was_marking = 1;

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -420,6 +420,18 @@ struct pool* caml_pool_of_shared_block(value v)
   }
 }
 
+struct domain* caml_owner_of_pool(struct pool* p) {
+  return p->owner;
+}
+
+void caml_acquire_pool_adoption_lock() {
+  caml_plat_lock(&pool_freelist.lock);
+}
+
+void caml_release_pool_adoption_lock() {
+  caml_plat_unlock(&pool_freelist.lock);
+}
+
 /* Sweeping */
 
 static intnat pool_sweep(struct caml_heap_state* local, pool** plist, sizeclass sz, int release_to_global_pool) {

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -90,11 +90,12 @@ struct caml_heap_state* caml_init_shared_heap() {
   return heap;
 }
 
-static int move_all_pools(pool** src, pool** dst, struct domain* new_owner) {
+static int move_all_pools(pool** src, struct domain* old_owner, pool** dst, struct domain* new_owner) {
   int count = 0;
   while (*src) {
     pool* p = *src;
     *src = p->next;
+    Assert(p->owner == old_owner);
     p->owner = new_owner;
     p->next = *dst;
     *dst = p;
@@ -109,9 +110,9 @@ void caml_teardown_shared_heap(struct caml_heap_state* heap) {
   caml_plat_lock(&pool_freelist.lock);
   for (i = 0; i < NUM_SIZECLASSES; i++) {
     released +=
-      move_all_pools(&heap->avail_pools[i], &pool_freelist.global_avail_pools[i], NULL);
+      move_all_pools(&heap->avail_pools[i], heap->owner, &pool_freelist.global_avail_pools[i], NULL);
     released +=
-      move_all_pools(&heap->full_pools[i], &pool_freelist.global_full_pools[i], NULL);
+      move_all_pools(&heap->full_pools[i], heap->owner, &pool_freelist.global_full_pools[i], NULL);
     /* should be swept by now */
     Assert(!heap->unswept_avail_pools[i]);
     Assert(!heap->unswept_full_pools[i]);
@@ -246,6 +247,7 @@ static pool* pool_global_adopt(struct caml_heap_state* local, sizeclass sz)
 
     if( r ) {
       pool_freelist.global_avail_pools[sz] = r->next;
+      r->owner = local->owner;
       r->next = 0;
       local->avail_pools[sz] = r;
 
@@ -279,6 +281,7 @@ static pool* pool_global_adopt(struct caml_heap_state* local, sizeclass sz)
 
     if( r ) {
       pool_freelist.global_full_pools[sz] = r->next;
+      r->owner = local->owner;
       r->next = local->full_pools[sz];
       local->full_pools[sz] = r;
 
@@ -820,9 +823,11 @@ void caml_cycle_heap(struct caml_heap_state* local) {
   caml_plat_lock(&pool_freelist.lock);
   for (i = 0; i < NUM_SIZECLASSES; i++) {
     received_p += move_all_pools(&pool_freelist.global_avail_pools[i],
+                                 NULL,
                                  &local->unswept_avail_pools[i],
                                  local->owner);
     received_p += move_all_pools(&pool_freelist.global_full_pools[i],
+                                 NULL,
                                  &local->unswept_full_pools[i],
                                  local->owner);
   }


### PR DESCRIPTION
This PR implements a solution to the problem of remarking pools owned by another domain as in ocaml-multicore#466. 

Remarking occurs when a domain's mark stack overflows its allowable space in `realloc_mark_stack`. Pools are determined to need remarking and all entries removed from that domain's mark stack for those pools. There is however a race bug should a domain attempt to remark a pool while another domain is allocating into that pool, because all allocations start as being `MARKED` even when their fields are not safe to use. 

The solution implemented pushes the responsibility for remarking a pool to the domain that owns the pool. This solves the race by making sure that the domain doing the remarking either owns the pool or knows that nobody else can use the pool for allocation. 

This PR introduces a mechanism for doing this and handles the domain lifecycle interactions needed to make it correct. In particular:
 - there are now _remark_stacks_ which hold pools that require remarking. There is a stack for each domain and also a `global_remark_stack` for orphaned pools that need remarking. These stacks live in a static area to make the domain lifecycle implications easier; every domain has a valid stack even while it is terminating. 
 - when a domain determines a pool needs remarking, it attempts to push it to the domain that owns it. If there isn't an owner _or_ the domain that owns it is no longer accepting entries because it is terminating, the pool ends up in the `global_remark_stack`. When a domain has pushed a pool to a remark stack, it is guaranteed that it will be remarked by somebody before the current phase of the major GC is complete. 
 - when a domain finds work in its remark stack (or the `global_remark_stack`) it calls `pop_from_remark_stack` in `major_gc.c` which: (i) if we own the pool, we remark; (ii) if another domain owns the pool, we push it to the correct accepting remark stack (that domain or global); (iii) if it is an orphaned pool, we lock the orphaned pool adoption lock to ensure that nobody can take ownership of the pool, then remark the pool and then release the adoption lock. 
 - there is an additional global atomic `num_domains_to_remark` in the major GC which checks that all remark stacks are empty before allowing phases to move forwards. 
 - on domain termination we have to be careful at what point we allow the domain to cease servicing its remark stack. It needs to happen at exactly the point that we know all its pools will be orphaned, otherwise there is the potential for deadlock where the domain ceases servicing its remarking stack, but remarking is needed to complete a major GC STW segment.
 - while debugging I discovered we were not correctly tracking pool ownership in the adoption paths; I've fixed this and added asserts when we orphan pools to check the ownership tracking is correct.

I've tested the implementation with the testsuite on a bunch of machines and also a big overnight loop of the troublesome `domain_serial_spawn_burn` (bytecode edition & native).

There are some niggles with how this has ended up:
 - I think the static remark_stack structures belong in `major_gc.c` not `domain.c` to keep it in the same place as the GC; there isn't a strong reason it needs to be in domain.
 - I'm not overly fond of the efficiency of what is going on with `Caml_state->marking_done` combined with the remarking stack checks we have to push in front of the guard. I was afraid of changing `Caml_state->marking_done` because sometimes the `Caml_state->marking_done` guard is an efficiency optimization, but in other places it is used for correct operation. I'm minded to leave the inefficiency there until there is a known problem, but may have a flash of insight on how to make it all a bit cleaner.

However I'd like feedback before refactoring it. 