### PR TITLE
Re-enable lib-obj and asmcomp/is_static tests

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -244,7 +244,7 @@ FLAT_FLOAT_ARRAY=@flat_float_array@
 FUNCTION_SECTIONS=@function_sections@
 AWK=@AWK@
 STDLIB_MANPAGES=@stdlib_manpages@
-NAKED_POINTERS=@naked_pointers@
+NAKED_POINTERS=false
 
 ### Native command to build ocamlrun.exe
 

--- a/configure
+++ b/configure
@@ -17092,7 +17092,7 @@ $as_echo "$ac_cv_lib_execinfo_backtrace" >&6; }
 if test "x$ac_cv_lib_execinfo_backtrace" = xyes; then :
   cclibs="$cclibs -lexecinfo"
 fi
-]
+
 
 case $host in #(
   *-*-mingw32) :

--- a/configure
+++ b/configure
@@ -1562,8 +1562,6 @@ Optional Features:
   --disable-ocamldoc      do not build the ocamldoc documentation system
   --disable-ocamltest     do not build the ocamltest driver
   --enable-frame-pointers use frame pointers in runtime and generated code
-  --disable-naked-pointers
-                          do not allow naked pointers
   --enable-naked-pointers-checker
                           enable the naked pointers checker
   --disable-cfi           disable the CFI directives in assembly files
@@ -3179,7 +3177,10 @@ fi
 
 # Check whether --enable-naked-pointers was given.
 if test "${enable_naked_pointers+set}" = set; then :
-  enableval=$enable_naked_pointers;
+  enableval=$enable_naked_pointers; as_fn_error $? "Naked pointers are not allowed in OCaml Multicore." "$LINENO" 5
+else
+  $as_echo "#define NO_NAKED_POINTERS 1" >>confdefs.h
+
 fi
 
 
@@ -16815,16 +16816,6 @@ else
   { $as_echo "$as_me:${as_lineno-$LINENO}: not using frame pointers" >&5
 $as_echo "$as_me: not using frame pointers" >&6;}
   frame_pointers=false
-fi
-
-## No naked pointers
-
-if test x"$enable_naked_pointers" = "xno" ; then :
-  naked_pointers=false
-   $as_echo "#define NO_NAKED_POINTERS 1" >>confdefs.h
-
-else
-  naked_pointers=true
 fi
 
 ## Collect multicore stats

--- a/configure.ac
+++ b/configure.ac
@@ -1833,7 +1833,7 @@ ocamlc_cflags="$common_cflags $sharedlib_cflags \$(CFLAGS)"
 ocamlc_cppflags="$common_cppflags \$(CPPFLAGS)"
 cclibs="$cclibs $mathlib"
 
-AC_CHECK_LIB(execinfo, backtrace, cclibs="$cclibs -lexecinfo",[])]
+AC_CHECK_LIB(execinfo, backtrace, cclibs="$cclibs -lexecinfo",[])
 
 AS_CASE([$host],
   [*-*-mingw32],

--- a/configure.ac
+++ b/configure.ac
@@ -276,9 +276,9 @@ AC_ARG_ENABLE([frame-pointers],
   [AS_HELP_STRING([--enable-frame-pointers],
     [use frame pointers in runtime and generated code])])
 
-AC_ARG_ENABLE([naked-pointers],
-  [AS_HELP_STRING([--disable-naked-pointers],
-    [do not allow naked pointers])])
+AC_ARG_ENABLE([naked-pointers], [],
+  [AC_MSG_ERROR([Naked pointers are not allowed in OCaml Multicore.])],
+  [AC_DEFINE([NO_NAKED_POINTERS])])
 
 AC_ARG_ENABLE([naked-pointers-checker],
   [AS_HELP_STRING([--enable-naked-pointers-checker],
@@ -1721,13 +1721,6 @@ AS_IF([test x"$enable_frame_pointers" = "xyes"],
   )],
   [AC_MSG_NOTICE([not using frame pointers])
   frame_pointers=false])
-
-## No naked pointers
-
-AS_IF([test x"$enable_naked_pointers" = "xno" ],
-  [naked_pointers=false
-   AC_DEFINE([NO_NAKED_POINTERS])],
-  [naked_pointers=true])
 
 ## Collect multicore stats
 

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -85,11 +85,5 @@ tests/regression/pr9326/'gc_set.ml' with 2 (bytecode)
 # ocamldebug is broken (#34)
 tool-debugger
 
-# Uses obj.reachable_words whose definition in multicore isn't clear (think racy programs)
-lib-obj
-
-# Uses caml_page_table_lookup() (<- Is_in_static_data ()) which is not available on multicore
-tests/asmcomp/'is_static.ml' with 1.1 (native)
-
 # since promotion is based on minor heap size now, this test can no longer be correct
 tests/promotion/bigrecmod.ml


### PR DESCRIPTION
This PR re-enables tests and cleans up the configure settings to make multicore NO_NAKED_POINTERS always.

The re-enabled tests are:
- lib-obj where the multicore `reachable_words` implementation matches [ocaml/ocaml#9678](https://github.com/ocaml/ocaml/pull/9678)
- asmcomp/is_static test is guarded by naked_pointer checks with ocamltest