### PR TITLE
Fix backtrace unwind

### DIFF
--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -55,6 +55,7 @@ static frame_descr * caml_next_frame_descriptor(caml_frame_descrs fds, uintnat *
         *pc = 0;
         return NULL;
       }
+      *pc = **(uintnat**)sp;
       *sp += sizeof(value); /* return address */
     }
   }

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -61,10 +61,6 @@ lib-systhreads-todo
 tests/lib-unix/kill/'unix_kill.ml' with 1.1 (bytecode)
 tests/lib-unix/kill/'unix_kill.ml' with 1.2 (native)
 
-# TODO: finaliser issue (#385)
-tests/backtrace/'callstack.ml' with 1.1.2 (bytecode)
-tests/backtrace/'callstack.ml' with 1.1.1 (native)
-
 # TODO: off-by-one error on MacOS+Clang (#408)
 tests/lib-threads/'beat.ml' with 1.2 (native)
 tests/lib-threads/'beat.ml' with 1.1 (bytecode)

--- a/testsuite/tests/backtrace/backtrace_c_exn.ml
+++ b/testsuite/tests/backtrace/backtrace_c_exn.ml
@@ -4,15 +4,17 @@
    ocamlrunparam += ",b=1"
 *)
 
-(* A test for stack backtraces *)
+(* https://github.com/ocaml-multicore/ocaml-multicore/issues/498 *)
 external stubbed_raise : unit -> unit = "caml_498_raise"
 
 let raise_exn () = failwith "exn"
+
 let () = Callback.register "test_raise_exn" raise_exn
 
 let () =
   try
     stubbed_raise ()
   with
-  | exn -> Printexc.to_string exn |> print_endline
-
+  | exn ->
+    Printexc.to_string exn |> print_endline;
+    Printexc.print_backtrace stdout

--- a/testsuite/tests/backtrace/backtrace_c_exn.ml
+++ b/testsuite/tests/backtrace/backtrace_c_exn.ml
@@ -1,0 +1,18 @@
+(* TEST
+   modules = "backtrace_c_exn_.c"
+   flags = "-g"
+   ocamlrunparam += ",b=1"
+*)
+
+(* A test for stack backtraces *)
+external stubbed_raise : unit -> unit = "caml_498_raise"
+
+let raise_exn () = failwith "exn"
+let () = Callback.register "test_raise_exn" raise_exn
+
+let () =
+  try
+    stubbed_raise ()
+  with
+  | exn -> Printexc.to_string exn |> print_endline
+

--- a/testsuite/tests/backtrace/backtrace_c_exn.reference
+++ b/testsuite/tests/backtrace/backtrace_c_exn.reference
@@ -1,1 +1,2 @@
 Failure("exn")
+Raised by primitive operation at Backtrace_c_exn in file "backtrace_c_exn.ml", line 16, characters 4-20

--- a/testsuite/tests/backtrace/backtrace_c_exn.reference
+++ b/testsuite/tests/backtrace/backtrace_c_exn.reference
@@ -1,0 +1,1 @@
+Failure("exn")

--- a/testsuite/tests/backtrace/backtrace_c_exn_.c
+++ b/testsuite/tests/backtrace/backtrace_c_exn_.c
@@ -1,0 +1,14 @@
+#include <caml/callback.h>
+#include <caml/memory.h>
+
+void caml_498_raise(void) {
+    CAMLparam0 ();
+    const value *cl;
+
+    cl = caml_named_value("test_raise_exn");
+
+    if (cl != NULL)
+      caml_callback(*cl, Val_unit);
+
+    CAMLreturn0;
+}

--- a/testsuite/tests/backtrace/backtrace_dynlink.ml
+++ b/testsuite/tests/backtrace/backtrace_dynlink.ml
@@ -1,0 +1,42 @@
+(* TEST
+
+include dynlink
+
+files = "backtrace_dynlink_plugin.ml"
+
+libraries = ""
+
+* shared-libraries
+** native-dynlink
+*** setup-ocamlopt.byte-build-env
+**** ocamlopt.byte
+module = "backtrace_dynlink.ml"
+flags = "-g"
+**** ocamlopt.byte
+program = "backtrace_dynlink_plugin.cmxs"
+flags = "-shared -g"
+all_modules = "backtrace_dynlink_plugin.ml"
+**** ocamlopt.byte
+program = "${test_build_directory}/main.exe"
+libraries = "dynlink"
+all_modules = "backtrace_dynlink.cmx"
+***** run
+ocamlrunparam += ",b=1"
+****** check-program-output
+*)
+
+(* test for backtrace and stack unwinding with dynlib. *)
+(* https://github.com/ocaml-multicore/ocaml-multicore/issues/440 *)
+(* https://github.com/ocaml-multicore/ocaml-multicore/pull/499 *)
+
+let ()  =
+  Dynlink.allow_unsafe_modules true;
+  try
+    Dynlink.loadfile "backtrace_dynlink_plugin.cmxs"
+  with
+  | Dynlink.Error err ->
+     print_endline @@ Dynlink.error_message err;
+     Printexc.print_backtrace stdout;
+  | exn ->
+     Printexc.to_string exn |> print_endline;
+     print_endline "ERROR"

--- a/testsuite/tests/backtrace/backtrace_dynlink.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.reference
@@ -1,0 +1,18 @@
+Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
+Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
+Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 347, characters 13-44
+Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
+Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 345, characters 8-240
+Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 357, characters 26-45
+Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 35, characters 4-52
+execution of module initializers in the shared library failed: Failure("SUCCESS")
+Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
+Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 10-149
+Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 347, characters 13-44
+Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
+Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 345, characters 8-240
+Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 355, characters 8-17
+Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 357, characters 26-45
+Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 35, characters 4-52

--- a/testsuite/tests/backtrace/backtrace_dynlink_plugin.ml
+++ b/testsuite/tests/backtrace/backtrace_dynlink_plugin.ml
@@ -1,0 +1,8 @@
+let () =
+  try
+    failwith "SUCCESS"
+  with
+  | e ->
+     let c = Printexc.get_callstack 10 in
+     Printexc.print_raw_backtrace stdout c;
+     raise e

--- a/testsuite/tests/backtrace/callstack.ml
+++ b/testsuite/tests/backtrace/callstack.ml
@@ -18,8 +18,7 @@ let () = f3 ()
 
 let () = Printf.printf "from finalizer:\n"
 let () =
-  Gc.finalise (fun _ -> ( (* f0  *) ())) [|1|];
-  (* TODO: finalizer issue to fix, see Multicore issue #385 *)
+  Gc.finalise (fun _ -> f0 ()) [|1|];
   Gc.full_major ();
   ()
 


### PR DESCRIPTION
This PR fixes a discrepancy in `caml_next_frame_descriptor` where it was not correctly unwinding stacks over callbacks. It matches the unwind behaviour of `scan_stack_frames`.

Fixes #385. Fixes #498. 

Joint work with @Engil 