### PR TITLE
Make the implementation of lazy aware of safe points.

### DIFF
--- a/testsuite/tests/backtrace/lazy.reference
+++ b/testsuite/tests/backtrace/lazy.reference
@@ -2,13 +2,13 @@ Uncaught exception Not_found
 Raised at Lazy.l1 in file "lazy.ml", line 8, characters 28-45
 Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 39, characters 17-27
 Re-raised at CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 45, characters 4-11
-Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml" (inlined), line 83, characters 27-67
+Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml" (inlined), line 92, characters 27-67
 Called from Lazy.test1 in file "lazy.ml", line 11, characters 11-24
 Called from Lazy.run in file "lazy.ml", line 20, characters 4-11
 Uncaught exception Not_found
 Raised at Lazy.l2 in file "lazy.ml", line 13, characters 28-45
 Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 39, characters 17-27
 Re-raised at CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 45, characters 4-11
-Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml" (inlined), line 83, characters 27-67
+Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml" (inlined), line 92, characters 27-67
 Called from Lazy.test2 in file "lazy.ml", line 16, characters 6-15
 Called from Lazy.run in file "lazy.ml", line 20, characters 4-11


### PR DESCRIPTION
The introduction of safe points at function entry may cause GC to run,
which may short circuit lazy values. This commit removes an assumption
about the structure of the lazy value `update_tag_forcing` and makes it
handle the possibility of GC running in the function prologue.

Fixes #483.