### PR TITLE
Remove caml_root API

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -231,6 +231,7 @@ static caml_thread_t caml_thread_new_info(void)
   th->external_raise = NULL;
   #endif
 
+  caml_register_generational_global_root(&th->backtrace_last_exn);
   return th;
 }
 
@@ -279,6 +280,7 @@ static void caml_thread_reinitialize(void)
   while (th != Current_thread) {
     next = th->next;
     caml_free_stack(th->current_stack);
+    caml_remove_generational_global_root(&th->backtrace_last_exn);
     caml_stat_free(th);
     th = next;
   }

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -64,7 +64,7 @@ struct caml_thread_struct {
   struct longjmp_buffer *exit_buf;
   int backtrace_pos;
   code_t * backtrace_buffer;
-  caml_root backtrace_last_exn;
+  value backtrace_last_exn;
   value * gc_regs;
   value * gc_regs_buckets;
   value ** gc_regs_slot;
@@ -219,7 +219,7 @@ static caml_thread_t caml_thread_new_info(void)
   th->exit_buf = NULL;
   th->backtrace_pos = 0;
   th->backtrace_buffer = NULL;
-  th->backtrace_last_exn = caml_create_root(Val_unit);
+  th->backtrace_last_exn = Val_unit;
   th->gc_regs = NULL;
   th->gc_regs_buckets = NULL;
   th->gc_regs_slot = NULL;
@@ -264,7 +264,6 @@ static void caml_thread_remove_info(caml_thread_t th)
   th->next->prev = th->prev;
   th->prev->next = th->next;
   caml_free_stack(th->current_stack);
-  caml_delete_root(th->backtrace_last_exn);
   caml_stat_free(th);
   return;
 }
@@ -280,7 +279,6 @@ static void caml_thread_reinitialize(void)
   while (th != Current_thread) {
     next = th->next;
     caml_free_stack(th->current_stack);
-    caml_delete_root(th->backtrace_last_exn);
     caml_stat_free(th);
     th = next;
   }

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -30,7 +30,7 @@
 
 void caml_init_backtrace(void)
 {
-  return;
+  caml_register_generational_global_root(&Caml_state->backtrace_last_exn);
 }
 
 /* Start or stop the backtrace machinery */
@@ -42,10 +42,9 @@ CAMLprim value caml_record_backtrace(value vflag)
     Caml_state->backtrace_active = flag;
     Caml_state->backtrace_pos = 0;
     if (flag) {
-      Caml_state->backtrace_last_exn = caml_create_root(Val_unit);
+      Caml_state->backtrace_last_exn = Val_unit;
     } else {
-      caml_delete_root(Caml_state->backtrace_last_exn);
-      Caml_state->backtrace_last_exn = NULL;
+      caml_remove_generational_global_root(&Caml_state->backtrace_last_exn);
     }
   }
   return Val_unit;
@@ -173,8 +172,7 @@ CAMLprim value caml_restore_raw_backtrace(value exn, value backtrace)
 
   caml_domain_state* domain_state = Caml_state;
 
