### PR TITLE
Replace `Op_val` with `Field`

### DIFF
--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -43,7 +43,7 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
     Alloc_small (result, wosize, tag, { caml_handle_gc_interrupt(); });
     if (tag < No_scan_tag){
       for (i = 0; i < wosize; i++) {
-        Op_val(result)[i] = Val_unit;
+        Field(result, i) = Val_unit;
       }
     }
   } else {
@@ -76,7 +76,7 @@ static inline value do_alloc_small(mlsize_t wosize, tag_t tag, value* vals)
   Alloc_small(v, wosize, tag,
       { enter_gc_preserving_vals(wosize, vals); });
   for (i = 0; i < wosize; i++) {
-    Op_val(v)[i] = vals[i];
+    Field(v, i) = vals[i];
   }
   return v;
 }
@@ -174,7 +174,7 @@ CAMLexport value caml_alloc_string (mlsize_t len)
   mlsize_t wosize = (len + sizeof (value)) / sizeof (value);
   value result = caml_alloc(wosize, String_tag);
 
-  Op_val (result) [wosize - 1] = 0;
+  Field (result, wosize - 1) = 0;
   offset_index = Bsize_wsize (wosize) - 1;
   Byte (result, offset_index) = offset_index - len;
   return result;

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -293,7 +293,7 @@ CAMLprim value caml_convert_raw_backtrace(value bt)
 
   array = caml_alloc(index, 0);
 
-  for (i = 0; i < index; i++) Op_val(array)[i] = Val_unit;
+  for (i = 0; i < index; i++) Field(array, i) = Val_unit;
 
   for (i = 0, index = 0; i < Wosize_val(bt); ++i)
   {

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -462,7 +462,7 @@ static void read_main_debug_info(struct debug_info *di)
     num_events = caml_getword(chan);
     events = caml_alloc(num_events, 0);
 
-    for (i = 0; i < num_events; i++) Op_val(events)[i] = Val_unit;
+    for (i = 0; i < num_events; i++) Field(events, i) = Val_unit;
 
     for (i = 0; i < num_events; i++) {
       orig = caml_getword(chan);

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -446,9 +446,9 @@ Caml_inline void caml_read_field(value x, intnat i, value* ret) {
   *ret = v;
 }
 
-#define Int_field(x, i) Int_val(Op_val(x)[i])
-#define Long_field(x, i) Long_val(Op_val(x)[i])
-#define Bool_field(x, i) Bool_val(Op_val(x)[i])
+#define Int_field(x, i) Int_val(Field(x, i))
+#define Long_field(x, i) Long_val(Field(x, i))
+#define Bool_field(x, i) Bool_val(Field(x, i))
 
 
 #ifdef __cplusplus

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -540,7 +540,7 @@ void caml_debugger(enum event_kind event, value param)
       i = caml_getword(dbg_in);
       if (Tag_val(val) != Double_array_tag) {
         caml_putch(dbg_out, 0);
-        putval(dbg_out, Op_val(val)[i]);
+        putval(dbg_out, Field(val, i));
       } else {
         double d = Double_flat_field(val, i);
         caml_putch(dbg_out, 1);

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -483,7 +483,7 @@ CAMLprim value caml_continuation_use_noexc (value cont)
   if (!Is_young(cont) ) caml_darken_cont(cont);
 
   /* at this stage the stack is assured to be marked */
-  v = Op_val(cont)[0];
+  v = Field(cont, 0);
 
   if (caml_domain_alone()) {
     Field(cont, 0) = null_stk;

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -271,7 +271,7 @@ static void generic_final_minor_update (struct domain* d, struct finalisable * f
     CAMLassert (Is_block (final->table[i].val));
     if (Is_young(final->table[i].val)) {
       CAMLassert (caml_get_header_val(final->table[i].val) == 0);
-      final->table[i].val = Op_val(final->table[i].val)[0];
+      final->table[i].val = Field(final->table[i].val, 0);
     }
   }
 }

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -82,8 +82,8 @@ CAMLexport double caml_Double_val(value val)
   union { value v[2]; double d; } buffer;
 
   CAMLassert(sizeof(double) == 2 * sizeof(value));
-  buffer.v[0] = Op_val(val)[0];
-  buffer.v[1] = Op_val(val)[1];
+  buffer.v[0] = Field(val, 0);
+  buffer.v[1] = Field(val, 0);
   return buffer.d;
 }
 
@@ -93,8 +93,8 @@ CAMLexport void caml_Store_double_val(value val, double dbl)
 
   CAMLassert(sizeof(double) == 2 * sizeof(value));
   buffer.d = dbl;
-  Op_val(val)[0] = buffer.v[0];
-  Op_val(val)[1] = buffer.v[1];
+  Field(val, 0) = buffer.v[0];
+  Field(val, 0) = buffer.v[1];
 }
 
 #endif

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -83,7 +83,7 @@ CAMLexport double caml_Double_val(value val)
 
   CAMLassert(sizeof(double) == 2 * sizeof(value));
   buffer.v[0] = Field(val, 0);
-  buffer.v[1] = Field(val, 0);
+  buffer.v[1] = Field(val, 1);
   return buffer.d;
 }
 
