### PR TITLE
Thread local allocation buffers

### DIFF
--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -39,6 +39,9 @@ struct domain {
   (CAMLalloc_point_here, \
    CAMLunlikely((uintnat)(dom_st)->young_ptr < (dom_st)->young_limit))
 
+#define REALLOCATE_OOM -1
+#define REALLOCATE_HEAP_FULL -2
+
 asize_t caml_norm_minor_heap_size (intnat);
 int caml_reallocate_minor_heap(asize_t);
 

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -106,6 +106,7 @@ struct domain* caml_domain_of_id(int);
 CAMLextern atomic_uintnat caml_num_domains_running;
 CAMLextern uintnat caml_minor_heaps_base;
 CAMLextern uintnat caml_minor_heaps_end;
+CAMLextern atomic_uintnat caml_global_minor_heap_ptr;
 
 INLINE intnat caml_domain_alone()
 {

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -180,7 +180,8 @@ int caml_reallocate_minor_heap(asize_t wsize)
 
     global_minor_heap_ptr = atomic_load_explicit(&caml_global_minor_heap_ptr, memory_order_acquire);
 
-    CAMLassert(global_minor_heap_ptr != 0x0);
+    CAMLassert(caml_minor_heaps_base <= global_minor_heap_ptr);
+    CAMLassert(global_minor_heap_ptr <= caml_minor_heaps_end);
 
     new_alloc_ptr = global_minor_heap_ptr + Bsize_wsize(wsize);
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -179,8 +179,6 @@ int caml_reallocate_minor_heap(asize_t wsize)
 
   caml_ev_begin("reallocate");
 
-  Assert(domain_state->young_ptr == domain_state->young_end);
-
   while (1) {
 
     global_minor_heap_ptr = atomic_load_explicit(&caml_global_minor_heap_ptr, memory_order_acquire);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -43,9 +43,6 @@
 #include "caml/finalise.h"
 #include "caml/gc_ctrl.h"
 
-#define REALLOCATE_OOM -1
-#define REALLOCATE_HEAP_FULL -2
-
 #define BT_IN_BLOCKING_SECTION 0
 #define BT_ENTERING_OCAML 1
 #define BT_TERMINATE 2

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -951,7 +951,7 @@ static void caml_poll_gc_work()
 	break;
 
       case REALLOCATE_OOM:
-	caml_raise_out_of_memory();
+	caml_fatal_error("could not allocate minor heap");
 	break;
 
       /* TODO(engil): same as earlier, rework, because in case we did reallocate

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -344,11 +344,11 @@ void caml_init_domains(uintnat minor_heap_wsz) {
     caml_fatal_error("Minor_heap_max misconfigured for this platform");
 
   /* reserve memory space for minor heaps and tls_areas */
-  size = (uintnat)Minor_heap_max * Max_domains;
+  size = (uintnat)Wsize_bsize(Minor_heap_max) * Max_domains;
   tls_size = caml_mem_round_up_pages(sizeof(caml_domain_state));
   tls_areas_size = tls_size * Max_domains;
 
-  heaps_base = caml_mem_map(size*2, size*2, 1 /* reserve_only */);
+  heaps_base = caml_mem_map(size, size, 1 /* reserve_only */);
   tls_base = caml_mem_map(tls_areas_size, tls_areas_size, 1 /* reserve_only */);
   if (!heaps_base || !tls_base) caml_raise_out_of_memory();
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -180,9 +180,7 @@ int caml_reallocate_minor_heap(asize_t wsize)
 
     global_minor_heap_ptr = atomic_load_explicit(&caml_global_minor_heap_ptr, memory_order_acquire);
 
-    #ifdef DEBUG
     CAMLassert(global_minor_heap_ptr != 0x0);
-    #endif
 
     new_alloc_ptr = global_minor_heap_ptr + Bsize_wsize(wsize);
 

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -523,7 +523,7 @@ void caml_empty_minor_heap_domain_clear (struct domain* domain, void* unused)
   if (realloc_retcode == REALLOCATE_HEAP_FULL)
     abort(); /* FIXME(engil): should not happen? */
   else if (realloc_retcode == REALLOCATE_OOM)
-    caml_raise_out_of_memory();
+    caml_fatal_error("could not allocate minor heap");
 
   return;
 }


### PR DESCRIPTION
(See #398 and the [draft on the wiki](https://github.com/ocaml-multicore/ocaml-multicore/wiki/Domain-Local-Allocation-Buffers))
This PR introduce thread local allocation buffers. (or Domain local allocation buffers.)

With this PR, we change the way we currently allocate minor heaps segment for each domains.

In the current setting, a minor heap segment is given to each domains as we initialize the `Max_domains` slots:

`caml_minor_heaps_start` and `caml_minor_heaps_end` delimits the minor heaps space, and contains exactly `Max_domains` segments, each one being set to each domains slot.

When a minor heap is full (any domain's), we proceed to do a minor collection, and reallocate each individual minor heap segments.

This means that each domains currently possess their own address range in the minor heaps area, and they keep the same range during their lifetime.

This PR introduces a new mechanism to allocate minor heaps segments, by using an allocation pointer in the global minor heap segment:
- Domains won't have a dedicated address range on the global minor heap, but will instead bump this allocation pointer to reserve a new minor heap segment from the global heap.
- When an individual minor heap runs out, a domain is allowed to fetch a new minor heap segment from the global_minor_heap instead.
- The new condition for organically triggering a minor collection (outside of a `finish_major_gc` cycle), is for the `global_minor_heap_ptr` to grow past the end of the global minor heaps segment.

3526033 addresses one existing issue where the current sizing for the minor heaps space is not properly sized.

The current state of this PR:
- The bump pointer allocation logic is implemented
- Greedily reallocating minor heap segments (ie. one domain can request another segment when it runs out of minor heap space) is done

Missing parts:
- Terminology adjustment: for the sake of keeping the core logic easy to review, renaming has not yet taken place. (we may want to rename `caml_reallocate_minor_heaps`, `caml_minor_heaps_base`, `caml_minor_heaps_end`... ect)
- Testsuite should be extended to include:
   - Spawning up to `Max_domains` and see if minor heaps math does checks out under various circumstances
   - More organic versions of the `spawn_burn` tests, that does not manually trigger GC, but rather let it happen.
- Benchmarking, and tweaking sizes: this PR takes not time to revisit the currents sizes: a minor heap segment is equal to the current default size. Which means a single busy domain can right now make usage of a minor heap space up to `Max_domains * Max_minor_heap_size` (so 128 * 256k words).
   - Related point: dynamically resizing the minor heap segment size?


