### PR TITLE
Add memprof stubs to build and stdlib

### DIFF
--- a/.depend
+++ b/.depend
@@ -2482,7 +2482,6 @@ asmcomp/emit.cmo : \
     lambda/lambda.cmi \
     asmcomp/emitaux.cmi \
     utils/domainstate.cmi \
-    lambda/debuginfo.cmi \
     utils/config.cmi \
     middle_end/compilenv.cmi \
     asmcomp/cmm.cmi \
@@ -2505,7 +2504,6 @@ asmcomp/emit.cmx : \
     lambda/lambda.cmx \
     asmcomp/emitaux.cmx \
     utils/domainstate.cmx \
-    lambda/debuginfo.cmx \
     utils/config.cmx \
     middle_end/compilenv.cmx \
     asmcomp/cmm.cmx \

--- a/.depend
+++ b/.depend
@@ -2482,6 +2482,7 @@ asmcomp/emit.cmo : \
     lambda/lambda.cmi \
     asmcomp/emitaux.cmi \
     utils/domainstate.cmi \
+    lambda/debuginfo.cmi \
     utils/config.cmi \
     middle_end/compilenv.cmi \
     asmcomp/cmm.cmi \
@@ -2504,6 +2505,7 @@ asmcomp/emit.cmx : \
     lambda/lambda.cmx \
     asmcomp/emitaux.cmx \
     utils/domainstate.cmx \
+    lambda/debuginfo.cmx \
     utils/config.cmx \
     middle_end/compilenv.cmx \
     asmcomp/cmm.cmx \

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -22,22 +22,22 @@ include $(ROOTDIR)/Makefile.common
 BYTECODE_C_SOURCES := $(addsuffix .c, \
   interp misc fix_code startup_aux startup_byt major_gc \
   minor_gc memory alloc roots globroots fail_byt signals \
-  signals_byt printexc backtrace_byt backtrace compare ints \
+  signals_byt printexc backtrace_byt backtrace compare ints eventlog \
   floats str array io extern intern hash sys meta parsing gc_ctrl md5 obj \
   lexing callback debugger weak finalise custom dynlink \
-  platform eventlog fiber shared_heap addrmap \
-  afl $(UNIX_OR_WIN32) bigarray main domain \
+  platform fiber shared_heap addrmap \
+  afl $(UNIX_OR_WIN32) bigarray main memprof domain \
   skiplist codefrag)
 
 NATIVE_C_SOURCES := $(addsuffix .c, \
   startup_aux startup_nat main fail_nat roots signals \
   signals_nat misc major_gc minor_gc memory alloc compare ints \
-  floats str array io extern intern hash sys parsing gc_ctrl md5 obj \
+  floats str array io extern intern hash sys parsing gc_ctrl eventlog md5 obj \
   lexing $(UNIX_OR_WIN32) printexc callback weak finalise custom \
   globroots backtrace_nat backtrace dynlink_nat debugger meta \
-  platform eventlog fiber shared_heap addrmap frame_descriptors \
+  platform fiber shared_heap addrmap frame_descriptors \
   dynlink clambda_checks afl bigarray \
-  domain skiplist codefrag)
+  memprof domain skiplist codefrag)
 
 GENERATED_HEADERS := caml/opnames.h caml/version.h caml/jumptbl.h
 CONFIG_HEADERS := caml/m.h caml/s.h

--- a/runtime/gen_primitives.sh
+++ b/runtime/gen_primitives.sh
@@ -23,9 +23,10 @@ export LC_ALL=C
 (
   for prim in \
       alloc array compare extern floats gc_ctrl hash intern interp ints io \
-  	  lexing md5 meta obj parsing signals str sys callback weak finalise \
-      domain platform eventlog fiber memory startup_aux \
-      dynlink backtrace_byt backtrace afl bigarray
+      lexing md5 meta memprof obj parsing signals str sys callback weak \
+      finalise domain platform fiber memory startup_aux \
+      dynlink backtrace_byt backtrace afl \
+      bigarray eventlog
   do
       sed -n -e 's/^CAMLprim value \([a-z0-9_][a-z0-9_]*\).*/\1/p' "$prim.c"
   done

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -15,6 +15,21 @@
 
 #define CAML_INTERNALS
 
+#include "caml/fail.h"
+
+CAMLprim value caml_memprof_start(value lv, value szv, value tracker_param)
+{
+  caml_failwith("Gc.memprof.start: not implemented in multicore");
+}
+
+CAMLprim value caml_memprof_stop(value unit)
+{
+  caml_failwith("Gc.memprof.stop: not implemented in multicore");
+}
+
+/* FIXME: integrate memprof with multicore */
+#if 0
+
 #include <string.h>
 #include "caml/memprof.h"
 #include "caml/fail.h"
@@ -1134,3 +1149,5 @@ CAMLexport void caml_memprof_enter_thread(struct caml_memprof_th_ctx* ctx)
   local = ctx;
   caml_memprof_set_suspended(ctx->suspended);
 }
+
+#endif /* 0 */

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -137,11 +137,9 @@ camlinternalFormatBasics.cmx : \
     camlinternalFormatBasics.cmi
 camlinternalFormatBasics.cmi :
 camlinternalLazy.cmo : \
