### PR TITLE
Remove caml_root API

### DIFF
--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -29,11 +29,6 @@
 #include "caml/debugger.h"
 #include "caml/startup.h"
 
-void caml_init_backtrace(void)
-{
-  return;
-}
-
 /* Start or stop the backtrace machinery */
 CAMLprim value caml_record_backtrace(value vflag)
 {
@@ -43,10 +38,9 @@ CAMLprim value caml_record_backtrace(value vflag)
     Caml_state->backtrace_active = flag;
     Caml_state->backtrace_pos = 0;
     if (flag) {
-      Caml_state->backtrace_last_exn = caml_create_root(Val_unit);
+      caml_modify_generational_global_root(&Caml_state->backtrace_last_exn, Val_unit);
     } else {
-      caml_delete_root(Caml_state->backtrace_last_exn);
-      Caml_state->backtrace_last_exn = NULL;
+      caml_remove_generational_global_root(&Caml_state->backtrace_last_exn);
     }
   }
   return Val_unit;
@@ -205,8 +199,7 @@ CAMLprim value caml_restore_raw_backtrace(value exn, value backtrace)
 
   caml_domain_state* domain_state = Caml_state;
 
-  if (domain_state->backtrace_last_exn != NULL)
-    caml_modify_root (domain_state->backtrace_last_exn, exn);
+  caml_modify_generational_global_root (&domain_state->backtrace_last_exn, exn);
 
   bt_size = Wosize_val(backtrace);
   if(bt_size > BACKTRACE_BUFFER_SIZE){

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -41,6 +41,7 @@ CAMLprim value caml_record_backtrace(value vflag)
       caml_modify_generational_global_root(&Caml_state->backtrace_last_exn, Val_unit);
     } else {
       caml_remove_generational_global_root(&Caml_state->backtrace_last_exn);
+      Caml_state->backtrace_last_exn = (value) NULL;
     }
   }
   return Val_unit;

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -273,9 +273,9 @@ void caml_stash_backtrace(value exn, value * sp, int reraise)
 {
   value *trap_sp;
 
-  if (exn != caml_read_root(Caml_state->backtrace_last_exn) || !reraise) {
+  if (exn != Caml_state->backtrace_last_exn || !reraise) {
     Caml_state->backtrace_pos = 0;
-    caml_modify_root(Caml_state->backtrace_last_exn, exn);
+    caml_modify_generational_global_root(&Caml_state->backtrace_last_exn, exn);
   }
 
   if (Caml_state->backtrace_buffer == NULL &&

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -80,9 +80,9 @@ void caml_stash_backtrace(value exn, uintnat pc, char * sp, char* trapsp)
   caml_domain_state* domain_state = Caml_state;
   caml_frame_descrs fds;
 
-  if (exn != caml_read_root(domain_state->backtrace_last_exn)) {
+  if (exn != domain_state->backtrace_last_exn) {
     domain_state->backtrace_pos = 0;
-    caml_modify_root(domain_state->backtrace_last_exn, exn);
+    caml_modify_generational_global_root(&domain_state->backtrace_last_exn, exn);
   }
 
   if (Caml_state->backtrace_buffer == NULL &&

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -25,8 +25,6 @@
 
 #include "misc.h"
 
-typedef struct caml_root_private* caml_root;
-
 /* This structure sits in the TLS area and is also accessed efficiently
  * via native code, which is why the indices are important */
 typedef struct {

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -84,7 +84,7 @@ DOMAIN_STATE(intnat, backtrace_active)
 
 DOMAIN_STATE(code_t*, backtrace_buffer)
 
-DOMAIN_STATE(caml_root, backtrace_last_exn)
+DOMAIN_STATE(value, backtrace_last_exn)
 
 DOMAIN_STATE(intnat, compare_unordered)
 
@@ -113,7 +113,7 @@ DOMAIN_STATE(struct pool**, pools_to_rescan)
 DOMAIN_STATE(int, pools_to_rescan_len)
 DOMAIN_STATE(int, pools_to_rescan_count)
 
-DOMAIN_STATE(caml_root, dls_root)
+DOMAIN_STATE(value, dls_root)
 /* Domain-local state */
 
 DOMAIN_STATE(value, unique_token_root)

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -77,7 +77,7 @@ struct c_stack_link {
 #define NUM_STACK_SIZE_CLASSES 5
 
 /* The table of global identifiers */
-extern caml_root caml_global_data;
+extern value caml_global_data;
 
 #define Trap_pc(tp) ((tp)[0])
 #define Trap_link(tp) ((tp)[1])

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -563,26 +563,6 @@ struct caml__roots_block {
 
 #define End_roots() CAML_LOCAL_ROOTS = caml__roots_block.next; }
 
-/* [caml_create_root] creates a new GC root, initialised to the given
-   value.  The value stored in this root may only be read and written
-   with [caml_read_root] and [caml_modify_root]. */
-
-CAMLextern caml_root caml_create_root (value);
-CAMLextern caml_root caml_create_root_noexc(value);
-
-/* [caml_delete_root] deletes a root created by caml_create_root */
-
-CAMLextern void caml_delete_root (caml_root);
-
-/* [caml_read_root] loads the value stored in a root */
-
-CAMLextern value caml_read_root (caml_root);
-
-/* [caml_modify_root] stores a new value in a root */
-
-CAMLextern void caml_modify_root (caml_root, value);
-
-
 /** Compatability with old C-API **/
 
 /* [caml_register_global_root] registers a global C variable as a memory root

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -277,9 +277,6 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
     }
 
     domain_state->dls_root = Val_unit;
-    if(domain_state->dls_root == (value)NULL) {
-      goto create_dls_root_failure;
-    }
     caml_register_generational_global_root(&domain_state->dls_root);
 
     domain_state->unique_token_root = caml_alloc_shr_noexc(Abstract_tag, Val_unit);
@@ -326,7 +323,6 @@ create_stack_cache_failure:
   caml_remove_generational_global_root(&domain_state->unique_token_root);
   caml_remove_generational_global_root(&domain_state->dls_root);
 create_unique_token_failure:
-create_dls_root_failure:
 reallocate_minor_heap_failure:
   caml_teardown_major_gc();
 init_major_gc_failure:

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -102,7 +102,7 @@ CAMLexport void caml_raise_with_string(value tag, char const *msg)
 */
 static void check_global_data(char const *exception_name)
 {
-  if (caml_global_data == 0 || !Is_block(caml_read_root(caml_global_data))) {
+  if (caml_global_data == 0 || !Is_block(caml_global_data)) {
     fprintf(stderr, "Fatal error: exception %s during initialisation\n", exception_name);
     exit(2);
   }
@@ -110,7 +110,7 @@ static void check_global_data(char const *exception_name)
 
 static void check_global_data_param(char const *exception_name, char const *msg)
 {
-  if (caml_global_data == 0 || !Is_block(caml_read_root(caml_global_data))) {
+  if (caml_global_data == 0 || !Is_block(caml_global_data)) {
     fprintf(stderr, "Fatal error: exception %s(\"%s\")\n", exception_name, msg);
     exit(2);
   }
@@ -119,7 +119,7 @@ static void check_global_data_param(char const *exception_name, char const *msg)
 Caml_inline value caml_get_failwith_tag (char const *msg)
 {
   check_global_data_param("Failure", msg);
-  return Field(caml_read_root(caml_global_data), FAILURE_EXN);
+  return Field(caml_global_data, FAILURE_EXN);
 }
 
 CAMLexport void caml_failwith (char const *msg)
@@ -138,7 +138,7 @@ CAMLexport void caml_failwith_value (value msg)
 Caml_inline value caml_get_invalid_argument_tag (char const *msg)
 {
   check_global_data_param("Invalid_argument", msg);
-  return Field(caml_read_root(caml_global_data), INVALID_EXN);
+  return Field(caml_global_data, INVALID_EXN);
 }
 
 CAMLexport void caml_invalid_argument (char const *msg)
@@ -162,56 +162,56 @@ CAMLexport void caml_array_bound_error(void)
 CAMLexport void caml_raise_out_of_memory(void)
 {
   check_global_data("Out_of_memory");
-  caml_raise_constant(Field(caml_read_root(caml_global_data),
+  caml_raise_constant(Field(caml_global_data,
                                 OUT_OF_MEMORY_EXN));
 }
 
 CAMLexport void caml_raise_stack_overflow(void)
 {
   check_global_data("Stack_overflow");
-  caml_raise_constant(Field(caml_read_root(caml_global_data),
+  caml_raise_constant(Field(caml_global_data,
                                 STACK_OVERFLOW_EXN));
 }
 
 CAMLexport void caml_raise_sys_error(value msg)
 {
   check_global_data_param("Sys_error", String_val(msg));
-  caml_raise_with_arg(Field(caml_read_root(caml_global_data),
+  caml_raise_with_arg(Field(caml_global_data,
                                 SYS_ERROR_EXN), msg);
 }
 
 CAMLexport void caml_raise_end_of_file(void)
 {
   check_global_data("End_of_file");
-  caml_raise_constant(Field(caml_read_root(caml_global_data),
+  caml_raise_constant(Field(caml_global_data,
                                 END_OF_FILE_EXN));
 }
 
 CAMLexport void caml_raise_zero_divide(void)
 {
   check_global_data("Division_by_zero");
-  caml_raise_constant(Field(caml_read_root(caml_global_data),
+  caml_raise_constant(Field(caml_global_data,
                                 ZERO_DIVIDE_EXN));
 }
 
 CAMLexport void caml_raise_not_found(void)
 {
   check_global_data("Not_found");
-  caml_raise_constant(Field(caml_read_root(caml_global_data),
+  caml_raise_constant(Field(caml_global_data,
                                 NOT_FOUND_EXN));
 }
 
 CAMLexport void caml_raise_sys_blocked_io(void)
 {
   check_global_data("Sys_blocked_io");
-  caml_raise_constant(Field(caml_read_root(caml_global_data),
+  caml_raise_constant(Field(caml_global_data,
                                 SYS_BLOCKED_IO));
 }
 
 CAMLexport void caml_raise_continuation_already_taken(void)
 {
   check_global_data("Continuation_already_taken");
-  caml_raise_constant(Field(caml_read_root(caml_global_data),
+  caml_raise_constant(Field(caml_global_data,
                                 CONTINUATION_ALREADY_TAKEN_EXN));
 }
 
@@ -229,11 +229,11 @@ int caml_is_special_exception(value exn) {
 
   value f;
 
-  if (caml_global_data == 0 || !Is_block(caml_read_root(caml_global_data))) {
+  if (caml_global_data == 0 || !Is_block(caml_global_data)) {
     return 0;
   }
 
-  f = caml_read_root(caml_global_data);
+  f = caml_global_data;
   return exn == Field(f, MATCH_FAILURE_EXN)
       || exn == Field(f, ASSERT_FAILURE_EXN)
       || exn == Field(f, UNDEFINED_RECURSIVE_MODULE_EXN);

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -227,7 +227,7 @@ void caml_maybe_expand_stack ()
 
 #else /* End NATIVE_CODE, begin BYTE_CODE */
 
-caml_root caml_global_data;
+value caml_global_data;
 
 CAMLprim value caml_alloc_stack(value hval, value hexn, value heff)
 {

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -25,57 +25,6 @@
 
 static caml_plat_mutex roots_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 
-/* legacy multicore API that we need to fix */
-CAMLexport caml_root caml_create_root(value init)
-{
-  CAMLparam1(init);
-
-  value* v = (value*)caml_stat_alloc(sizeof(value));
-
-  *v = init;
-
-  caml_register_global_root(v);
-
-  CAMLreturnT(caml_root, (caml_root)v);
-}
-
-CAMLexport caml_root caml_create_root_noexc(value init)
-{
-  CAMLparam1(init);
-
-  value* v = (value*)caml_stat_alloc_noexc(sizeof(value));
-
-  if( v == NULL ) {
-    CAMLdrop;
-    return NULL;
-  }
-
-  *v = init;
-
-  caml_register_global_root(v);
-
-  CAMLreturnT(caml_root, (caml_root)v);
-}
-
-CAMLexport void caml_delete_root(caml_root root)
-{
-  value* v = (value*)root;
-  Assert(root);
-  /* the root will be removed from roots_all and freed at the next GC */
-  caml_remove_global_root(v);
-  caml_stat_free(v);
-}
-
-CAMLexport value caml_read_root(caml_root root)
-{
-  return *((value*)root);
-}
-
-CAMLexport void caml_modify_root(caml_root root, value newv)
-{
-  *((value*)root) = newv;
-}
-
 /* The three global root lists.
    Each is represented by a skip list with the key being the address
    of the root.  (The associated data field is unused.) */

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -219,7 +219,6 @@ static __thread intnat caml_bcodcount;
 #endif
 
 static value raise_unhandled;
-value global_data;
 
 /* The interpreter itself */
 value caml_interprete(code_t prog, asize_t prog_size)
@@ -705,13 +704,12 @@ value caml_interprete(code_t prog, asize_t prog_size)
       Next;
     }
 
-    Instruct(SETGLOBAL):
-      global_data = caml_global_data;
-      caml_modify(&Field(global_data, *pc), accu);
-      caml_modify_generational_global_root(&caml_global_data, global_data);
+    Instruct(SETGLOBAL):  {
+      caml_modify(&Field(caml_global_data, *pc), accu);
       accu = Val_unit;
       pc++;
       Next;
+    }
 
 /* Allocation of blocks */
 

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -218,7 +218,8 @@ sp is a local copy of the global variable Caml_state->extern_sp. */
 static __thread intnat caml_bcodcount;
 #endif
 
-static caml_root raise_unhandled;
+static value raise_unhandled;
+value global_data;
 
 /* The interpreter itself */
 value caml_interprete(code_t prog, asize_t prog_size)
@@ -272,8 +273,10 @@ value caml_interprete(code_t prog, asize_t prog_size)
     raise_unhandled_closure = caml_alloc_small (2, Closure_tag);
     Field(raise_unhandled_closure, 0) = Val_bytecode(raise_unhandled_code);
     Closinfo_val(raise_unhandled_closure) = Make_closinfo(0, 2);
-    raise_unhandled = caml_create_root(raise_unhandled_closure);
-    caml_global_data = caml_create_root(Val_unit);
+    raise_unhandled = raise_unhandled_closure;
+    caml_register_generational_global_root(&raise_unhandled);
+    caml_global_data = Val_unit;
+    caml_register_generational_global_root(&caml_global_data);
     caml_init_callbacks();
     return Val_unit;
   }
@@ -687,7 +690,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       *--sp = accu;
       /* Fallthrough */
     Instruct(GETGLOBAL):
-      accu = Field(caml_read_root(caml_global_data), *pc);
+      accu = Field(caml_global_data, *pc);
       pc++;
       Next;
 
@@ -695,7 +698,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       *--sp = accu;
       /* Fallthrough */
     Instruct(GETGLOBALFIELD): {
-      accu = Field(caml_read_root(caml_global_data), *pc);
+      accu = Field(caml_global_data, *pc);
       pc++;
       accu = Field(accu, *pc);
       pc++;
@@ -703,7 +706,9 @@ value caml_interprete(code_t prog, asize_t prog_size)
     }
 
     Instruct(SETGLOBAL):
-      caml_modify(&Field(caml_read_root(caml_global_data), *pc), accu);
+      global_data = caml_global_data;
+      caml_modify(&Field(global_data, *pc), accu);
+      caml_modify_generational_global_root(&caml_global_data, global_data);
       accu = Val_unit;
       pc++;
       Next;
@@ -1270,7 +1275,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
 do_resume: {
       struct stack_info* stk = Ptr_val(accu);
       if (stk == NULL) {
-         accu = Field(caml_read_root(caml_global_data), CONTINUATION_ALREADY_TAKEN_EXN);
+         accu = Field(caml_global_data, CONTINUATION_ALREADY_TAKEN_EXN);
          goto raise_exception;
       }
       while (Stack_parent(stk) != NULL) stk = Stack_parent(stk);
@@ -1304,7 +1309,7 @@ do_resume: {
       struct stack_info* parent_stack = Stack_parent(old_stack);
 
       if (parent_stack == NULL) {
-        accu = Field(caml_read_root(caml_global_data), UNHANDLED_EXN);
+        accu = Field(caml_global_data, UNHANDLED_EXN);
         goto raise_exception;
       }
 
@@ -1348,8 +1353,8 @@ do_resume: {
 
       if (parent == NULL) {
         accu = caml_continuation_use(cont);
-        resume_fn = caml_read_root(raise_unhandled);
-        resume_arg = Field(caml_read_root(caml_global_data), UNHANDLED_EXN);
+        resume_fn = raise_unhandled;
+        resume_arg = Field(caml_global_data, UNHANDLED_EXN);
         goto do_resume;
       }
 

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -40,7 +40,7 @@
 
 CAMLprim value caml_get_global_data(value unit)
 {
-  return caml_read_root(caml_global_data);
+  return caml_global_data;
 }
 
 CAMLprim value caml_get_section_table(value unit)
@@ -165,7 +165,7 @@ CAMLprim value caml_realloc_global(value size)
   CAMLparam1(size);
   CAMLlocal2(old_global_data, new_global_data);
   mlsize_t requested_size, actual_size, i;
-  old_global_data = caml_read_root(caml_global_data);
+  old_global_data = caml_global_data;
 
   requested_size = Long_val(size);
   actual_size = Wosize_val(old_global_data);
@@ -180,7 +180,7 @@ CAMLprim value caml_realloc_global(value size)
     for (i = actual_size; i < requested_size; i++){
       Field (new_global_data, i) = Val_long (0);
     }
-    caml_modify_root(caml_global_data, new_global_data);
+    caml_modify_generational_global_root(&caml_global_data, new_global_data);
   }
   CAMLreturn (Val_unit);
 }

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -125,10 +125,11 @@ void caml_free_signal_stack()
 
 /* Execute a signal handler immediately */
 
-static caml_root caml_signal_handlers;
+static value caml_signal_handlers;
 
 void caml_init_signal_handling() {
-  caml_signal_handlers = caml_create_root(caml_alloc_shr(NSIG, 0));
+  caml_signal_handlers = caml_alloc_shr(NSIG, 0);
+  caml_register_generational_global_root(&caml_signal_handlers);
 }
 
 static void caml_execute_signal(int signal_number)
@@ -143,7 +144,7 @@ static void caml_execute_signal(int signal_number)
   sigaddset(&nsigs, signal_number);
   sigprocmask(SIG_BLOCK, &nsigs, &sigs);
 #endif
-  caml_read_field(caml_read_root(caml_signal_handlers), signal_number, &handler);
+  caml_read_field(caml_signal_handlers, signal_number, &handler);
   res = caml_callback_exn(
            handler,
            Val_int(caml_rev_convert_signal_number(signal_number)));
@@ -296,14 +297,16 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
     res = Val_int(1);
     break;
   case 2:                       /* was Signal_handle */
-    caml_read_field(caml_read_root(caml_signal_handlers), sig, &handler);
+    caml_read_field(caml_signal_handlers, signal_number, &handler);
     res = caml_alloc_1 (0, handler);
     break;
   default:                      /* error in caml_set_signal_action */
     caml_sys_error(NO_ARG);
   }
   if (Is_block(action)) {
-    caml_modify(&Field(caml_read_root(caml_signal_handlers), sig), Field(action, 0));
+    value signal_handlers = caml_signal_handlers;
+    caml_modify(&Field(signal_handlers, sig), Field(action, 0));
+    caml_modify_generational_global_root(&caml_signal_handlers, signal_handlers);
   }
   caml_process_pending_signals();
   CAMLreturn (res);

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -297,7 +297,7 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
     res = Val_int(1);
     break;
   case 2:                       /* was Signal_handle */
-    caml_read_field(caml_signal_handlers, signal_number, &handler);
+    caml_read_field(caml_signal_handlers, sig, &handler);
     res = caml_alloc_1 (0, handler);
     break;
   default:                      /* error in caml_set_signal_action */

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -304,9 +304,7 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
     caml_sys_error(NO_ARG);
   }
   if (Is_block(action)) {
-    value signal_handlers = caml_signal_handlers;
-    caml_modify(&Field(signal_handlers, sig), Field(action, 0));
-    caml_modify_generational_global_root(&caml_signal_handlers, signal_handlers);
+    caml_modify(&Field(caml_signal_handlers, sig), Field(action, 0));
   }
   caml_process_pending_signals();
   CAMLreturn (res);

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -361,7 +361,7 @@ CAMLexport void caml_main(char_os **argv)
   caml_seek_section(fd, &trail, "DATA");
   chan = caml_open_descriptor_in(fd);
   /* TODO: do we need multicore Lock here */
-  caml_modify_root(caml_global_data, caml_input_val(chan));
+  caml_modify_generational_global_root(&caml_global_data, caml_input_val(chan));
   /* TODO: do we need multicore Unlock here */
   caml_close_channel(chan); /* this also closes fd */
   caml_stat_free(trail.section);
@@ -445,7 +445,7 @@ CAMLexport value caml_startup_code_exn(
   /* Use the builtin table of primitives */
   caml_build_primitive_table_builtin();
   /* Load the globals */
-  caml_modify_root(caml_global_data, caml_input_value_from_block(data, data_size));
+  caml_modify_generational_global_root(&caml_global_data, caml_input_value_from_block(data, data_size));
   caml_minor_collection(); /* ensure all globals are in major heap */
   /* Record the sections (for caml_get_section_table in meta.c) */
   caml_init_section_table(section_table, section_table_size);

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -416,7 +416,7 @@ CAMLprim value caml_sys_getenv(value var)
   return val;
 }
 
-static caml_root main_argv;
+static value main_argv;
 
 CAMLprim value caml_sys_get_argv(value unit)
 {
@@ -425,18 +425,18 @@ CAMLprim value caml_sys_get_argv(value unit)
   exe_name = caml_copy_string_of_os(caml_params->exe_name);
   res = caml_alloc_small(2, 0);
   caml_initialize(&Field(res, 0), exe_name);
-  caml_initialize(&Field(res, 1), caml_read_root(main_argv));
+  caml_initialize(&Field(res, 1), main_argv);
   CAMLreturn(res);
 }
 
 CAMLprim value caml_sys_argv(value unit)
 {
-  return caml_read_root(main_argv);
+  return main_argv;
 }
 
 CAMLprim value caml_sys_modify_argv(value new_argv)
 {
-  caml_modify_root(main_argv, new_argv);
+  caml_modify_generational_global_root(&main_argv, new_argv);
   return Val_unit;
 }
 
@@ -459,7 +459,8 @@ void caml_sys_init(char_os * exe_name, char_os **argv)
   caml_init_exe_name(exe_name);
   v = caml_alloc_array((void *)caml_copy_string_of_os,
                        (char const **) argv);
-  main_argv = caml_create_root(v);
+  main_argv = v;
+  caml_register_generational_global_root(&main_argv);
 }
 
 #ifdef _WIN32

--- a/testsuite/tests/backtrace/backtrace_systhreads.ml
+++ b/testsuite/tests/backtrace/backtrace_systhreads.ml
@@ -1,0 +1,40 @@
+(* TEST
+flags = "-g"
+ocamlrunparam += ",b=1"
+* hassysthreads
+include systhreads
+** bytecode
+** native
+*)
+
+let throw_exn msg = failwith msg [@@inline never]
+
+let thread_func delay =
+  Thread.yield ();
+  try throw_exn (string_of_int delay) with
+  | exn ->
+     Thread.delay (float_of_int delay);
+     Gc.minor ();
+     raise exn
+
+let thread_backtrace (cond, mut) =
+  Thread.yield ();
+  try throw_exn "backtrace" with
+  | exn ->
+     Mutex.lock mut;
+     Condition.wait cond mut;
+     raise exn
+
+let () =
+  Random.self_init ();
+  let mut = Mutex.create () in
+  let cond = Condition.create () in
+  let backtrace_thread = Thread.create thread_backtrace (cond, mut) in
+  let threads =
+    List.init 4 begin fun i ->
+      Thread.create thread_func i
+      end
+  in
+  List.iter Thread.join threads;
+  Condition.signal cond;
+  Thread.join backtrace_thread

--- a/testsuite/tests/backtrace/backtrace_systhreads.reference
+++ b/testsuite/tests/backtrace/backtrace_systhreads.reference
@@ -1,0 +1,25 @@
+Thread 2 killed on uncaught exception Failure("0")
+Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
+Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
+Called from Thread.create.(fun) in file "thread.ml", line 41, characters 8-14
+Thread 3 killed on uncaught exception Failure("1")
+Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
+Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
+Called from Thread.create.(fun) in file "thread.ml", line 41, characters 8-14
+Thread 4 killed on uncaught exception Failure("2")
+Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
+Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
+Called from Thread.create.(fun) in file "thread.ml", line 41, characters 8-14
+Thread 5 killed on uncaught exception Failure("3")
+Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
+Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
+Called from Thread.create.(fun) in file "thread.ml", line 41, characters 8-14
+Thread 1 killed on uncaught exception Failure("backtrace")
+Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+Called from Backtrace_systhreads.thread_backtrace in file "backtrace_systhreads.ml", line 22, characters 6-27
+Re-raised at Backtrace_systhreads.thread_backtrace in file "backtrace_systhreads.ml", line 26, characters 5-14
+Called from Thread.create.(fun) in file "thread.ml", line 41, characters 8-14


### PR DESCRIPTION
This is essentially #488 rebased to `4.12+domains+effects`.

Thanks to @engil, the patch now includes a test for backtrace last exception.