### PR TITLE
Fix problems with finaliser orphaning (issue468)

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -257,6 +257,7 @@ void caml_adopt_orphaned_work ()
     CAMLassert (caml_gc_phase == Phase_sweep_and_mark_main);
     if (f->todo_head) {
       if (myf->todo_tail == NULL) {
+        CAMLassert(myf->todo_head == NULL);
         myf->todo_head = f->todo_head;
         myf->todo_tail = f->todo_tail;
       } else {

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -256,8 +256,13 @@ void caml_adopt_orphaned_work ()
     CAMLassert (!myf->updated_last);
     CAMLassert (caml_gc_phase == Phase_sweep_and_mark_main);
     if (f->todo_head) {
-      myf->todo_tail->next = f->todo_head;
-      myf->todo_tail = f->todo_tail;
+      if (myf->todo_tail == NULL) {
+        myf->todo_head = f->todo_head;
+        myf->todo_tail = f->todo_tail;
+      } else {
+        myf->todo_tail->next = f->todo_head;
+        myf->todo_tail = f->todo_tail;
+      }
     }
     if (f->first.young > 0) {
       caml_final_merge_finalisable (&f->first, &myf->first);

--- a/testsuite/tests/weak-ephe-final/issue468.ml
+++ b/testsuite/tests/weak-ephe-final/issue468.ml
@@ -1,0 +1,24 @@
+(* TEST *)
+
+let tree_size = try int_of_string Sys.argv.(1) with _ -> 9
+let iterations = try int_of_string Sys.argv.(2) with _ -> 1000
+let num_domains = try int_of_string Sys.argv.(3) with _ -> 4
+
+type 'a tree = Empty | Node of 'a tree * 'a tree
+
+let rec make d =
+  if d = 0 then Node(Empty, Empty)
+  else let d = d - 1 in Node(make d, make d)
+
+let rec check = function Empty -> 0 | Node(l, r) -> 1 + check l + check r
+
+let work () =
+  for _ = 0 to iterations do
+    let v = make tree_size in
+    Gc.finalise (fun v -> ignore @@ check v) v
+  done
+
+let _ =
+  let domains = Array.init (num_domains - 1) (fun _ -> Domain.spawn(work)) in
+  work ();
+  Array.iter Domain.join domains

--- a/testsuite/tests/weak-ephe-final/issue468.ml
+++ b/testsuite/tests/weak-ephe-final/issue468.ml
@@ -1,7 +1,7 @@
 (* TEST *)
 
 let tree_size = try int_of_string Sys.argv.(1) with _ -> 9
-let iterations = try int_of_string Sys.argv.(2) with _ -> 1000
+let iterations = try int_of_string Sys.argv.(2) with _ -> 500
 let num_domains = try int_of_string Sys.argv.(3) with _ -> 4
 
 type 'a tree = Empty | Node of 'a tree * 'a tree
@@ -19,6 +19,9 @@ let work () =
   done
 
 let _ =
-  let domains = Array.init (num_domains - 1) (fun _ -> Domain.spawn(work)) in
-  work ();
-  Array.iter Domain.join domains
+  for _ = 0 to 5 do
+    let domains = Array.init (num_domains - 1) (fun _ -> Domain.spawn(work)) in
+    let v = make tree_size in
+    ignore @@ check v;
+    Array.iter Domain.join domains
+  done


### PR DESCRIPTION
This PR fixes #468 which has two bugs in how we merge finalisation tables when picking up orphaned finaliser work.

The previous code used the incorrect field (`source->young`) for doing a `memmove` of `target`. We also didn't check that we had a valid `todo_tail` in our domain to append finalisers onto. 