@@ -94,7 +94,7 @@ CAMLexport void caml_Store_double_val(value val, double dbl)
   CAMLassert(sizeof(double) == 2 * sizeof(value));
   buffer.d = dbl;
   Field(val, 0) = buffer.v[0];
-  Field(val, 0) = buffer.v[1];
+  Field(val, 1) = buffer.v[1];
 }
 
 #endif

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -262,7 +262,7 @@ static void scan_native_globals(scanning_action f, void* fdata)
   for (i = 0; i <= caml_globals_inited && caml_globals[i] != 0; i++) {
     for(glob = caml_globals[i]; *glob != 0; glob++) {
       for (j = 0; j < Wosize_val(*glob); j++){
-        f(fdata, Op_val(*glob)[j], &Op_val(*glob)[j]);
+        f(fdata, Field(*glob, j), &Field(*glob, j));
       }
     }
   }
@@ -271,7 +271,7 @@ static void scan_native_globals(scanning_action f, void* fdata)
   iter_list(dyn_globals, lnk) {
     for(glob = (value *) lnk->data; *glob != 0; glob++) {
       for (j = 0; j < Wosize_val(*glob); j++){
-        f(fdata, Op_val(*glob)[j], &Op_val(*glob)[j]);
+        f(fdata, Field(*glob, j), &Field(*glob, j));
       }
     }
   }

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -156,7 +156,7 @@ caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f)
         };
         if (i > 0)
           putc (' ', f);
-        fprintf (f, "%#" ARCH_INTNAT_PRINTF_FORMAT "x", Op_val (v)[i]);
+        fprintf (f, "%#" ARCH_INTNAT_PRINTF_FORMAT "x", Field (v, i));
       };
       if (s > 0)
         putc (')', f);

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -410,7 +410,7 @@ static value intern_rec(mlsize_t whsize, mlsize_t num_objects)
             Assert(tag != Closure_tag);
             Assert(tag != Infix_tag);
             v = caml_alloc(size, tag);
