### PR TITLE
Clear the minor heap at the end of a collection if we're in the debug runtime

### DIFF
--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -517,6 +517,14 @@ void caml_empty_minor_heap_domain_clear (struct domain* domain, void* unused)
   clear_table ((struct generic_table *)&minor_tables->major_ref);
   clear_table ((struct generic_table *)&minor_tables->ephe_ref);
   clear_table ((struct generic_table *)&minor_tables->custom);
+
+#ifdef DEBUG
+  {
+    uintnat* p = (uintnat*)domain_state->young_start;
+    for (; p < (uintnat*)domain_state->young_end; p++)
+      *p = Debug_uninit_align;
+  }
+#endif
 }
 
 void caml_empty_minor_heap_promote (struct domain* domain, int participating_count, struct domain** participating, int not_alone)

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -85,4 +85,4 @@ tool-debugger
 tests/promotion/bigrecmod.ml
 
 # disabled as there's a bug with signal handlers
-tests/callback/test_signalhandlers
+tests/callback/'test_signalhandler.ml' with 1.2 (native)

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -83,3 +83,6 @@ tool-debugger
 
 # since promotion is based on minor heap size now, this test can no longer be correct
 tests/promotion/bigrecmod.ml
+
+# disabled as there's a bug with signal handlers
+tests/callback/test_signalhandlers

--- a/testsuite/tests/callback/test1.ml
+++ b/testsuite/tests/callback/test1.ml
@@ -42,31 +42,6 @@ let tripwire f =
   let s = String.make 5 'a' in
   f s trapexit ()
 
-(* Test callbacks performed to handle signals *)
-
-let sighandler signo =
-(*
-  print_string "Got signal, triggering garbage collection...";
-  print_newline();
-*)
-  (* Thoroughly wipe the minor heap *)
-  ignore (tak (18, 12, 6))
-
-external unix_getpid : unit -> int = "unix_getpid" [@@noalloc]
-external unix_kill : int -> int -> unit = "unix_kill" [@@noalloc]
-
-let callbacksig () =
-  let pid = unix_getpid() in
-  (* Allocate a block in the minor heap *)
-  let s = String.make 5 'b' in
-  (* Send a signal to self.  We want s to remain in a register and
-     not be spilled on the stack, hence we declare unix_kill
-     [@@noalloc]. *)
-  unix_kill pid Sys.sigusr1;
-  (* Allocate some more so that the signal will be tested *)
-  let u = (s, s) in
-  fst u
-
 let _ =
   print_int(mycallback1 tak (18, 12, 6)); print_newline();
   print_int(mycallback2 tak2 18 (12, 6)); print_newline();
@@ -75,5 +50,3 @@ let _ =
   print_int(trapexit ()); print_newline();
   print_string(tripwire mypushroot); print_newline();
   print_string(tripwire mycamlparam); print_newline();
-  Sys.set_signal Sys.sigusr1 (Sys.Signal_handle sighandler);
-  print_string(callbacksig ()); print_newline()

