### PR TITLE
Replace caml_modify_field with caml_modify

### DIFF
--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -744,8 +744,8 @@ let float_array_ref arr ofs dbg =
   box_float dbg (unboxed_float_array_ref arr ofs dbg)
 
 let addr_array_set arr ofs newval dbg =
-  Cop(Cextcall("caml_modify_field", typ_void, [], false),
-      [arr; untag_int ofs dbg; newval], dbg)
+  Cop(Cextcall("caml_modify", typ_void, [], false),
+      [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
 let addr_array_initialize arr ofs newval dbg =
   Cop(Cextcall("caml_initialize_field", typ_void, [], false),
       [arr; untag_int ofs dbg; newval], dbg)
@@ -2197,9 +2197,9 @@ let setfield n ptr init arg1 arg2 dbg =
   match assignment_kind ptr init with
   | Caml_modify ->
       return_unit dbg
-        (Cop(Cextcall("caml_modify_field", typ_void, [], false),
-             [arg1; Cconst_int (n, dbg); arg2],
-             dbg))
+        (Cop(Cextcall("caml_modify", typ_void, [], false),
+            [field_address arg1 n dbg; arg2],
+            dbg))
   | Caml_initialize ->
       return_unit dbg
         (Cop(Cextcall("caml_initialize_field", typ_void, [], false),

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -425,8 +425,8 @@ static value st_encode_sigset(sigset_t * set)
     for (i = 1; i < NSIG; i++)
       if (sigismember(set, i) > 0) {
         value newcons = caml_alloc_small(2, 0);
-        caml_modify_field(newcons, 0, Val_int(caml_rev_convert_signal_number(i)));
-        caml_modify_field(newcons, 1, res);
+        caml_modify(&Field(newcons, 0), Val_int(caml_rev_convert_signal_number(i)));
+        caml_modify(&Field(newcons, 1), res);
         res = newcons;
       }
   End_roots();

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -111,7 +111,7 @@ CAMLprim value caml_array_set_addr(value array, value index, value newval)
 {
   intnat idx = Long_val(index);
   if (idx < 0 || idx >= Wosize_val(array)) caml_array_bound_error();
-  caml_modify_field(array, idx, newval);
+  caml_modify(&Field(array, idx), newval);
   return Val_unit;
 }
 
@@ -204,7 +204,7 @@ CAMLprim value caml_floatarray_unsafe_get(value array, value index)
 CAMLprim value caml_array_unsafe_set_addr(value array, value index,value newval)
 {
   intnat idx = Long_val(index);
-  caml_modify_field(array, idx, newval);
+  caml_modify(&Field(array, idx), newval);
   return Val_unit;
 }
 
@@ -387,7 +387,7 @@ CAMLprim value caml_array_blit(value a1, value ofs1, value a2, value ofs2,
 #endif
     CAMLassert (Tag_val(a2) != Double_array_tag);
     caml_blit_fields(a1, Long_val(ofs1), a2, Long_val(ofs2), Long_val(n));
-    /* Many caml_modify_field in a row can create a lot of old-to-young refs.
+    /* Many caml_modify in a row can create a lot of old-to-young refs.
         Give the minor GC a chance to run if it needs to. */
     caml_check_urgent_gc(Val_unit);
     return Val_unit;
@@ -541,7 +541,7 @@ CAMLprim value caml_array_fill(value array,
 #endif
   /* TODO: potential optimization by code duplication as in PR8716 */
   for (; len > 0; len--, ofs++) {
-    caml_modify_field(array, ofs, val);
+    caml_modify(&Field(array, ofs), val);
   }
   return Val_unit;
 }

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -51,8 +51,6 @@ CAMLextern value caml_alloc_shr_preserving_profinfo (mlsize_t, tag_t,
 CAMLextern value caml_alloc_shr_no_raise (mlsize_t wosize, tag_t);
 CAMLextern void caml_alloc_dependent_memory (mlsize_t);
 CAMLextern void caml_free_dependent_memory (mlsize_t);
-CAMLextern void caml_modify_field (value, intnat, value);
-#define caml_modify_field caml_modify_field
 CAMLextern int caml_atomic_cas_field (value, intnat, value, value);
 CAMLextern void caml_initialize_field (value, intnat, value);
 #define caml_initialize_field caml_initialize_field
@@ -470,7 +468,7 @@ struct caml__roots_block {
 #define Store_field(block, offset, val) do{ \
   mlsize_t caml__temp_offset = (offset); \
   value caml__temp_val = (val); \
-  caml_modify_field ((block), caml__temp_offset, caml__temp_val); \
+  caml_modify (&Field ((block), caml__temp_offset), caml__temp_val); \
 }while(0)
 
 /*

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -703,7 +703,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
     }
 
     Instruct(SETGLOBAL):
-      caml_modify_field(caml_read_root(caml_global_data), *pc, accu);
+      caml_modify(&Field(caml_read_root(caml_global_data), *pc), accu);
       accu = Val_unit;
       pc++;
       Next;
@@ -816,23 +816,23 @@ value caml_interprete(code_t prog, asize_t prog_size)
     }
 
     Instruct(SETFIELD0):
-      caml_modify_field(accu, 0, *sp++);
+      caml_modify(&Field(accu, 0), *sp++);
       accu = Val_unit;
       Next;
     Instruct(SETFIELD1):
-      caml_modify_field(accu, 1, *sp++);
+      caml_modify(&Field(accu, 1), *sp++);
       accu = Val_unit;
       Next;
     Instruct(SETFIELD2):
-      caml_modify_field(accu, 2, *sp++);
+      caml_modify(&Field(accu, 2), *sp++);
       accu = Val_unit;
       Next;
     Instruct(SETFIELD3):
-      caml_modify_field(accu, 3, *sp++);
+      caml_modify(&Field(accu, 3), *sp++);
       accu = Val_unit;
       Next;
     Instruct(SETFIELD):
-      caml_modify_field(accu, *pc, *sp++);
+      caml_modify(&Field(accu, *pc), *sp++);
       accu = Val_unit;
       pc++;
       Next;
@@ -859,7 +859,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       sp += 1;
       Next;
     Instruct(SETVECTITEM):
-      caml_modify_field(accu, Long_val(sp[0]), sp[1]);
+      caml_modify(&Field(accu, Long_val(sp[0])), sp[1]);
       accu = Val_unit;
       sp += 2;
       Next;
@@ -1159,7 +1159,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
     Instruct(OFFSETREF): {
         long n = Long_field(accu, 0);
         n += *pc;
-        caml_modify_field(accu, 0, Val_long(n));
+        caml_modify(&Field(accu, 0), Val_long(n));
       }
       accu = Val_unit;
       pc++;

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -96,7 +96,7 @@
    Using release stores for all writes also ensures publication safety
    for newly-allocated objects, and isn't necessary for initialising
    writes. The cost is free on x86, but requires a fence in
-   caml_modify_field on weakly-ordered architectures (ARM, Power).
+   caml_modify on weakly-ordered architectures (ARM, Power).
 
    However, instead of using acquire loads for all reads, an
    optimisation is possible. (Optimising reads is more important than

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -148,24 +148,6 @@ static void write_barrier(value obj, intnat field, value old_val, value new_val)
    }
 }
 
-CAMLexport void caml_modify_field (value obj, intnat field, value val)
-{
-  Assert (Is_block(obj));
-  Assert(field >= 0 && field < Wosize_val(obj));
-
-  write_barrier(obj, field, Op_val(obj)[field], val);
-#if defined(COLLECT_STATS) && defined(NATIVE_CODE)
-  Caml_state->mutable_stores++;
-#endif
-  /* See Note [MM] above */
-  atomic_thread_fence(memory_order_acquire);
-  atomic_store_explicit(&Op_atomic_val(obj)[field], val,
-                        memory_order_release);
-}
-
-/* Compatability with old C-API
-   bit of a HACK as less Assert possible here
- */
 CAMLexport CAMLweakdef void caml_modify (value *fp, value val)
 {
   write_barrier((value)fp, 0, *fp, val);
@@ -313,7 +295,7 @@ CAMLexport void caml_set_fields (value obj, value v)
   Assert (Is_block(obj));
 
   for (i = 0; i < Wosize_val(obj); i++) {
-    caml_modify_field(obj, i, v);
+    caml_modify(&Field(obj, i), v);
   }
 }
 
@@ -335,13 +317,13 @@ CAMLexport void caml_blit_fields (value src, int srcoff, value dst, int dstoff, 
     /* copy descending */
     for (i = n; i > 0; i--) {
       caml_read_field(src, srcoff + i - 1, &x);
-      caml_modify_field(dst, dstoff + i - 1, x);
+      caml_modify(&Field(dst, dstoff + i - 1), x);
     }
   } else {
     /* copy ascending */
     for (i = 0; i < n; i++) {
       caml_read_field(src, srcoff + i, &x);
-      caml_modify_field(dst, dstoff + i, x);
+      caml_modify(&Field(dst, dstoff + i), x);
     }
   }
   CAMLreturn0;

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -91,7 +91,7 @@ CAMLprim value caml_obj_set_raw_field(value arg, value pos, value bits)
 CAMLprim value caml_obj_make_forward (value blk, value fwd)
 {
   /* Modify field before setting tag */
-  caml_modify_field(blk, 0, fwd);
+  caml_modify(&Field(blk, 0), fwd);
 
   /* This function is only called on Lazy_tag objects. The only racy write to
    * this object is by the GC threads. */

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -173,14 +173,10 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
     RESTORE;
     if (Is_block(arg)) {
       env->curr_char = Val_int(Int_field(tables->transl_block, Tag_val(arg)));
-      caml_modify_field((value)env,
-                        offsetof(struct parser_env, lval) / sizeof(value),
-                        Field(arg, 0));
+      caml_modify(&env->lval, Field(arg, 0));
     } else {
       env->curr_char = Val_int(Int_field(tables->transl_const, Int_val(arg)));
-      caml_modify_field((value)env,
-                        offsetof(struct parser_env, lval) / sizeof(value),
-                        Val_long(0));
+      caml_modify(&env->lval, Val_long(0));
     }
     if (trace()) print_token(tables, state, arg);
 
@@ -288,7 +284,7 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
   case SEMANTIC_ACTION_COMPUTED:
     RESTORE;
     Store_field(env->s_stack, sp, Val_int(state));
-    caml_modify_field(env->v_stack, sp, arg);
+    caml_modify(&Field(env->v_stack, sp), arg);
     asp = Int_val(env->asp);
     Store_field (env->symb_end_stack, sp, Field(env->symb_end_stack, asp));
     if (sp > asp) {

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -303,7 +303,7 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
     caml_sys_error(NO_ARG);
   }
   if (Is_block(action)) {
-    caml_modify_field(caml_read_root(caml_signal_handlers), sig, Field(action, 0));
+    caml_modify(&Field(caml_read_root(caml_signal_handlers), sig), Field(action, 0));
   }
   caml_process_pending_signals();
   CAMLreturn (res);

--- a/testsuite/tests/callback/minor_named_.c
+++ b/testsuite/tests/callback/minor_named_.c
@@ -5,6 +5,6 @@
 value incr_ref(value unit) {
   static const value* v;
   if (!v) v = caml_named_value("incr_ref");
-  caml_modify_field(*v, 0, Val_int(Int_field(*v, 0) + 1));
+  caml_modify(&Field(*v, 0), Val_int(Int_field(*v, 0) + 1));
   return Val_unit;
 }


### PR DESCRIPTION
One more patch removing historic C-functions that are not required anymore. This one replaces all usages of `cam_modify_field` with `caml_modify` and remove `cam_modify_field`.