-  if (domain_state->backtrace_last_exn != NULL)
-    caml_modify_root (domain_state->backtrace_last_exn, exn);
+  caml_modify_generational_global_root (&domain_state->backtrace_last_exn, exn);
 
   bt_size = Wosize_val(backtrace);
   if(bt_size > BACKTRACE_BUFFER_SIZE){

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -42,7 +42,7 @@ CAMLprim value caml_record_backtrace(value vflag)
     Caml_state->backtrace_active = flag;
     Caml_state->backtrace_pos = 0;
     if (flag) {
-      Caml_state->backtrace_last_exn = Val_unit;
+      caml_modify_generational_global_root(&Caml_state->backtrace_last_exn, Val_unit);
     } else {
       caml_remove_generational_global_root(&Caml_state->backtrace_last_exn);
     }

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -28,10 +28,6 @@
 #include "caml/fail.h"
 #include "caml/debugger.h"
 
-void caml_init_backtrace(void)
-{
-  caml_register_generational_global_root(&Caml_state->backtrace_last_exn);
-}
 
 /* Start or stop the backtrace machinery */
 CAMLprim value caml_record_backtrace(value vflag)

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -235,9 +235,9 @@ int caml_alloc_backtrace_buffer(void){
 
 void caml_stash_backtrace(value exn, value * sp, int reraise)
 {
-  if (exn != caml_read_root(Caml_state->backtrace_last_exn) || !reraise) {
+  if (exn != Caml_state->backtrace_last_exn || !reraise) {
     Caml_state->backtrace_pos = 0;
-    caml_modify_root(Caml_state->backtrace_last_exn, exn);
+    caml_modify_generational_global_root(&Caml_state->backtrace_last_exn, exn);
   }
 
   if (Caml_state->backtrace_buffer == NULL &&

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -79,9 +79,9 @@ void caml_stash_backtrace(value exn, uintnat pc, char * sp, char* trapsp)
   caml_domain_state* domain_state = Caml_state;
   caml_frame_descrs fds;
 
-  if (exn != caml_read_root(domain_state->backtrace_last_exn)) {
+  if (exn != domain_state->backtrace_last_exn) {
     domain_state->backtrace_pos = 0;
-    caml_modify_root(domain_state->backtrace_last_exn, exn);
+    caml_modify_generational_global_root(&domain_state->backtrace_last_exn, exn);
   }
 
   if (Caml_state->backtrace_buffer == NULL &&

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -260,7 +260,7 @@ CAMLexport value caml_callbackN (value closure, int narg, value args[])
 /* Naming of OCaml values */
 
 struct named_value {
-  caml_root val;
+  value val;
   struct named_value * next;
   char name[1];
 };
@@ -292,7 +292,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
   caml_plat_lock(&named_value_lock);
   for (nv = named_value_table[h]; nv != NULL; nv = nv->next) {
     if (strcmp(name, nv->name) == 0) {
-      caml_modify_root(nv->val, val);
+      caml_modify_generational_global_root(&nv->val, val);
       found = 1;
       break;
     }
@@ -301,8 +301,9 @@ CAMLprim value caml_register_named_value(value vname, value val)
     nv = (struct named_value *)
       caml_stat_alloc(sizeof(struct named_value) + namelen);
     memcpy(nv->name, name, namelen + 1);
-    nv->val = caml_create_root(val);
+    nv->val = val;
     nv->next = named_value_table[h];
+    caml_register_generational_global_root(&nv->val);
     named_value_table[h] = nv;
   }
   caml_plat_unlock(&named_value_lock);
@@ -312,18 +313,17 @@ CAMLprim value caml_register_named_value(value vname, value val)
 CAMLexport const value* caml_named_value(char const *name)
 {
   struct named_value * nv;
-  caml_root ret = NULL;
   caml_plat_lock(&named_value_lock);
   for (nv = named_value_table[hash_value_name(name)];
        nv != NULL;
        nv = nv->next) {
     if (strcmp(name, nv->name) == 0){
-      ret = nv->val;
-      break;
+      caml_plat_unlock(&named_value_lock);
+      return &nv->val;
     }
   }
   caml_plat_unlock(&named_value_lock);
-  return Op_val(ret);
+  return NULL;
 }
 
 CAMLexport int caml_get_callback_depth ()

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -24,7 +24,6 @@
 
 #include "misc.h"
 
-typedef struct caml_root_private* caml_root;
 
 /* This structure sits in the TLS area and is also accessed efficiently
  * via native code, which is why the indices are important */

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -84,7 +84,7 @@ DOMAIN_STATE(intnat, backtrace_active)
 
 DOMAIN_STATE(code_t*, backtrace_buffer)
 
-DOMAIN_STATE(caml_root, backtrace_last_exn)
+DOMAIN_STATE(value, backtrace_last_exn)
 
 DOMAIN_STATE(intnat, compare_unordered)
 
@@ -113,7 +113,7 @@ DOMAIN_STATE(struct pool**, pools_to_rescan)
 DOMAIN_STATE(int, pools_to_rescan_len)
 DOMAIN_STATE(int, pools_to_rescan_count)
 
-DOMAIN_STATE(caml_root, dls_root)
+DOMAIN_STATE(value, dls_root)
 
 /*****************************************************************************/
 /* GC stats (see gc_ctrl.c and the Gc module) */

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -77,7 +77,7 @@ struct c_stack_link {
 #define NUM_STACK_SIZE_CLASSES 5
 
 /* The table of global identifiers */
-extern caml_root caml_global_data;
+extern value caml_global_data;
 
 #define Trap_pc(tp) ((tp)[0])
 #define Trap_link(tp) ((tp)[1])

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -565,26 +565,6 @@ struct caml__roots_block {
 
 #define End_roots() CAML_LOCAL_ROOTS = caml__roots_block.next; }
 
-/* [caml_create_root] creates a new GC root, initialised to the given
-   value.  The value stored in this root may only be read and written
-   with [caml_read_root] and [caml_modify_root]. */
-
-CAMLextern caml_root caml_create_root (value);
-CAMLextern caml_root caml_create_root_noexc(value);
-
-/* [caml_delete_root] deletes a root created by caml_create_root */
-
-CAMLextern void caml_delete_root (caml_root);
-
-/* [caml_read_root] loads the value stored in a root */
-
-CAMLextern value caml_read_root (caml_root);
-
-/* [caml_modify_root] stores a new value in a root */
-
-CAMLextern void caml_modify_root (caml_root, value);
-
-
 /** Compatability with old C-API **/
 
 /* [caml_register_global_root] registers a global C variable as a memory root

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -33,7 +33,7 @@
 int caml_debugger_in_use = 0;
 uintnat caml_event_count;
 int caml_debugger_fork_mode = 1; /* parent by default */
-caml_root marshal_flags;
+value marshal_flags = Val_emptylist;
 
 #if !defined(HAS_SOCKETS) || defined(NATIVE_CODE)
 
@@ -175,13 +175,12 @@ void caml_debugger_init(void)
   size_t a_len;
   char * port, * p;
   struct hostent * host;
-  value flags;
   int n;
 
-  flags = caml_alloc(2, Tag_cons);
-  Store_field(flags, 0, Val_int(1)); /* Marshal.Closures */
-  Store_field(flags, 1, Val_emptylist);
-  marshal_flags = caml_create_root(flags);
+  caml_register_generational_global_root(&marshal_flags);
+  marshal_flags = caml_alloc(2, Tag_cons);
+  Store_field(marshal_flags, 0, Val_int(1)); /* Marshal.Closures */
+  Store_field(marshal_flags, 1, Val_emptylist);
 
   a = caml_secure_getenv(T("CAML_DEBUG_SOCKET"));
   address = a ? caml_stat_strdup_of_os(a) : NULL;
@@ -266,7 +265,7 @@ static void safe_output_value(struct channel *chan, value val)
   saved_external_raise = Caml_state->external_raise;
   if (sigsetjmp(raise_buf.buf, 0) == 0) {
     Caml_state->external_raise = &exception_ctx;
-    caml_output_val(chan, val, caml_read_root(marshal_flags));
+    caml_output_val(chan, val, marshal_flags);
   } else {
     /* Send wrong magic number, will cause [caml_input_value] to fail */
     caml_really_putblock(chan, "\000\000\000\000", 4);
@@ -537,7 +536,7 @@ void caml_debugger(enum event_kind event, value param)
       break;
     case REQ_GET_GLOBAL:
       i = caml_getword(dbg_in);
-      putval(dbg_out, Field(caml_read_root(caml_global_data), i));
+      putval(dbg_out, Field(caml_global_data, i));
       caml_flush(dbg_out);
       break;
     case REQ_GET_ACCU:

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -290,6 +290,9 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
     }
 
     domain_state->backtrace_buffer = NULL;
+    domain_state->backtrace_last_exn = Val_unit;
+    caml_register_generational_global_root(&domain_state->backtrace_last_exn);
+
 #ifndef NATIVE_CODE
     domain_state->external_raise = NULL;
     domain_state->trap_sp_off = 1;
@@ -1272,6 +1275,7 @@ static void domain_terminate()
   }
   caml_sample_gc_collect(domain_state);
   caml_remove_generational_global_root(&domain_state->dls_root);
+  caml_remove_generational_global_root(&domain_state->backtrace_last_exn);
 
   caml_stat_free(domain_state->final_info);
   // run the domain termination hook

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -530,6 +530,8 @@ static void* domain_thread_func(void* v)
                 domain_self->interruptor.unique_id);
     caml_domain_start_hook();
     caml_callback(*domain_callback, Val_unit);
+    caml_remove_generational_global_root(domain_callback);
+    caml_stat_free(domain_callback);
     domain_terminate();
   } else {
     caml_gc_log("Failed to create domain");
@@ -1224,7 +1226,6 @@ static void domain_terminate()
 
   caml_gc_log("Domain terminating");
   caml_ev_pause(EV_PAUSE_YIELD);
-  caml_remove_generational_global_root(&domain_state->dls_root);
   s->terminating = 1;
 
   while (!finished) {
@@ -1270,6 +1271,7 @@ static void domain_terminate()
     caml_plat_unlock(&s->lock);
   }
   caml_sample_gc_collect(domain_state);
+  caml_remove_generational_global_root(&domain_state->dls_root);
 
   caml_stat_free(domain_state->final_info);
   // run the domain termination hook

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -101,7 +101,7 @@ CAMLexport void caml_raise_with_string(value tag, char const *msg)
 */
 static void check_global_data(char const *exception_name)
 {
-  if (caml_global_data == 0 || !Is_block(caml_read_root(caml_global_data))) {
+  if (caml_global_data == 0 || !Is_block(caml_global_data)) {
     fprintf(stderr, "Fatal error: exception %s during initialisation\n", exception_name);
     exit(2);
   }
@@ -109,7 +109,7 @@ static void check_global_data(char const *exception_name)
 
 static void check_global_data_param(char const *exception_name, char const *msg)
 {
-  if (caml_global_data == 0 || !Is_block(caml_read_root(caml_global_data))) {
+  if (caml_global_data == 0 || !Is_block(caml_global_data)) {
     fprintf(stderr, "Fatal error: exception %s(\"%s\")\n", exception_name, msg);
     exit(2);
   }
@@ -118,7 +118,7 @@ static void check_global_data_param(char const *exception_name, char const *msg)
 static inline value caml_get_failwith_tag (char const *msg)
 {
   check_global_data_param("Failure", msg);
-  return Field(caml_read_root(caml_global_data), FAILURE_EXN);
+  return Field(caml_global_data, FAILURE_EXN);
 }
 
 CAMLexport void caml_failwith (char const *msg)
@@ -137,7 +137,7 @@ CAMLexport void caml_failwith_value (value msg)
 static inline value caml_get_invalid_argument_tag (char const *msg)
 {
   check_global_data_param("Invalid_argument", msg);
-  return Field(caml_read_root(caml_global_data), INVALID_EXN);
+  return Field(caml_global_data, INVALID_EXN);
 }
 
 CAMLexport void caml_invalid_argument (char const *msg)
@@ -161,56 +161,56 @@ CAMLexport void caml_array_bound_error(void)
 CAMLexport void caml_raise_out_of_memory(void)
 {
   check_global_data("Out_of_memory");
-  caml_raise_constant(Field(caml_read_root(caml_global_data),
+  caml_raise_constant(Field(caml_global_data,
                                 OUT_OF_MEMORY_EXN));
 }
 
 CAMLexport void caml_raise_stack_overflow(void)
 {
   check_global_data("Stack_overflow");
-  caml_raise_constant(Field(caml_read_root(caml_global_data),
+  caml_raise_constant(Field(caml_global_data,
                                 STACK_OVERFLOW_EXN));
 }
 
 CAMLexport void caml_raise_sys_error(value msg)
 {
   check_global_data_param("Sys_error", String_val(msg));
-  caml_raise_with_arg(Field(caml_read_root(caml_global_data),
+  caml_raise_with_arg(Field(caml_global_data,
                                 SYS_ERROR_EXN), msg);
 }
 
 CAMLexport void caml_raise_end_of_file(void)
 {
   check_global_data("End_of_file");
-  caml_raise_constant(Field(caml_read_root(caml_global_data),
+  caml_raise_constant(Field(caml_global_data,
                                 END_OF_FILE_EXN));
 }
 
 CAMLexport void caml_raise_zero_divide(void)
 {
   check_global_data("Division_by_zero");
-  caml_raise_constant(Field(caml_read_root(caml_global_data),
+  caml_raise_constant(Field(caml_global_data,
                                 ZERO_DIVIDE_EXN));
 }
 
 CAMLexport void caml_raise_not_found(void)
 {
   check_global_data("Not_found");
-  caml_raise_constant(Field(caml_read_root(caml_global_data),
+  caml_raise_constant(Field(caml_global_data,
                                 NOT_FOUND_EXN));
 }
 
 CAMLexport void caml_raise_sys_blocked_io(void)
 {
   check_global_data("Sys_blocked_io");
-  caml_raise_constant(Field(caml_read_root(caml_global_data),
+  caml_raise_constant(Field(caml_global_data,
                                 SYS_BLOCKED_IO));
 }
 
 CAMLexport void caml_raise_continuation_already_taken(void)
 {
   check_global_data("Continuation_already_taken");
-  caml_raise_constant(Field(caml_read_root(caml_global_data),
+  caml_raise_constant(Field(caml_global_data,
                                 CONTINUATION_ALREADY_TAKEN_EXN));
 }
 
@@ -228,11 +228,11 @@ int caml_is_special_exception(value exn) {
 
   value f;
 
-  if (caml_global_data == 0 || !Is_block(caml_read_root(caml_global_data))) {
+  if (caml_global_data == 0 || !Is_block(caml_global_data)) {
     return 0;
   }
 
-  f = caml_read_root(caml_global_data);
+  f = caml_global_data;
   return exn == Field(f, MATCH_FAILURE_EXN)
       || exn == Field(f, ASSERT_FAILURE_EXN)
       || exn == Field(f, UNDEFINED_RECURSIVE_MODULE_EXN);

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -227,7 +227,7 @@ void caml_maybe_expand_stack ()
 
 #else /* End NATIVE_CODE, begin BYTE_CODE */
 
-caml_root caml_global_data;
+value caml_global_data;
 
 CAMLprim value caml_alloc_stack(value hval, value hexn, value heff)
 {

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -25,56 +25,6 @@
 
 static caml_plat_mutex roots_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 
-/* legacy multicore API that we need to fix */
-CAMLexport caml_root caml_create_root(value init)
-{
-  CAMLparam1(init);
-
-  value* v = (value*)caml_stat_alloc(sizeof(value));
-
-  *v = init;
-
-  caml_register_global_root(v);
-
-  CAMLreturnT(caml_root, (caml_root)v);
-}
-
-CAMLexport caml_root caml_create_root_noexc(value init)
-{
-  CAMLparam1(init);
-
-  value* v = (value*)caml_stat_alloc_noexc(sizeof(value));
-
-  if( v == NULL ) {
-    CAMLdrop;
-    return NULL;
-  }
-
-  *v = init;
-
-  caml_register_global_root(v);
-
-  CAMLreturnT(caml_root, (caml_root)v);
-}
-
-CAMLexport void caml_delete_root(caml_root root)
-{
-  value* v = (value*)root;
-  Assert(root);
-  /* the root will be removed from roots_all and freed at the next GC */
-  caml_remove_global_root(v);
-  caml_stat_free(v);
-}
-
-CAMLexport value caml_read_root(caml_root root)
-{
-  return *((value*)root);
-}
-
-CAMLexport void caml_modify_root(caml_root root, value newv)
-{
-  *((value*)root) = newv;
-}
 
 /* The three global root lists.
    Each is represented by a skip list with the key being the address

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -276,6 +276,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
     raise_unhandled = raise_unhandled_closure;
     caml_register_generational_global_root(&raise_unhandled);
     caml_global_data = Val_unit;
+    caml_register_generational_global_root(&caml_global_data);
     caml_init_callbacks();
     return Val_unit;
   }
@@ -707,12 +708,14 @@ value caml_interprete(code_t prog, asize_t prog_size)
       Next;
     }
 
-    Instruct(SETGLOBAL):
-      caml_modify_field(caml_global_data, *pc, accu);
+    Instruct(SETGLOBAL):{
+      value global_data = caml_global_data;
+      caml_modify_field(global_data, *pc, accu);
+      caml_modify_generational_global_root(&caml_global_data, global_data);
       accu = Val_unit;
       pc++;
       Next;
-
+    }
 /* Allocation of blocks */
 
     Instruct(PUSHATOM0):

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -39,7 +39,7 @@
 
 CAMLprim value caml_get_global_data(value unit)
 {
-  return caml_read_root(caml_global_data);
+  return caml_global_data;
 }
 
 CAMLprim value caml_get_section_table(value unit)
@@ -166,7 +166,7 @@ CAMLprim value caml_realloc_global(value size)
   CAMLparam1(size);
   CAMLlocal2(old_global_data, new_global_data);
   mlsize_t requested_size, actual_size, i;
-  old_global_data = caml_read_root(caml_global_data);
+  old_global_data = caml_global_data;
 
   requested_size = Long_val(size);
   actual_size = Wosize_val(old_global_data);
@@ -181,7 +181,7 @@ CAMLprim value caml_realloc_global(value size)
     for (i = actual_size; i < requested_size; i++){
       caml_initialize_field(new_global_data, i, Val_long(0));
     }
-    caml_modify_root(caml_global_data, new_global_data);
+    caml_modify_generational_global_root(&caml_global_data, new_global_data);
   }
   CAMLreturn (Val_unit);
 }

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -129,10 +129,11 @@ void caml_free_signal_stack()
 
 /* Execute a signal handler immediately */
 
-static caml_root caml_signal_handlers;
+static value caml_signal_handlers = 0;
 
 void caml_init_signal_handling() {
-  caml_signal_handlers = caml_create_root(caml_alloc_shr(NSIG, 0));
+  caml_signal_handlers = caml_alloc_shr(NSIG, 0);
+  caml_register_generational_global_root(&caml_signal_handlers);
 }
 
 static void caml_execute_signal(int signal_number)
@@ -165,12 +166,12 @@ static void caml_execute_signal(int signal_number)
   if (caml_signal_handlers == 0) {
     res = caml_sys_exit(Val_int(2));
   } else {
-    caml_read_field(caml_read_root(caml_signal_handlers), signal_number, &handler);
+    caml_read_field(caml_signal_handlers, signal_number, &handler);
     if (!Is_block(handler)) {
       res = caml_sys_exit(Val_int(2));
     } else {
 #else
-  caml_read_field(caml_read_root(caml_signal_handlers), signal_number, &handler);
+  caml_read_field(caml_signal_handlers, signal_number, &handler);
 #endif
   res = caml_callback_exn(
            handler,
@@ -329,14 +330,14 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
     res = Val_int(1);
     break;
   case 2:                       /* was Signal_handle */
-    caml_read_field(caml_read_root(caml_signal_handlers), sig, &handler);
+    caml_read_field(caml_signal_handlers, sig, &handler);
     res = caml_alloc_1 (0, handler);
     break;
   default:                      /* error in caml_set_signal_action */
     caml_sys_error(NO_ARG);
   }
   if (Is_block(action)) {
-    caml_modify_field(caml_read_root(caml_signal_handlers), sig, Field(action, 0));
+    caml_modify_field(caml_signal_handlers, sig, Field(action, 0));
   }
   caml_process_pending_signals();
   CAMLreturn (res);

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -337,7 +337,9 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
     caml_sys_error(NO_ARG);
   }
   if (Is_block(action)) {
-    caml_modify_field(caml_signal_handlers, sig, Field(action, 0));
+    value signal_handlers = caml_signal_handlers;
+    caml_modify_field(signal_handlers, sig, Field(action, 0));
+    caml_modify_generational_global_root(&caml_signal_handlers, signal_handlers);
   }
   caml_process_pending_signals();
   CAMLreturn (res);

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -355,7 +355,7 @@ CAMLexport void caml_main(char_os **argv)
   /* Load the globals */
   caml_seek_section(fd, &trail, "DATA");
   chan = caml_open_descriptor_in(fd);
-  caml_modify_root(caml_global_data, caml_input_val(chan));
+  caml_modify_generational_global_root(&caml_global_data, caml_input_val(chan));
   caml_close_channel(chan); /* this also closes fd */
   caml_stat_free(trail.section);
   /* Initialize system libraries */
@@ -435,7 +435,7 @@ CAMLexport value caml_startup_code_exn(
   /* Use the builtin table of primitives */
   caml_build_primitive_table_builtin();
   /* Load the globals */
-  caml_modify_root(caml_global_data, caml_input_value_from_block(data, data_size));
+  caml_modify_generational_global_root(&caml_global_data, caml_input_value_from_block(data, data_size));
   caml_minor_collection(); /* ensure all globals are in major heap */
   /* Record the sections (for caml_get_section_table in meta.c) */
   caml_init_section_table(section_table, section_table_size);

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -334,7 +334,10 @@ CAMLexport void caml_main(char_os **argv)
   /* Initialize the abstract machine */
   caml_init_gc ();
   Caml_state->external_raise = NULL;
-  if (caml_params->backtrace_enabled_init) caml_record_backtrace(Val_int(1));
+  if (caml_params->backtrace_enabled_init){
+    caml_init_backtrace();
+    caml_record_backtrace(Val_int(1));
+  }
   /* Initialize the interpreter */
   caml_interprete(NULL, 0);
   /* Initialize the debugger, if needed */
@@ -418,7 +421,10 @@ CAMLexport value caml_startup_code_exn(
   if (exe_name == NULL) exe_name = caml_search_exe_in_path(argv[0]);
   Caml_state->external_raise = NULL;
   caml_sys_init(exe_name, argv);
-  if (caml_params->backtrace_enabled_init) caml_record_backtrace(Val_int(1));
+  if (caml_params->backtrace_enabled_init){
+    caml_init_backtrace();
+    caml_record_backtrace(Val_int(1));
+  }
   Caml_state->external_raise = NULL;
   /* Initialize the interpreter */
   caml_interprete(NULL, 0);

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -334,10 +334,7 @@ CAMLexport void caml_main(char_os **argv)
   /* Initialize the abstract machine */
   caml_init_gc ();
   Caml_state->external_raise = NULL;
-  if (caml_params->backtrace_enabled_init){
-    caml_init_backtrace();
-    caml_record_backtrace(Val_int(1));
-  }
+  if (caml_params->backtrace_enabled_init) caml_record_backtrace(Val_int(1));
   /* Initialize the interpreter */
   caml_interprete(NULL, 0);
   /* Initialize the debugger, if needed */
@@ -421,10 +418,7 @@ CAMLexport value caml_startup_code_exn(
   if (exe_name == NULL) exe_name = caml_search_exe_in_path(argv[0]);
   Caml_state->external_raise = NULL;
   caml_sys_init(exe_name, argv);
-  if (caml_params->backtrace_enabled_init){
-    caml_init_backtrace();
-    caml_record_backtrace(Val_int(1));
-  }
+  if (caml_params->backtrace_enabled_init) caml_record_backtrace(Val_int(1));
   Caml_state->external_raise = NULL;
   /* Initialize the interpreter */
   caml_interprete(NULL, 0);

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -116,8 +116,10 @@ value caml_startup_common(char_os **argv, int pooling)
   caml_init_custom_operations();
   caml_init_gc ();
 
-  if (caml_params->backtrace_enabled_init)
+  if (caml_params->backtrace_enabled_init){
+    caml_init_backtrace();
     caml_record_backtrace(Val_int(1));
+  }
 
   init_segments();
   caml_init_signals();

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -116,10 +116,7 @@ value caml_startup_common(char_os **argv, int pooling)
   caml_init_custom_operations();
   caml_init_gc ();
 
-  if (caml_params->backtrace_enabled_init){
-    caml_init_backtrace();
-    caml_record_backtrace(Val_int(1));
-  }
+  if (caml_params->backtrace_enabled_init) caml_record_backtrace(Val_int(1));
 
   init_segments();
   caml_init_signals();

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -382,7 +382,7 @@ CAMLprim value caml_sys_getenv(value var)
   return val;
 }
 
-static caml_root main_argv;
+static value main_argv;
 
 CAMLprim value caml_sys_get_argv(value unit)
 {
@@ -390,19 +390,19 @@ CAMLprim value caml_sys_get_argv(value unit)
   CAMLlocal2 (exe_name, res);
   exe_name = caml_copy_string_of_os(caml_params->exe_name);
   res = caml_alloc_small(2, 0);
-  caml_initialize_field(res, 0, exe_name);
-  caml_initialize_field(res, 1, caml_read_root(main_argv));
+  Field(res, 0) = exe_name;
+  Field(res, 1) = main_argv;
   CAMLreturn(res);
 }
 
 CAMLprim value caml_sys_argv(value unit)
 {
-  return caml_read_root(main_argv);
+  return main_argv;
 }
 
 CAMLprim value caml_sys_modify_argv(value new_argv)
 {
-  caml_modify_root(main_argv, new_argv);
+  caml_modify_generational_global_root(&main_argv, new_argv);
   return Val_unit;
 }
 
@@ -425,7 +425,8 @@ void caml_sys_init(char_os * exe_name, char_os **argv)
   caml_init_exe_name(exe_name);
   v = caml_alloc_array((void *)caml_copy_string_of_os,
                        (char const **) argv);
-  main_argv = caml_create_root(v);
+  main_argv = v;
+  caml_register_generational_global_root(&main_argv);
 }
 
 #ifdef _WIN32


### PR DESCRIPTION
This is another attempt at removing the now obsolete `caml_root` API. This PR supersedes #459 which had some pending items.

`caml_root` variables are now changed to `value` type and managed as generational global roots. This patch tries to stay close to trunk on the variables that are common to both trunk and multicore runtime. Checking off one of the items in #424.