### PR TITLE
Remove leave_when_done and friends from STW API

### DIFF
--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -129,9 +129,8 @@ int caml_domain_is_in_stw();
 void caml_run_on_all_running_domains_during_stw(void (*handler)(struct domain*, void*), void* data);
 int caml_try_run_on_all_domains_with_spin_work(void (*handler)(struct domain*, void*, int, struct domain**), void*, void (*leader_setup)(struct domain*),
   void (*enter_spin_callback)(struct domain*, void*), void*,
-  void (*leave_spin_callback)(struct domain*, void*), void*,
-  int);
-int caml_try_run_on_all_domains(void (*handler)(struct domain*, void*, int, struct domain**), void*, void (*leader_setup)(struct domain*), int);
+  void (*leave_spin_callback)(struct domain*, void*), void*);
+int caml_try_run_on_all_domains(void (*handler)(struct domain*, void*, int, struct domain**), void*, void (*leader_setup)(struct domain*));
 
 void caml_global_barrier();
 
@@ -141,7 +140,6 @@ int caml_global_barrier_is_final(barrier_status);
 void caml_global_barrier_end(barrier_status);
 int caml_global_barrier_num_domains();
 int caml_domain_is_terminating(void);
-int caml_global_barrier_leave_when_done();
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -127,9 +127,10 @@ int caml_domain_is_in_stw();
 #endif
 
 void caml_run_on_all_running_domains_during_stw(void (*handler)(struct domain*, void*), void* data);
