### PR TITLE
Change interpreter to uses naked code pointers

### DIFF
--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -79,7 +79,7 @@ struct c_stack_link {
 /* The table of global identifiers */
 extern caml_root caml_global_data;
 
-#define Trap_pc(tp) ((tp)[0])
+#define Trap_pc(tp) (((code_t *)(tp))[0])
 #define Trap_link(tp) ((tp)[1])
 
 struct stack_info** caml_alloc_stack_cache (void);

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -256,9 +256,6 @@ static inline void* Ptr_val(value val)
   return (void*)(val - 1);
 }
 
-#define Val_pc(pc) Val_ptr(pc)
-#define Pc_val(val) ((code_t)Ptr_val(val))
-
 /* Special case of tuples of fields: closures */
 #define Closure_tag 247
 #define Code_val(val) (((code_t *) (val)) [0])     /* Also an l-value. */

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -259,6 +259,8 @@ static inline void* Ptr_val(value val)
 #define Val_pc(pc) Val_ptr(pc)
 #define Pc_val(val) ((code_t)Ptr_val(val))
 
+#define Code_val_our(val) Pc_val(Field((val), 0))
+
 /* Special case of tuples of fields: closures */
 #define Closure_tag 247
 

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -259,13 +259,9 @@ static inline void* Ptr_val(value val)
 #define Val_pc(pc) Val_ptr(pc)
 #define Pc_val(val) ((code_t)Ptr_val(val))
 
-#define Code_val_our(val) Pc_val(Field((val), 0))
-
 /* Special case of tuples of fields: closures */
 #define Closure_tag 247
-
-/* TODO: move fully to the upstream representation of Code_val */
-#define Code_val(val) Pc_val(Field((val), 0))
+#define Code_val(val) (((code_t *) (val)) [0])     /* Also an l-value. */
 #define Closinfo_val(val) Field((val), 1)          /* Arity and start env */
 /* In the closure info field, the top 8 bits are the arity (signed).
    The low bit is set to one, to look like an integer.

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -263,9 +263,7 @@ static inline void* Ptr_val(value val)
 #define Closure_tag 247
 
 /* TODO: move fully to the upstream representation of Code_val */
-#define Bytecode_val(val) (Pc_val(val))
-#define Val_bytecode(code) (Val_pc(code))
-#define Code_val(val) Bytecode_val(Field((val), 0))
+#define Code_val(val) Pc_val(Field((val), 0))
 #define Closinfo_val(val) Field((val), 1)          /* Arity and start env */
 /* In the closure info field, the top 8 bits are the arity (signed).
    The low bit is set to one, to look like an integer.

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -103,7 +103,7 @@ caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f)
   if (prog && v % sizeof (int) == 0
            && (code_t) v >= prog
            && (code_t) v < (code_t) ((char *) prog + proglen))
-    fprintf (f, "=code@%ld", Pc_val(v) - prog);
+    fprintf (f, "=code@%ld", (long) ((code_t) v - prog));
   else if (Is_long (v))
     fprintf (f, "=long%" ARCH_INTNAT_PRINTF_FORMAT "d", Long_val (v));
   else if (Stack_base(Caml_state->current_stack) <= (value*)v &&

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -275,7 +275,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
                      sizeof(raise_unhandled_code));
 #endif
     raise_unhandled_closure = caml_alloc_small (2, Closure_tag);
-    Field(raise_unhandled_closure, 0) = Val_bytecode(raise_unhandled_code);
+    Field(raise_unhandled_closure, 0) = Val_pc(raise_unhandled_code);
     Closinfo_val(raise_unhandled_closure) = Make_closinfo(0, 2);
     raise_unhandled = caml_create_root(raise_unhandled_closure);
     caml_global_data = caml_create_root(Val_unit);
@@ -598,7 +598,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
         Alloc_small(accu, num_args + 3, Closure_tag, Enter_gc);
         Field(accu, 2) = env;
         for (i = 0; i < num_args; i++) Field(accu, i + 3) = sp[i];
-        Field(accu, 0) = Val_bytecode(pc-3); /* Point to the preceding RESTART instr. */
+        Field(accu, 0) = Val_pc(pc-3); /* Point to the preceding RESTART instr. */
         Closinfo_val(accu) = Make_closinfo(0, 2);
         sp += num_args;
         goto do_return;
@@ -622,7 +622,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       }
       /* The code pointer is not in the heap, so no need to go through
          caml_initialize. */
