### PR TITLE
Update a testcase in principality-and-gadts.ml to reflect changes in #9584

### DIFF
--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -21,10 +21,6 @@ tests/lib-dynlink-private/'test.ml' with 1.2.1.2.8.19.1 (run)
 tests/weak-ephe-final/'weaktest.ml' with 1 (native)
 tests/weak-ephe-final/'weaktest.ml' with 2 (bytecode)
 
-# TODO: something is bad in typing with gadts and effects
-# (went wrong when this test was introduced in #1931)
-tests/typing-gadts/'principality-and-gadts.ml' with 1 (expect)
-
 # TODO: port the new Ephemeron C-api to multicore
 #  https://github.com/ocaml/ocaml/pull/676
 ephe-c-api

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -404,7 +404,7 @@ val foo : string foo -> string = <fun>
 Line 3, characters 29-34:
 3 |   | { x = (x : string); eq = Refl3 } -> x
                                  ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering M.t and string as equal.
+Warning 18 [not-principal]: typing this pattern requires considering M.t and N.t as equal.
 But the knowledge of these types is not principal.
 val foo : string foo -> string = <fun>
 |}]


### PR DESCRIPTION
This PR updates a testcase which was logging out a different warning message in mulitcore when compared to 4.12 branch in ocaml/ocaml.

The log looked something like this
```
--- principality-and-gadts.ml	2021-03-18 15:26:04.493555453 +0530
+++ principality-and-gadts.ml.corrected.corrected	2021-03-22 12:42:09.893389521 +0530
@@ -404,7 +404,7 @@
 Line 3, characters 29-34:
 3 |   | { x = (x : string); eq = Refl3 } -> x
                                  ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering M.t and string as equal.
+Warning 18 [not-principal]: typing this pattern requires considering M.t and N.t as equal.
 But the knowledge of these types is not principal.
 val foo : string foo -> string = <fun>
 |}]
)
> Specified modules: principality-and-gadts.ml
> Source modules: principality-and-gadts.ml
> Running test expect with 3 actions
> 
> Running action 1/3 (setup-simple-build-env)
> Action 1/3 (setup-simple-build-env) passed
> 
> Running action 2/3 (run-expect)
> Commandline: /home/sk/ocaml-multicore/runtime/ocamlrun /home/sk/ocaml-multicore/testsuite/tools/expect_test -repo-root /home/sk/ocaml-multicore principality-and-gadts.ml
> Commandline: /home/sk/ocaml-multicore/runtime/ocamlrun /home/sk/ocaml-multicore/testsuite/tools/expect_test -repo-root /home/sk/ocaml-multicore -principal principality-and-gadts.ml.corrected
> Action 2/3 (run-expect) passed
> 
> Running action 3/3 (check-program-output)
> Comparing program output principality-and-gadts.ml.corrected.corrected to reference principality-and-gadts.ml
> Action 3/3 (check-program-output) failed (program output principality-and-gadts.ml.corrected.corrected differs from reference principality-and-gadts.ml: 
> --- principality-and-gadts.ml	2021-03-18 15:26:04.493555453 +0530
> +++ principality-and-gadts.ml.corrected.corrected	2021-03-22 12:42:09.893389521 +0530
> @@ -404,7 +404,7 @@
>  Line 3, characters 29-34:
>  3 |   | { x = (x : string); eq = Refl3 } -> x
>                                   ^^^^^
> -Warning 18 [not-principal]: typing this pattern requires considering M.t and string as equal.
> +Warning 18 [not-principal]: typing this pattern requires considering M.t and N.t as equal.
>  But the knowledge of these types is not principal.
>  val foo : string foo -> string = <fun>
>  |}]
> 
> )
```
Specifically this line 
```
> -Warning 18 [not-principal]: typing this pattern requires considering M.t and string as equal.
> +Warning 18 [not-principal]: typing this pattern requires considering M.t and N.t as equal.
```
which ocaml#9584 updates to reflect the one multicore produces.
https://github.com/ocaml/ocaml/pull/9584