-int caml_try_run_on_all_domains_with_spin_work(void (*handler)(struct domain*, void*, int, struct domain**), void*, void (*leader_setup)(struct domain*),
-  void (*enter_spin_callback)(struct domain*, void*), void*,
-  void (*leave_spin_callback)(struct domain*, void*), void*);
+int caml_try_run_on_all_domains_with_spin_work(
+  void (*handler)(struct domain*, void*, int, struct domain**), void* data,
+  void (*leader_setup)(struct domain*),
+  void (*enter_spin_callback)(struct domain*, void*), void* enter_spin_data);
 int caml_try_run_on_all_domains(void (*handler)(struct domain*, void*, int, struct domain**), void*, void (*leader_setup)(struct domain*));
 
 void caml_global_barrier();

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -621,8 +621,6 @@ static struct {
   atomic_uintnat barrier;
   void (*enter_spin_callback)(struct domain*, void*);
   void* enter_spin_data;
-  void (*leave_spin_callback)(struct domain*, void*);
-  void* leave_spin_data;
 
   struct interrupt reqs[Max_domains];
   struct domain* participating[Max_domains];
@@ -633,8 +631,6 @@ static struct {
   NULL,
   0,
   ATOMIC_UINTNAT_INIT(0),
-  NULL,
-  NULL,
   NULL,
   NULL,
   { { 0 } },
@@ -768,8 +764,7 @@ static void caml_wait_interrupt_acknowledged(struct interruptor* self, struct in
 int caml_try_run_on_all_domains_with_spin_work(
   void (*handler)(struct domain*, void*, int, struct domain**), void* data,
   void (*leader_setup)(struct domain*),
-  void (*enter_spin_callback)(struct domain*, void*), void* enter_spin_data,
-  void (*leave_spin_callback)(struct domain*, void*), void* leave_spin_data)
+  void (*enter_spin_callback)(struct domain*, void*), void* enter_spin_data)
 {
 #ifdef DEBUG
   caml_domain_state* domain_state = Caml_state;
@@ -807,8 +802,6 @@ int caml_try_run_on_all_domains_with_spin_work(
   stw_request.enter_spin_data = enter_spin_data;
   stw_request.callback = handler;
   stw_request.data = data;
-  stw_request.leave_spin_callback = leave_spin_callback;
-  stw_request.leave_spin_data = leave_spin_data;
   atomic_store_rel(&stw_request.barrier, 0);
   atomic_store_rel(&stw_request.domains_still_running, 1);
 
@@ -876,7 +869,7 @@ int caml_try_run_on_all_domains_with_spin_work(
 
 int caml_try_run_on_all_domains(void (*handler)(struct domain*, void*, int, struct domain**), void* data, void (*leader_setup)(struct domain*))
 {
-  return caml_try_run_on_all_domains_with_spin_work(handler, data, leader_setup, 0, 0, 0, 0);
+  return caml_try_run_on_all_domains_with_spin_work(handler, data, leader_setup, 0, 0);
 }
 
 void caml_interrupt_self() {

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -617,7 +617,6 @@ static struct {
   atomic_uintnat num_domains_still_processing;
   void (*callback)(struct domain*, void*, int participating_count, struct domain** others_participating);
   void* data;
-  int leave_when_done;
   int num_domains;
   atomic_uintnat barrier;
   void (*enter_spin_callback)(struct domain*, void*);
@@ -632,7 +631,6 @@ static struct {
   ATOMIC_UINTNAT_INIT(0),
   NULL,
   NULL,
-  0,
   0,
   ATOMIC_UINTNAT_INIT(0),
   NULL,
@@ -683,11 +681,6 @@ int caml_global_barrier_num_domains()
   return stw_request.num_domains;
 }
 
-int caml_global_barrier_leave_when_done()
-{
-  return stw_request.leave_when_done;
-}
-
 static void decrement_stw_domains_still_processing()
 {
   /* we check if we are the last to leave a stw section
@@ -735,16 +728,6 @@ static void stw_handler(struct domain* domain, void* unused2, interrupt* done)
 
   decrement_stw_domains_still_processing();
 
-  if( !stw_request.leave_when_done ) {
-    SPIN_WAIT {
-      if (atomic_load_acq(&stw_request.num_domains_still_processing) == 0)
-        break;
-
-      if (stw_request.leave_spin_callback)
-        stw_request.leave_spin_callback(domain, stw_request.leave_spin_data);
-    }
-  }
-
   caml_ev_end("stw/handler");
 
   /* poll the GC to check for deferred work
@@ -786,9 +769,7 @@ int caml_try_run_on_all_domains_with_spin_work(
   void (*handler)(struct domain*, void*, int, struct domain**), void* data,
   void (*leader_setup)(struct domain*),
   void (*enter_spin_callback)(struct domain*, void*), void* enter_spin_data,
-  void (*leave_spin_callback)(struct domain*, void*), void* leave_spin_data,
-  int leave_when_done
-  )
+  void (*leave_spin_callback)(struct domain*, void*), void* leave_spin_data)
 {
 #ifdef DEBUG
   caml_domain_state* domain_state = Caml_state;
@@ -828,7 +809,6 @@ int caml_try_run_on_all_domains_with_spin_work(
   stw_request.data = data;
   stw_request.leave_spin_callback = leave_spin_callback;
   stw_request.leave_spin_data = leave_spin_data;
-  stw_request.leave_when_done = leave_when_done;
   atomic_store_rel(&stw_request.barrier, 0);
   atomic_store_rel(&stw_request.domains_still_running, 1);
 
@@ -886,13 +866,6 @@ int caml_try_run_on_all_domains_with_spin_work(
 
   decrement_stw_domains_still_processing();
 
-  if( !leave_when_done ) {
-    SPIN_WAIT {
-      if (atomic_load_acq(&stw_request.num_domains_still_processing) == 0)
-        break;
-    }
-  }
-
   caml_ev_end("stw/leader");
   /* other domains might not have finished stw_handler yet, but they
      will finish as soon as they notice num_domains_still_processing
@@ -901,9 +874,9 @@ int caml_try_run_on_all_domains_with_spin_work(
   return 1;
 }
 
-int caml_try_run_on_all_domains(void (*handler)(struct domain*, void*, int, struct domain**), void* data, void (*leader_setup)(struct domain*), int leave_when_done)
+int caml_try_run_on_all_domains(void (*handler)(struct domain*, void*, int, struct domain**), void* data, void (*leader_setup)(struct domain*))
 {
-  return caml_try_run_on_all_domains_with_spin_work(handler, data, leader_setup, 0, 0, 0, 0, leave_when_done);
+  return caml_try_run_on_all_domains_with_spin_work(handler, data, leader_setup, 0, 0, 0, 0);
 }
 
 void caml_interrupt_self() {

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -919,7 +919,6 @@ static void cycle_all_domains_callback(struct domain* domain, void* unused,
   CAMLassert(atomic_load(&num_domains_to_mark) == 0);
   CAMLassert(atomic_load(&num_domains_to_sweep) == 0);
   CAMLassert(atomic_load(&num_domains_to_ephe_sweep) == 0);
-  CAMLassert(caml_global_barrier_leave_when_done() == 0);
 
   caml_empty_minor_heap_no_major_slice_from_stw(domain, (void*)0, participating_count, participating);
 
@@ -1053,6 +1052,7 @@ static void cycle_all_domains_callback(struct domain* domain, void* unused,
   domain->state->final_info->updated_first = 0;
   domain->state->final_info->updated_last = 0;
 
+  caml_global_barrier();
   caml_ev_end("major_gc/stw");
   caml_ev_end("major_gc/cycle_domains");
 }
@@ -1272,7 +1272,7 @@ mark_again:
       if (barrier_participants) {
         try_complete_gc_phase (d, (void*)0, participant_count, barrier_participants);
       } else {
-        caml_try_run_on_all_domains (&try_complete_gc_phase, 0, 0, 0);
+        caml_try_run_on_all_domains (&try_complete_gc_phase, 0, 0);
       }
       if (budget > 0) goto mark_again;
     }
@@ -1301,7 +1301,7 @@ mark_again:
       if (barrier_participants) {
         cycle_all_domains_callback(d, (void*)0, participant_count, barrier_participants);
       } else {
-        caml_try_run_on_all_domains(&cycle_all_domains_callback, 0, 0, 0);
+        caml_try_run_on_all_domains(&cycle_all_domains_callback, 0, 0);
       }
     }
   }
@@ -1351,7 +1351,7 @@ void caml_finish_major_cycle ()
   uintnat saved_major_cycles = caml_major_cycles_completed;
 
   while( saved_major_cycles == caml_major_cycles_completed ) {
-    caml_try_run_on_all_domains(&finish_major_cycle_callback, (void*)caml_major_cycles_completed, 0, 0);
+    caml_try_run_on_all_domains(&finish_major_cycle_callback, (void*)caml_major_cycles_completed, 0);
   }
 }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1052,7 +1052,11 @@ static void cycle_all_domains_callback(struct domain* domain, void* unused,
   domain->state->final_info->updated_first = 0;
   domain->state->final_info->updated_last = 0;
 
+  /* To ensure a mutator doesn't resume while global roots are being marked.
+     Mutators can alter the set of global roots, to preserve its correctness,
+     they should not run while global roots are being marked.*/
   caml_global_barrier();
+
   caml_ev_end("major_gc/stw");
   caml_ev_end("major_gc/cycle_domains");
 }

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -794,8 +794,8 @@ int caml_try_stw_empty_minor_heap_on_all_domains ()
     &caml_stw_empty_minor_heap, 0, /* stw handler */
     &caml_empty_minor_heap_setup, /* leader setup */
     &caml_do_opportunistic_major_slice, 0, /* enter spin work */
-    0, 0, /* leave spin work */
-    1); /* leave when done */
+    0, 0 /* leave spin work */);
+    /* leaves when done by default*/
 }
 
 /* must be called outside a STW section, will retry until we have emptied our minor heap */

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -793,8 +793,7 @@ int caml_try_stw_empty_minor_heap_on_all_domains ()
   return caml_try_run_on_all_domains_with_spin_work(
     &caml_stw_empty_minor_heap, 0, /* stw handler */
     &caml_empty_minor_heap_setup, /* leader setup */
-    &caml_do_opportunistic_major_slice, 0, /* enter spin work */
-    0, 0 /* leave spin work */);
+    &caml_do_opportunistic_major_slice, 0 /* enter spin work */);
     /* leaves when done by default*/
 }
 


### PR DESCRIPTION
After a discussion with @ctk21 on #472, we figured `stw_request.leave_when_done` is best gone. This patch attempts that, by removing barriers from `caml_try_run_on_all_domains*` and `stw_request`.

So, the change this patch brings is, `caml_try_run_on_all_domains*` no longer has a barrier inside, therefore by default the callback function would leave as soon as it's done. When a barrier is present inside `caml_try_run_on_all_domains*` with `leave_when_done` as the parameter to keep spinning or not, it is not straightforward to find out whether the callback function is going to exit when done or will keep spinning till other domains are done. In particular, the outcome could be different at different entry points for the same function.

Wherever barriers are necessary, they would have to be added in the callback function itself, making it easier to reason about whether a function is going to leave, or is it going to wait until other domains are done. This is already done for existing functions requiring a barrier.