--- a/testsuite/tests/callback/test1.mli
+++ b/testsuite/tests/callback/test1.mli
@@ -13,7 +13,3 @@ val trapexit : unit -> int
 external mypushroot : 'a -> ('b -> 'c) -> 'b -> 'a = "mypushroot"
 external mycamlparam : 'a -> ('b -> 'c) -> 'b -> 'a = "mycamlparam"
 val tripwire : (string -> (unit -> int) -> unit -> 'a) -> 'a
-val sighandler : 'a -> unit
-external unix_getpid : unit -> int = "unix_getpid" [@@noalloc]
-external unix_kill : int -> int -> unit = "unix_kill" [@@noalloc]
-val callbacksig : unit -> string

--- a/testsuite/tests/callback/test1.reference
+++ b/testsuite/tests/callback/test1.reference
@@ -5,4 +5,3 @@
 7
 aaaaa
 aaaaa
-bbbbb

--- a/testsuite/tests/callback/test_signalhandler.ml
+++ b/testsuite/tests/callback/test_signalhandler.ml
@@ -1,0 +1,79 @@
+(* TEST
+   include unix
+   modules = "test_signalhandler_.c"
+   * libunix
+   ** bytecode
+   ** native
+*)
+
+(**************************************************************************)
+
+external mycallback1 : ('a -> 'b) -> 'a -> 'b = "mycallback1"
+external mycallback2 : ('a -> 'b -> 'c) -> 'a -> 'b -> 'c = "mycallback2"
+external mycallback3 : ('a -> 'b -> 'c -> 'd) -> 'a -> 'b -> 'c -> 'd
+    = "mycallback3"
+external mycallback4 :
+    ('a -> 'b -> 'c -> 'd -> 'e) -> 'a -> 'b -> 'c -> 'd -> 'e = "mycallback4"
+
+let rec tak (x, y, z as _tuple) =
+  if x > y then tak(tak (x-1, y, z), tak (y-1, z, x), tak (z-1, x, y))
+           else z
+
+let tak2 x (y, z) = tak (x, y, z)
+
+let tak3 x y z = tak (x, y, z)
+
+let tak4 x y z u = tak (x, y, z + u)
+
+let raise_exit () = (raise Exit : unit)
+
+let trapexit () =
+  begin try
+    mycallback1 raise_exit ()
+  with Exit ->
+    ()
+  end;
+  tak (18, 12, 6)
+
+external mypushroot : 'a -> ('b -> 'c) -> 'b -> 'a = "mypushroot"
+external mycamlparam : 'a -> ('b -> 'c) -> 'b -> 'a = "mycamlparam"
+
+let tripwire f =
+  let s = String.make 5 'a' in
+  f s trapexit ()
+
+(* Test callbacks performed to handle signals *)
+
+let sighandler signo =
+(*
+  print_string "Got signal, triggering garbage collection...";
+  print_newline();
+*)
+  (* Thoroughly wipe the minor heap *)
+  ignore (tak (18, 12, 6))
+
+external unix_getpid : unit -> int = "unix_getpid" [@@noalloc]
+external unix_kill : int -> int -> unit = "unix_kill" [@@noalloc]
+
+let callbacksig () =
+  let pid = unix_getpid() in
+  (* Allocate a block in the minor heap *)
+  let s = String.make 5 'b' in
+  (* Send a signal to self.  We want s to remain in a register and
+     not be spilled on the stack, hence we declare unix_kill
+     [@@noalloc]. *)
+  unix_kill pid Sys.sigusr1;
+  (* Allocate some more so that the signal will be tested *)
+  let u = (s, s) in
+  fst u
+
+let _ =
+  print_int(mycallback1 tak (18, 12, 6)); print_newline();
+  print_int(mycallback2 tak2 18 (12, 6)); print_newline();
+  print_int(mycallback3 tak3 18 12 6); print_newline();
+  print_int(mycallback4 tak4 18 12 3 3); print_newline();
+  print_int(trapexit ()); print_newline();
+  print_string(tripwire mypushroot); print_newline();
+  print_string(tripwire mycamlparam); print_newline();
+  Sys.set_signal Sys.sigusr1 (Sys.Signal_handle sighandler);
+  print_string(callbacksig ()); print_newline()

--- a/testsuite/tests/callback/test_signalhandler.mli
+++ b/testsuite/tests/callback/test_signalhandler.mli
@@ -1,0 +1,19 @@
+external mycallback1 : ('a -> 'b) -> 'a -> 'b = "mycallback1"
+external mycallback2 : ('a -> 'b -> 'c) -> 'a -> 'b -> 'c = "mycallback2"
+external mycallback3 : ('a -> 'b -> 'c -> 'd) -> 'a -> 'b -> 'c -> 'd
+  = "mycallback3"
+external mycallback4 :
+  ('a -> 'b -> 'c -> 'd -> 'e) -> 'a -> 'b -> 'c -> 'd -> 'e = "mycallback4"
+val tak : int * int * int -> int
+val tak2 : int -> int * int -> int
+val tak3 : int -> int -> int -> int
+val tak4 : int -> int -> int -> int -> int
+val raise_exit : unit -> unit
+val trapexit : unit -> int
+external mypushroot : 'a -> ('b -> 'c) -> 'b -> 'a = "mypushroot"
+external mycamlparam : 'a -> ('b -> 'c) -> 'b -> 'a = "mycamlparam"
+val tripwire : (string -> (unit -> int) -> unit -> 'a) -> 'a
+val sighandler : 'a -> unit
+external unix_getpid : unit -> int = "unix_getpid" [@@noalloc]
+external unix_kill : int -> int -> unit = "unix_kill" [@@noalloc]
+val callbacksig : unit -> string

--- a/testsuite/tests/callback/test_signalhandler.reference
+++ b/testsuite/tests/callback/test_signalhandler.reference
@@ -1,0 +1,8 @@
+7
+7
+7
+7
+7
+aaaaa
+aaaaa
+bbbbb

--- a/testsuite/tests/callback/test_signalhandler_.c
+++ b/testsuite/tests/callback/test_signalhandler_.c
@@ -1,0 +1,69 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                OCaml                                   */
+/*                                                                        */
+/*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 1995 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#include "caml/mlvalues.h"
+#include "caml/memory.h"
+#include "caml/callback.h"
+
+value mycallback1(value fun, value arg)
+{
+  value res;
+  res = caml_callback(fun, arg);
+  return res;
+}
+
+value mycallback2(value fun, value arg1, value arg2)
+{
+  value res;
+  res = caml_callback2(fun, arg1, arg2);
+  return res;
+}
+
+value mycallback3(value fun, value arg1, value arg2, value arg3)
+{
+  value res;
+  res = caml_callback3(fun, arg1, arg2, arg3);
+  return res;
+}
+
+value mycallback4(value fun, value arg1, value arg2, value arg3, value arg4)
+{
+  value args[4];
+  value res;
+  args[0] = arg1;
+  args[1] = arg2;
+  args[2] = arg3;
+  args[3] = arg4;
+  res = caml_callbackN(fun, 4, args);
+  return res;
+}
+
+value mypushroot(value v, value fun, value arg)
+{
+  Begin_root(v)
+    caml_callback(fun, arg);
+  End_roots();
+  return v;
+}
+
+value mycamlparam (value v, value fun, value arg)
+{
+  CAMLparam3 (v, fun, arg);
+  CAMLlocal2 (x, y);
+  x = v;
+  y = caml_callback (fun, arg);
+  v = x;
+  CAMLreturn (v);
+}


### PR DESCRIPTION
It is currently possible to miss bugs where values in the minor heap that should be promoted are not. This happens because the data is still present in the minor heap before being over-written by a future minor allocation.

This PR clears the minor heap at the end of a minor collection and so enables us to catch this class of bugs. We actually write a debug value in to every element of the minor heap, which is useful for debugging failures.

There will be two commits on this PR. One that clears the minor heap and a second that disables the two failing tests. I'll link an issue to investigate these.