-    stdlib__sys.cmi \
     stdlib__obj.cmi \
     camlinternalLazy.cmi
 camlinternalLazy.cmx : \
-    stdlib__sys.cmx \
     stdlib__obj.cmx \
     camlinternalLazy.cmi
 camlinternalLazy.cmi :
@@ -313,13 +311,16 @@ stdlib__gc.cmo : \
     stdlib__sys.cmi \
     stdlib__string.cmi \
     stdlib__printf.cmi \
+    stdlib__printexc.cmi \
     stdlib__gc.cmi
 stdlib__gc.cmx : \
     stdlib__sys.cmx \
     stdlib__string.cmx \
     stdlib__printf.cmx \
+    stdlib__printexc.cmx \
     stdlib__gc.cmi
-stdlib__gc.cmi :
+stdlib__gc.cmi : \
+    stdlib__printexc.cmi
 stdlib__genlex.cmo : \
     stdlib__string.cmi \
     stdlib__stream.cmi \

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -445,3 +445,106 @@ external eventlog_resume : unit -> unit = "caml_eventlog_resume"
    This call can be used after calling [eventlog_pause], or if the program
    was started with OCAML_EVENTLOG_ENABLED=p. (which pauses the collection of
    traces before the first event.) *)
+
+
+(** [Memprof] is a sampling engine for allocated memory words. Every
+   allocated word has a probability of being sampled equal to a
+   configurable sampling rate. Once a block is sampled, it becomes
+   tracked. A tracked block triggers a user-defined callback as soon
+   as it is allocated, promoted or deallocated.
+
+   Since blocks are composed of several words, a block can potentially
+   be sampled several times. If a block is sampled several times, then
+   each of the callback is called once for each event of this block:
+   the multiplicity is given in the [n_samples] field of the
+   [allocation] structure.
+
+   This engine makes it possible to implement a low-overhead memory
+   profiler as an OCaml library.
+
+   Note: this API is EXPERIMENTAL. It may change without prior
+   notice. *)
+module Memprof :
+  sig
+    type allocation_source = Normal | Marshal | Custom
+    type allocation = private
+      { n_samples : int;
+        (** The number of samples in this block (>= 1). *)
+
+        size : int;
+        (** The size of the block, in words, excluding the header. *)
+
+        source : allocation_source;
+        (** The type of the allocation. *)
+
+        callstack : Printexc.raw_backtrace
+        (** The callstack for the allocation. *)
+      }
+    (** The type of metadata associated with allocations. This is the
+       type of records passed to the callback triggered by the
+       sampling of an allocation. *)
+
+    type ('minor, 'major) tracker = {
+      alloc_minor: allocation -> 'minor option;
+      alloc_major: allocation -> 'major option;
+      promote: 'minor -> 'major option;
+      dealloc_minor: 'minor -> unit;
+      dealloc_major: 'major -> unit;
+    }
+    (**
+       A [('minor, 'major) tracker] describes how memprof should track
+       sampled blocks over their lifetime, keeping a user-defined piece
+       of metadata for each of them: ['minor] is the type of metadata
+       to keep for minor blocks, and ['major] the type of metadata
+       for major blocks.
+
+       When using threads, it is guaranteed that allocation callbacks are
+       always run in the thread where the allocation takes place.
+
+       If an allocation-tracking or promotion-tracking function returns [None],
+       memprof stops tracking the corresponding value.
+     *)
+
+    val null_tracker: ('minor, 'major) tracker
+    (** Default callbacks simply return [None] or [()] *)
+
+    val start :
+      sampling_rate:float ->
+      ?callstack_size:int ->
+      ('minor, 'major) tracker ->
+      unit
+    (** Start the sampling with the given parameters. Fails if
+       sampling is already active.
+
+       The parameter [sampling_rate] is the sampling rate in samples
+       per word (including headers). Usually, with cheap callbacks, a
+       rate of 1e-4 has no visible effect on performance, and 1e-3
+       causes the program to run a few percent slower
+
+       The parameter [callstack_size] is the length of the callstack
+       recorded at every sample. Its default is [max_int].
+
+       The parameter [tracker] determines how to track sampled blocks
+       over their lifetime in the minor and major heap.
+
+       Sampling is temporarily disabled when calling a callback
+       for the current thread. So they do not need to be re-entrant if
+       the program is single-threaded. However, if threads are used,
+       it is possible that a context switch occurs during a callback,
+       in this case the callback functions must be re-entrant.
+
+       Note that the callback can be postponed slightly after the
+       actual event. The callstack passed to the callback is always
+       accurate, but the program state may have evolved. *)
+
+    val stop : unit -> unit
+    (** Stop the sampling. Fails if sampling is not active.
+
+        This function does not allocate memory.
+
+        All the already tracked blocks are discarded. If there are
+        pending postponed callbacks, they may be discarded.
+
+        Calling [stop] when a callback is running can lead to
+        callbacks not being called even though some events happened. *)
+end


### PR DESCRIPTION
This PR merges the stdlib side changes for memprof. It also adds the pieces needed to build memprof on the runtime side. The actual memprof runtime implementation integration with multicore is for the future. 

This PR allows some useful external libraries to build: for example I tested `batteries` from an opam switch and it now installs. Before this PR it was bombing out because the memprof stdlib functions were missing. 