-            for (i = 0; i < size; i++) Op_val(v)[i] = Val_unit;
+            for (i = 0; i < size; i++) Field(v, i) = Val_unit;
             if (use_intern_table) Store_field(intern_obj_table, obj_counter++, v);
             /* For objects, we need to freshen the oid */
             if (tag == Object_tag) {

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -131,7 +131,7 @@ sp is a local copy of the global variable Caml_state->extern_sp. */
 
 
 /* Initialising fields of objects just allocated with Alloc_small */
-#define Init_field(o, i, x) Op_val(o)[i] = (x)
+#define Init_field(o, i, x) Field(o, i) = (x)
 
 #define Check_trap_barrier \
   if (domain_state->trap_sp_off >= domain_state->trap_barrier_off) \

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -702,7 +702,7 @@ void caml_darken_cont(value cont)
           atomic_compare_exchange_strong(
               Hp_atomic_val(cont), &hd,
               With_status_hd(hd, NOT_MARKABLE))) {
-        value stk = Op_val(cont)[0];
+        value stk = Field(cont, 0);
         if (Ptr_val(stk) != NULL)
           caml_scan_stack(&caml_darken, 0, Ptr_val(stk), 0);
         atomic_store_explicit(
@@ -772,7 +772,7 @@ intnat ephe_mark (intnat budget, uintnat for_cycle)
 
     size = Wosize_hd(hd);
     for (i = CAML_EPHE_FIRST_KEY; alive_data && i < size; i++) {
-      key = Op_val(v)[i];
+      key = Field(v, i);
     ephemeron_again:
       if (key != caml_ephe_none && Is_block(key)) {
         if (Tag_val(key) == Forward_tag) {
@@ -782,7 +782,7 @@ intnat ephe_mark (intnat budget, uintnat for_cycle)
                 Tag_val(f) == Double_tag) {
               /* Do not short-circuit the pointer */
             } else {
-              Op_val(v)[i] = key = f;
+              Field(v, i) = key = f;
               goto ephemeron_again;
             }
           }

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -179,7 +179,7 @@ CAMLexport int caml_atomic_cas_field (value obj, intnat field, value oldval, val
 {
   if (caml_domain_alone()) {
     /* non-atomic CAS since only this thread can access the object */
-    value* p = &Op_val(obj)[field];
+    value* p = &Field(obj, field);
     if (*p == oldval) {
       *p = newval;
       write_barrier(obj, field, oldval, newval);
@@ -203,7 +203,7 @@ CAMLexport int caml_atomic_cas_field (value obj, intnat field, value oldval, val
 CAMLprim value caml_atomic_load (value ref)
 {
   if (caml_domain_alone()) {
-    return Op_val(ref)[0];
+    return Field(ref, 0);
   } else {
     value v;
     /* See Note [MM] above */
@@ -218,8 +218,8 @@ CAMLprim value caml_atomic_exchange (value ref, value v)
 {
   value ret;
   if (caml_domain_alone()) {
-    ret = Op_val(ref)[0];
-    Op_val(ref)[0] = v;
+    ret = Field(ref, 0);
+    Field(ref, 0) = v;
   } else {
     /* See Note [MM] above */
     atomic_thread_fence(memory_order_acquire);

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -341,8 +341,7 @@ static void oldify_one (void* st_v, value v, value *p)
     st->live_bytes += Bhsize_hd(hd);
     result = alloc_shared(sz, tag);
     for (i = 0; i < sz; i++) {
-      value curr = Field(v, i);
-      Field(result, i) = curr;
+      Field(result, i) = Field(v, i);
     }
     CAMLassert (infix_offset == 0);
     if( !try_update_object_header(v, p, result, 0) ) {

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -201,20 +201,20 @@ static int try_update_object_header(value v, value *p, value result, mlsize_t in
 
   if( caml_domain_alone() ) {
     *Hp_val (v) = 0;
-    Op_val(v)[0] = result;
+    Field(v, 0) = result;
     success = 1;
   } else {
     header_t hd = atomic_load(Hp_atomic_val(v));
     if( hd == 0 ) {
       // in this case this has been updated by another domain, throw away result
       // and return the one in the object
-      result = Op_val(v)[0];
+      result = Field(v, 0);
     } else if( Is_update_in_progress(hd) ) {
       // here we've caught a domain in the process of moving a minor heap object
       // we need to wait for it to finish
       spin_on_header(v);
       // Also throw away result and use the one from the other domain
-      result = Op_val(v)[0];
+      result = Field(v, 0);
     } else {
       // Here the header is neither zero nor an in-progress update
       header_t desired_hd = In_progress_update_val;
@@ -230,7 +230,7 @@ static int try_update_object_header(value v, value *p, value result, mlsize_t in
         // We were sniped by another domain, spin for that to complete then
         // throw away result and use the one from the other domain
         spin_on_header(v);
-        result = Op_val(v)[0];
+        result = Field(v, 0);
       }
     }
   }
@@ -274,7 +274,7 @@ static void oldify_one (void* st_v, value v, value *p)
     hd = get_header_val(v);
     if (hd == 0) {
       /* already forwarded, another domain is likely working on this. */
-      *p = Op_val(v)[0] + infix_offset;
+      *p = Field(v, 0) + infix_offset;
       return;
     }
     tag = Tag_hd (hd);
@@ -288,12 +288,12 @@ static void oldify_one (void* st_v, value v, value *p)
   } while (tag == Infix_tag);
 
   if (tag == Cont_tag) {
-    value stack_value = Op_val(v)[0];
+    value stack_value = Field(v, 0);
     CAMLassert(Wosize_hd(hd) == 1 && infix_offset == 0);
     result = alloc_shared(1, Cont_tag);
     if( try_update_object_header(v, p, result, 0) ) {
       struct stack_info* stk = Ptr_val(stack_value);
-      Op_val(result)[0] = Val_ptr(stk);
+      Field(result, 0) = Val_ptr(stk);
       if (stk != NULL) {
         caml_scan_stack(&oldify_one, st, stk, 0);
       }
@@ -303,7 +303,7 @@ static void oldify_one (void* st_v, value v, value *p)
       // Conflict - fix up what we allocated on the major heap
       *Hp_val(result) = Make_header(1, No_scan_tag, global.MARKED);
       #ifdef DEBUG
-      Op_val(result)[0] = Val_long(1);
+      Field(result, 0) = Val_long(1);
       #endif
     }
   } else if (tag < Infix_tag) {
@@ -311,11 +311,11 @@ static void oldify_one (void* st_v, value v, value *p)
     sz = Wosize_hd (hd);
     st->live_bytes += Bhsize_hd(hd);
     result = alloc_shared (sz, tag);
-    field0 = Op_val(v)[0];
+    field0 = Field(v, 0);
     if( try_update_object_header(v, p, result, infix_offset) ) {
       if (sz > 1){
-        Op_val (result)[0] = field0;
-        Op_val (result)[1] = st->todo_list;
+        Field(result, 0) = field0;
+        Field(result, 1) = st->todo_list;
         st->todo_list = v;
       } else {
         CAMLassert (sz == 1);
@@ -330,7 +330,7 @@ static void oldify_one (void* st_v, value v, value *p)
       {
         int c;
         for( c = 0; c < sz ; c++ ) {
-          Op_val(result)[c] = Val_long(1);
+          Field(result, c) = Val_long(1);
         }
       }
       #endif
@@ -341,8 +341,8 @@ static void oldify_one (void* st_v, value v, value *p)
     st->live_bytes += Bhsize_hd(hd);
     result = alloc_shared(sz, tag);
     for (i = 0; i < sz; i++) {
-      value curr = Op_val(v)[i];
-      Op_val (result)[i] = curr;
+      value curr = Field(v, i);
+      Field(result, i) = curr;
     }
     CAMLassert (infix_offset == 0);
     if( !try_update_object_header(v, p, result, 0) ) {
@@ -350,7 +350,7 @@ static void oldify_one (void* st_v, value v, value *p)
       *Hp_val(result) = Make_header(sz, No_scan_tag, global.MARKED);
       #ifdef DEBUG
       for( i = 0; i < sz ; i++ ) {
-        Op_val(result)[i] = Val_long(1);
+        Field(result, i) = Val_long(1);
       }
       #endif
     }
@@ -364,7 +364,7 @@ static void oldify_one (void* st_v, value v, value *p)
     ft = 0;
 
     if (Is_block (f)) {
-      ft = Tag_val (get_header_val(f) == 0 ? Op_val (f)[0] : f);
+      ft = Tag_val (get_header_val(f) == 0 ? Field(f, 0) : f);
     }
 
     if (ft == Forward_tag || ft == Lazy_tag || ft == Double_tag) {
@@ -379,7 +379,7 @@ static void oldify_one (void* st_v, value v, value *p)
       } else {
         *Hp_val(result) = Make_header(1, No_scan_tag, global.MARKED);
         #ifdef DEBUG
-        Op_val(result)[0] = Val_long(1);
+        Field(result, 0) = Val_long(1);
         #endif
       }
     } else {
@@ -435,21 +435,21 @@ static void oldify_mopup (struct oldify_state* st, int do_ephemerons)
     by another domain, so this assert using get_header_val is probably not
     neccessary */
     CAMLassert (get_header_val(v) == 0);       /* It must be forwarded. */
-    new_v = Op_val (v)[0];                /* Follow forward pointer. */
-    st->todo_list = Op_val (new_v)[1]; /* Remove from list. */
+    new_v = Field(v, 0);                /* Follow forward pointer. */
+    st->todo_list = Field (new_v, 1); /* Remove from list. */
 
-    f = Op_val (new_v)[0];
+    f = Field(new_v, 0);
     CAMLassert (!Is_debug_tag(f));
     if (Is_block (f) && Is_young(f)) {
       oldify_one (st, f, Op_val (new_v));
     }
     for (i = 1; i < Wosize_val (new_v); i++){
-      f = Op_val (v)[i];
+      f = Field(v, i);
       CAMLassert (!Is_debug_tag(f));
       if (Is_block (f) && Is_young(f)) {
         oldify_one (st, f, Op_val (new_v) + i);
       } else {
-        Op_val (new_v)[i] = f;
+        Field(new_v, i) = f;
       }
     }
     CAMLassert (Wosize_val(new_v));
@@ -465,11 +465,11 @@ static void oldify_mopup (struct oldify_state* st, int do_ephemerons)
          re < ephe_ref_table.ptr; re++) {
       value *data = re->offset == CAML_EPHE_DATA_OFFSET
               ? &Ephe_data(re->ephe)
-              :  &Op_val(re->ephe)[re->offset];
+              :  &Field(re->ephe, re->offset);
       if (*data != caml_ephe_none && Is_block(*data) && Is_young(*data) ) {
         resolve_infix_val(data);
         if (get_header_val(*data) == 0) { /* Value copied to major heap */
-          *data = Op_val(*data)[0];
+          *data = Field(*data, 0);
         } else {
           oldify_one(st, *data, data);
           redo = 1; /* oldify_todo_list can still be 0 */
@@ -629,7 +629,7 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
     value *v = &elt->block;
     if (Is_block(*v) && Is_young(*v)) {
       if (get_header_val(*v) == 0) { /* value copied to major heap */
-        *v = Op_val(*v)[0];
+        *v = Field(*v, 0);
       } else {
         oldify_one(&st, *v, v);
       }

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -330,7 +330,7 @@ CAMLprim value caml_fresh_oo_id (value v) {
 
 CAMLprim value caml_set_oo_id (value obj) {
   value v = Val_unit;
-  Op_val(obj)[1] = caml_fresh_oo_id(v);
+  Field(obj, 1) = caml_fresh_oo_id(v);
   return obj;
 }
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -405,7 +405,7 @@ value* caml_shared_try_alloc(struct caml_heap_state* local, mlsize_t wosize,
   {
     int i;
     for (i = 0; i < wosize; i++) {
-      Op_val(Val_hp(p))[i] = Debug_free_major;
+      Field(Val_hp(p), i) = Debug_free_major;
     }
   }
 #endif
@@ -681,7 +681,7 @@ static void verify_object(struct heap_verify_state* st, value v) {
   Assert(Has_status_hd(Hd_val(v), global.UNMARKED));
 
   if (Tag_val(v) == Cont_tag) {
-    struct stack_info* stk = Ptr_val(Op_val(v)[0]);
+    struct stack_info* stk = Ptr_val(Field(v, 0));
     if (stk != NULL)
       caml_scan_stack(verify_push, st, stk, 0);
   } else if (Tag_val(v) < No_scan_tag) {
@@ -690,7 +690,7 @@ static void verify_object(struct heap_verify_state* st, value v) {
       i = Start_env_closinfo(Closinfo_val(v));
     }
     for (; i < Wosize_val(v); i++) {
-      value f = Op_val(v)[i];
+      value f = Field(v, i);
       if (Is_young(v) && Is_young(f)) {
         Assert(caml_owner_of_young_block(v) ==
                caml_owner_of_young_block(f));


### PR DESCRIPTION
Changes usages of `Op_val (x)[i]` to `Field (x, i)`. `Op_val` was supposedly used at a time `Field` was not working with multicore. They are both same and the latter seems to be more widely used in trunk.