### PR TITLE
Allocate unique root token on the major heap instead of the minor

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -281,7 +281,11 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
       goto create_dls_root_failure;
     }
 
-    domain_state->unique_token_root = caml_alloc_1(Abstract_tag, Val_unit);
+    domain_state->unique_token_root = caml_alloc_shr_noexc(Abstract_tag, Val_unit);
+    if(domain_state->unique_token_root == (value)NULL) {
+      goto create_unique_token_failure;
+    }
+
     caml_register_generational_global_root(&domain_state->unique_token_root);
 
     domain_state->stack_cache = caml_alloc_stack_cache();
@@ -318,6 +322,7 @@ alloc_main_stack_failure:
 create_stack_cache_failure:
   caml_remove_generational_global_root(&domain_state->unique_token_root);
   caml_delete_root(domain_state->dls_root);
+create_unique_token_failure:
 create_dls_root_failure:
 reallocate_minor_heap_failure:
   caml_teardown_major_gc();


### PR DESCRIPTION
Fixes bug in https://github.com/ocaml-multicore/ocaml-multicore/pull/505

In `create_domain` we are allocating the unique root token on the minor heap, this potentially opens us up to ending up in a stop-the-world pause with a partially constructed Domain.

This PR changes that to a major heap allocation that does not raise an exception and bails on Domain creation if it fails.

Noticed because it causes the DLABs PR to deadlock in tests.