### PR TITLE
systhreads: set gc_regs_buckets and friends to NULL at thread startup

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -215,6 +215,9 @@ static caml_thread_t caml_thread_new_info(void)
   th->exn_handler = NULL;
   th->local_roots = NULL;
   th->exit_buf = NULL;
+  th->gc_regs_buckets = NULL;
+  th->gc_regs = NULL;
+  th->gc_regs_slot = NULL;
   th->backtrace_pos = 0;
   th->backtrace_buffer = NULL;
   th->backtrace_last_exn = caml_create_root(Val_unit);

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -210,18 +210,18 @@ static caml_thread_t caml_thread_new_info(void)
   if (th == NULL) return NULL;
 
   th->descr = Val_unit;
+  th->domain_id = d->state->id;
   th->current_stack = caml_alloc_main_stack(Stack_size / sizeof(value));;
   th->c_stack = NULL;
-  th->exn_handler = NULL;
   th->local_roots = NULL;
   th->exit_buf = NULL;
-  th->gc_regs_buckets = NULL;
-  th->gc_regs = NULL;
-  th->gc_regs_slot = NULL;
   th->backtrace_pos = 0;
   th->backtrace_buffer = NULL;
   th->backtrace_last_exn = caml_create_root(Val_unit);
-  th->domain_id = d->state->id;
+  th->gc_regs = NULL;
+  th->gc_regs_buckets = NULL;
+  th->gc_regs_slot = NULL;
+  th->exn_handler = NULL;
 
   #ifndef NATIVE_CODE
   th->trap_sp_off = 1;

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -210,6 +210,8 @@ static caml_thread_t caml_thread_new_info(void)
   if (th == NULL) return NULL;
 
   th->descr = Val_unit;
+  th->next = NULL;
+  th->prev = NULL;
   th->domain_id = d->state->id;
   th->current_stack = caml_alloc_main_stack(Stack_size / sizeof(value));;
   th->c_stack = NULL;


### PR DESCRIPTION
This fixes the issue encountered on #485 

Those fields were ignored during the initialization phase, and it is not correct.

I re-checked the initialization of the thread and I think these were the only missing fields, maybe this was a mishap while aligning our systhreads implementation to trunk's.