-      Field(accu, 0) = Val_bytecode(pc + *pc);
+      Field(accu, 0) = Val_pc(pc + *pc);
       Closinfo_val(accu) = Make_closinfo(0, 2);
       pc++;
       sp += nvars;
@@ -654,12 +654,12 @@ value caml_interprete(code_t prog, asize_t prog_size)
          so no need to go through caml_initialize. */
       *--sp = accu;
       p = &Field(accu, 0);
-      *p++ = Val_bytecode (pc + pc[0]);
+      *p++ = Val_pc (pc + pc[0]);
       *p++ = Make_closinfo(0, envofs);
       for (i = 1; i < nfuncs; i++) {
         *p++ = Make_header(i * 3, Infix_tag, 0); /* color irrelevant */
         *--sp = (value) p;
-        *p++ = Val_bytecode (pc + pc[i]);
+        *p++ = Val_pc (pc + pc[i]);
         envofs -= 3;
         *p++ = Make_closinfo(0, envofs);
       }

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -20,6 +20,7 @@
 #include "caml/alloc.h"
 #include "caml/backtrace.h"
 #include "caml/callback.h"
+#include "caml/codefrag.h"
 #include "caml/debugger.h"
 #include "caml/fail.h"
 #include "caml/fix_code.h"
@@ -263,6 +264,10 @@ value caml_interprete(code_t prog, asize_t prog_size)
   if (prog == NULL) {           /* Interpreter is initializing */
     static opcode_t raise_unhandled_code[] = { ACC, 0, RAISE };
     value raise_unhandled_closure;
+
+    caml_register_code_fragment((char *) raise_unhandled_code,
+                                (char *) raise_unhandled_code + sizeof(raise_unhandled_code),
+                                DIGEST_IGNORE, NULL);
 #ifdef THREADED_CODE
     caml_instr_table = (char **) jumptable;
     caml_instr_base = Jumptbl_base;

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -126,7 +126,7 @@ CAMLprim value caml_reify_bytecode(value ls_prog,
   (void)fragnum; /* clobber warning */
 
   clos = caml_alloc_small (2, Closure_tag);
-  Field(clos, 0) = Val_bytecode(prog);
+  Field(clos, 0) = Val_pc(prog);
   Closinfo_val(clos) = Make_closinfo(0, 2);
   bytecode = caml_alloc_small (2, Abstract_tag);
   Bc_val(bytecode)->prog = prog;

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -54,7 +54,7 @@ struct bytecode {
   code_t prog;
   asize_t len;
 };
-#define Bc_val(p) ((struct bytecode*)Data_abstract_val(p))
+#define Bytecode_val(p) ((struct bytecode*)Data_abstract_val(p))
 
 /* Convert a bytes array (= LongString.t) to a contiguous buffer.
    The result is allocated with caml_stat_alloc */
@@ -126,11 +126,11 @@ CAMLprim value caml_reify_bytecode(value ls_prog,
   (void)fragnum; /* clobber warning */
 
   clos = caml_alloc_small (2, Closure_tag);
-  Field(clos, 0) = Val_pc(prog);
+  Code_val(clos) = (code_t) prog;
   Closinfo_val(clos) = Make_closinfo(0, 2);
   bytecode = caml_alloc_small (2, Abstract_tag);
-  Bc_val(bytecode)->prog = prog;
-  Bc_val(bytecode)->len = len;
+  Bytecode_val(bytecode)->prog = prog;
+  Bytecode_val(bytecode)->len = len;
   retval = caml_alloc_small (2, 0);
   Field(retval, 0) = bytecode;
   Field(retval, 1) = clos;
@@ -145,7 +145,7 @@ CAMLprim value caml_static_release_bytecode(value bc)
   code_t prog;
   struct code_fragment *cf;
 
-  prog = Bc_val(bc)->prog;
+  prog = Bytecode_val(bc)->prog;
   caml_remove_debug_info(prog);
 
   cf = caml_find_code_fragment_by_pc((char *) prog);


### PR DESCRIPTION
This PR completes the OCaml multicore interpreter integration of [ocaml/ocaml#9680](https://github.com/ocaml/ocaml/pull/9680) which alters how naked pointers are identified in the interpreter stack. 

With this PR merged, the main areas of divergence between multicore and ocaml/ocaml for the bytecode interpreter would be:
 - how push/pop trap is handled with the stack representation;
 - the fiber and effects specific implementation.

I think any changes to the above (if desired) go into follow on PRs. 