### PR TITLE
Replace caml_initialize_field with caml_initialize

### DIFF
--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -747,8 +747,8 @@ let addr_array_set arr ofs newval dbg =
   Cop(Cextcall("caml_modify_field", typ_void, [], false),
       [arr; untag_int ofs dbg; newval], dbg)
 let addr_array_initialize arr ofs newval dbg =
-  Cop(Cextcall("caml_initialize_field", typ_void, [], false),
-      [arr; untag_int ofs dbg; newval], dbg)
+  Cop(Cextcall("caml_initialize", typ_void, [], false),
+      [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
 let int_array_set arr ofs newval dbg =
   Cop(Cstore (Word_int, Lambda.Assignment),
     [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
@@ -820,8 +820,8 @@ let make_alloc_generic set_fn dbg tag wordsize args =
 
 let make_alloc dbg tag args =
   let addr_array_init arr ofs newval dbg =
-    Cop(Cextcall("caml_initialize_field", typ_void, [], false),
-        [arr; untag_int ofs dbg; newval], dbg)
+    Cop(Cextcall("caml_initialize", typ_void, [], false),
+        [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
   in
   make_alloc_generic addr_array_init dbg tag (List.length args) args
 
@@ -2202,8 +2202,8 @@ let setfield n ptr init arg1 arg2 dbg =
              dbg))
   | Caml_initialize ->
       return_unit dbg
-        (Cop(Cextcall("caml_initialize_field", typ_void, [], false),
-             [arg1; Cconst_int (n, dbg); arg2],
+        (Cop(Cextcall("caml_initialize", typ_void, [], false),
+             [field_address arg1 n dbg; arg2],
              dbg))
   | Simple ->
       return_unit dbg (set_field arg1 n arg2 init dbg)

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -188,8 +188,7 @@ CAMLprim value caml_get_exception_raw_backtrace(value unit)
 
     res = caml_alloc(saved_caml_backtrace_pos, 0);
     for (i = 0; i < saved_caml_backtrace_pos; i++) {
-      caml_initialize_field(res, i,
-        Val_backtrace_slot(saved_caml_backtrace_buffer[i]));
+      caml_initialize(&Field(res, i), Val_backtrace_slot(saved_caml_backtrace_buffer[i]));
     }
   }
 

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -54,8 +54,6 @@ CAMLextern void caml_free_dependent_memory (mlsize_t);
 CAMLextern void caml_modify_field (value, intnat, value);
 #define caml_modify_field caml_modify_field
 CAMLextern int caml_atomic_cas_field (value, intnat, value, value);
-CAMLextern void caml_initialize_field (value, intnat, value);
-#define caml_initialize_field caml_initialize_field
 CAMLextern void caml_blit_fields (value src, int srcoff, value dst, int dstoff, int n);
 CAMLextern value caml_check_urgent_gc (value);
 #ifdef CAML_INTERNALS

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -734,12 +734,12 @@ value caml_interprete(code_t prog, asize_t prog_size)
       } else {
         block = caml_alloc_shr(wosize, tag);
         Setup_for_c_call;
-        caml_initialize_field(block, 0, accu);
+        caml_initialize(&Field(block, 0), accu);
         Restore_after_c_call;
         for (i = 1; i < wosize; i++) {
           value v = *sp++;
           Setup_for_c_call;
-          caml_initialize_field(block, i, v);
+          caml_initialize(&Field(block, i), v);
           Restore_after_c_call;
         }
       }

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -179,9 +179,6 @@ CAMLexport CAMLweakdef void caml_modify (value *fp, value val)
                         memory_order_release);
 }
 
-/* Compatability with old C-API
-   bit of a HACK as less Assert possible here
- */
 CAMLexport CAMLweakdef void caml_initialize (value *fp, value val)
 {
 #ifdef DEBUG

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -179,31 +179,12 @@ CAMLexport CAMLweakdef void caml_modify (value *fp, value val)
                         memory_order_release);
 }
 
-CAMLexport void caml_initialize_field (value obj, intnat field, value val)
-{
-  Assert(Is_block(obj));
-  Assert(0 <= field && field < Wosize_val(obj));
-#ifdef DEBUG
-  /* caml_initialize_field can only be used on just-allocated objects */
-  if (Is_young(obj))
-    Assert(Op_val(obj)[field] == Debug_uninit_minor ||
-           Op_val(obj)[field] == Val_unit);
-  else
-    Assert(Op_val(obj)[field] == Debug_uninit_major ||
-           Op_val(obj)[field] == Val_unit);
-#endif
-
-  write_barrier(obj, field, Op_val(obj)[field], val);
-  Op_val(obj)[field] = val;
-}
-
 /* Compatability with old C-API
    bit of a HACK as less Assert possible here
  */
 CAMLexport CAMLweakdef void caml_initialize (value *fp, value val)
 {
 #ifdef DEBUG
-  /* caml_initialize_field can only be used on just-allocated objects */
   if (Is_young((value)fp))
     Assert(*fp == Debug_uninit_minor ||
            *fp == Val_unit);

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -424,8 +424,8 @@ CAMLprim value caml_sys_get_argv(value unit)
   CAMLlocal2 (exe_name, res);
   exe_name = caml_copy_string_of_os(caml_params->exe_name);
   res = caml_alloc_small(2, 0);
-  caml_initialize_field(res, 0, exe_name);
-  caml_initialize_field(res, 1, caml_read_root(main_argv));
+  caml_initialize(&Field(res, 0), exe_name);
+  caml_initialize(&Field(res, 1), caml_read_root(main_argv));
   CAMLreturn(res);
 }
 

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -248,7 +248,7 @@ static value ephe_get_field (value e, mlsize_t offset)
     elt = Op_val(e)[offset];
     caml_darken (0, elt, 0);
     res = caml_alloc_shr (1, Some_tag);
-    caml_initialize_field(res, 0, elt);
+    caml_initialize(&Field(res, 0), elt);
   }
   CAMLreturn (res);
 }
@@ -300,7 +300,7 @@ static value ephe_get_field_copy (value e, mlsize_t offset)
     Op_val(e)[offset] = elt = v;
   }
   res = caml_alloc_shr (1, Some_tag);
-  caml_initialize_field(res, 0, elt);
+  caml_initialize(&Field(res, 0), elt);
   CAMLreturn(res);
 }
 


### PR DESCRIPTION
This patch replaces `caml_initialize_field` - one of the leftover items from concurrent minor collector that are no longer necessary, with `caml_initialize`.

Note: Some minor conflicts may arise with #488, I shall rebase on top of whichever is landed first.