### PR TITLE
Port eventlog to CTF

### DIFF
--- a/configure
+++ b/configure
@@ -2789,7 +2789,7 @@ toolchain="cc"
 profinfo=false
 profinfo_width=0
 extralibs=
-instrumented_runtime=false
+instrumented_runtime=true
 instrumented_runtime_ldlibs=""
 
 # Information about the package
@@ -2838,7 +2838,6 @@ VERSION=4.12.0+multicore
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
-
 
 
 
@@ -3104,12 +3103,11 @@ fi
 
 
 
-# Disable instrumented-runtime with multicore
 # Check whether --enable-instrumented-runtime was given.
 if test "${enable_instrumented_runtime+set}" = set; then :
   enableval=$enable_instrumented_runtime;
 else
-  enable_instrumented_runtime=no
+  enable_instrumented_runtime=auto
 fi
 
 
@@ -3202,6 +3200,7 @@ fi
 if test "${enable_installing_bytecode_programs+set}" = set; then :
   enableval=$enable_installing_bytecode_programs;
 fi
+
 
 # Check whether --enable-native-compiler was given.
 if test "${enable_native_compiler+set}" = set; then :

--- a/configure.ac
+++ b/configure.ac
@@ -61,7 +61,7 @@ toolchain="cc"
 profinfo=false
 profinfo_width=0
 extralibs=
-instrumented_runtime=false
+instrumented_runtime=true
 instrumented_runtime_ldlibs=""
 
 # Information about the package
@@ -227,12 +227,11 @@ AC_ARG_ENABLE([dependency-generation],
 AC_ARG_VAR([DLLIBS],
   [which libraries to use (in addition to -ldl) to load dynamic libs])
 
-# Disable instrumented-runtime with multicore
 AC_ARG_ENABLE([instrumented-runtime],
   [AS_HELP_STRING([--enable-instrumented-runtime],
     [build the instrumented runtime @<:@default=auto@:>@])],
   [],
-  [enable_instrumented_runtime=no])
+  [enable_instrumented_runtime=auto])
 
 AC_ARG_ENABLE([vmthreads], [],
   [AC_MSG_ERROR([The vmthreads library is no longer available. \

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -129,23 +129,6 @@ DOMAIN_STATE(intnat, stat_major_collections)
 DOMAIN_STATE(intnat, stat_forced_major_collections)
 DOMAIN_STATE(uintnat, stat_blocks_marked)
 
-/*****************************************************************************/
-/* Detailed stats */
-/*****************************************************************************/
-DOMAIN_STATE(uintnat, allocations)
-DOMAIN_STATE(uintnat, mutable_loads)
-DOMAIN_STATE(uintnat, immutable_loads)
-DOMAIN_STATE(uintnat, mutable_stores)
-DOMAIN_STATE(uintnat, immutable_stores)
-DOMAIN_STATE(uintnat, extcall_noalloc)
-DOMAIN_STATE(uintnat, extcall_alloc)
-DOMAIN_STATE(uintnat, extcall_alloc_stackargs)
-DOMAIN_STATE(uintnat, tailcall_imm)
-DOMAIN_STATE(uintnat, tailcall_ind)
-DOMAIN_STATE(uintnat, call_imm)
-DOMAIN_STATE(uintnat, call_ind)
-DOMAIN_STATE(uintnat, stackoverflow_checks)
-
 DOMAIN_STATE(uintnat, eventlog_paused)
 DOMAIN_STATE(uintnat, eventlog_enabled)
 DOMAIN_STATE(FILE*, eventlog_out)

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -129,11 +129,27 @@ DOMAIN_STATE(intnat, stat_major_collections)
 DOMAIN_STATE(intnat, stat_forced_major_collections)
 DOMAIN_STATE(uintnat, stat_blocks_marked)
 
-DOMAIN_STATE(uintnat, eventlog_startup_timestamp)
-DOMAIN_STATE(long, eventlog_startup_pid)
+/*****************************************************************************/
+/* Detailed stats */
+/*****************************************************************************/
+DOMAIN_STATE(uintnat, allocations)
+DOMAIN_STATE(uintnat, mutable_loads)
+DOMAIN_STATE(uintnat, immutable_loads)
+DOMAIN_STATE(uintnat, mutable_stores)
+DOMAIN_STATE(uintnat, immutable_stores)
+DOMAIN_STATE(uintnat, extcall_noalloc)
+DOMAIN_STATE(uintnat, extcall_alloc)
+DOMAIN_STATE(uintnat, extcall_alloc_stackargs)
+DOMAIN_STATE(uintnat, tailcall_imm)
+DOMAIN_STATE(uintnat, tailcall_ind)
+DOMAIN_STATE(uintnat, call_imm)
+DOMAIN_STATE(uintnat, call_ind)
+DOMAIN_STATE(uintnat, stackoverflow_checks)
+
 DOMAIN_STATE(uintnat, eventlog_paused)
 DOMAIN_STATE(uintnat, eventlog_enabled)
 DOMAIN_STATE(FILE*, eventlog_out)
+DOMAIN_STATE(struct event_buffer *, eventlog_buffer)
 /* See eventlog.c */
 
 // whether or not a domain is inside of a stop-the-world handler

--- a/runtime/caml/eventlog.h
+++ b/runtime/caml/eventlog.h
@@ -25,55 +25,64 @@ typedef enum {
 } ev_type;
 
 typedef enum {
-    EV_DOMAIN_SPAWN,
-    EV_DOMAIN_SEND_INTERRUPT,
-    EV_DOMAIN_IDLE_WAIT,
+    EV_COMPACT_MAIN,
+    EV_COMPACT_RECOMPACT,
     EV_EXPLICIT_GC_SET,
     EV_EXPLICIT_GC_STAT,
     EV_EXPLICIT_GC_MINOR,
     EV_EXPLICIT_GC_MAJOR,
-    EV_EXPLICIT_GC_MAJOR_SLICE,
     EV_EXPLICIT_GC_FULL_MAJOR,
     EV_EXPLICIT_GC_COMPACT,
+    EV_MAJOR,
+    EV_MAJOR_ROOTS,
+    EV_MAJOR_SWEEP,
+    EV_MAJOR_MARK_ROOTS,
+    EV_MAJOR_MARK_MAIN,
+    EV_MAJOR_MARK_FINAL,
+    EV_MAJOR_MARK,
+    EV_MAJOR_MARK_GLOBAL_ROOTS_SLICE,
+    EV_MAJOR_ROOTS_GLOBAL,
+    EV_MAJOR_ROOTS_DYNAMIC_GLOBAL,
+    EV_MAJOR_ROOTS_LOCAL,
+    EV_MAJOR_ROOTS_C,
+    EV_MAJOR_ROOTS_FINALISED,
+    EV_MAJOR_ROOTS_MEMPROF,
+    EV_MAJOR_ROOTS_HOOK,
+    EV_MAJOR_CHECK_AND_COMPACT,
+    EV_MINOR,
+    EV_MINOR_LOCAL_ROOTS,
+    EV_MINOR_REF_TABLES,
+    EV_MINOR_COPY,
+    EV_MINOR_UPDATE_WEAK,
+    EV_MINOR_FINALIZED,
+    EV_EXPLICIT_GC_MAJOR_SLICE,
+    EV_DOMAIN_SPAWN,
+    EV_DOMAIN_SEND_INTERRUPT,
+    EV_DOMAIN_IDLE_WAIT,
     EV_FINALISE_UPDATE_FIRST,
     EV_FINALISE_UPDATE_LAST,
     EV_INTERRUPT_GC,
     EV_INTERRUPT_REMOTE,
-    EV_MAJOR,
     EV_MAJOR_EPHE_MARK,
     EV_MAJOR_EPHE_SWEEP,
     EV_MAJOR_FINISH_MARKING,
     EV_MAJOR_GC_CYCLE_DOMAINS,
     EV_MAJOR_GC_PHASE_CHANGE,
     EV_MAJOR_GC_STW,
-    EV_MAJOR_MARK_ROOTS,
-    EV_MAJOR_MARK_MAIN,
-    EV_MAJOR_MARK_FINAL,
-    EV_MAJOR_MARK,
-    EV_MAJOR_MARK_GLOBAL_ROOTS_SLICE,
     EV_MAJOR_MARK_OPPORTUNISTIC,
-    EV_MAJOR_ROOTS,
-    EV_MAJOR_ROOTS_GLOBAL,
-    EV_MAJOR_ROOTS_DYNAMIC_GLOBAL,
-    EV_MAJOR_ROOTS_LOCAL,
-    EV_MAJOR_ROOTS_C,
-    EV_MAJOR_ROOTS_FINALISED,
-    EV_MAJOR_ROOTS_HOOK,
     EV_MAJOR_SLICE,
-    EV_MAJOR_SWEEP,
-    EV_MINOR,
     EV_MINOR_CLEAR,
-    EV_MINOR_FINALIZED,
     EV_MINOR_FINALIZERS_OLDIFY,
     EV_MINOR_GLOBAL_ROOTS,
     EV_MINOR_LEAVE_BARRIER,
-    EV_MINOR_LOCAL_ROOTS,
-    EV_MINOR_REF_TABLES,
-    EV_MINOR_UPDATE_WEAK,
     EV_STW_API_BARRIER,
     EV_STW_HANDLER,
     EV_STW_LEADER,
-
+    EV_MAJOR_FINISH_SWEEPING,
+    EV_MINOR_FINALIZERS_ADMIN,
+    EV_MINOR_REMEMBERED_SET,
+    EV_MINOR_REMEMBERED_SET_PROMOTE,
+    EV_MINOR_LOCAL_ROOTS_PROMOTE
 } ev_gc_phase;
 
 typedef enum {
@@ -81,6 +90,8 @@ typedef enum {
     EV_C_FORCE_MINOR_ALLOC_SMALL,
     EV_C_FORCE_MINOR_MAKE_VECT,
     EV_C_FORCE_MINOR_SET_MINOR_HEAP_SIZE,
+    EV_C_FORCE_MINOR_WEAK,
+    EV_C_FORCE_MINOR_MEMPROF,
     EV_C_MAJOR_MARK_SLICE_REMAIN,
     EV_C_MAJOR_MARK_SLICE_FIELDS,
     EV_C_MAJOR_MARK_SLICE_POINTERS,
@@ -102,12 +113,14 @@ typedef enum {
 
 #define CAML_EVENTLOG_INIT() caml_eventlog_init()
 #define CAML_EVENTLOG_DISABLE() caml_eventlog_disable()
+#define CAML_EVENTLOG_IS_BACKUP_THREAD() caml_eventlog_is_backup_thread()
 #define CAML_EV_BEGIN(p) caml_ev_begin(p)
 #define CAML_EV_END(p) caml_ev_end(p)
 #define CAML_EV_COUNTER(c, v) caml_ev_counter(c, v)
 #define CAML_EV_ALLOC(s) caml_ev_alloc(s)
 #define CAML_EV_ALLOC_FLUSH() caml_ev_alloc_flush()
 #define CAML_EV_FLUSH() caml_ev_flush()
+#define CAML_EVENTLOG_TEARDOWN() caml_eventlog_teardown()
 
 /* General note about the public API for the eventlog framework
    The caml_ev_* functions are no-op when called with the eventlog framework
@@ -120,6 +133,8 @@ typedef enum {
 
 void caml_eventlog_init(void);
 void caml_eventlog_disable(void);
+void caml_eventlog_teardown(void);
+void caml_eventlog_is_backup_thread(void);
 void caml_ev_begin(ev_gc_phase phase);
 void caml_ev_end(ev_gc_phase phase);
 void caml_ev_counter(ev_gc_counter counter, uint64_t val);
@@ -133,12 +148,14 @@ void caml_ev_flush(void);
 
 #define CAML_EVENTLOG_INIT() /**/
 #define CAML_EVENTLOG_DISABLE() /**/
+#define CAML_EVENTLOG_IS_BACKUP_THREAD() /**/
 #define CAML_EV_BEGIN(p) /**/
 #define CAML_EV_END(p) /**/
 #define CAML_EV_COUNTER(c, v) /**/
 #define CAML_EV_ALLOC(S) /**/
 #define CAML_EV_ALLOC_FLUSH() /**/
 #define CAML_EV_FLUSH() /**/
+#define CAML_EVENTLOG_TEARDOWN() /**/
 
 #endif /*CAML_INSTR*/
 

--- a/runtime/eventlog.c
+++ b/runtime/eventlog.c
@@ -375,6 +375,8 @@ void caml_ev_alloc(uint64_t sz)
 /*  Note that this function does not trigger an actual disk flush, it just
     pushes events in the event buffer.
 */
+// FIXME(engil): alloc events are not flushed on Multicore for now.
+// we have no counter currently in place in the runtime.
 void caml_ev_alloc_flush()
 {
   int i;

--- a/runtime/eventlog.c
+++ b/runtime/eventlog.c
@@ -165,7 +165,7 @@ static void thread_setup_eventlog_file(int unique_id)
   eventlog_filename = caml_secure_getenv(T("OCAML_EVENTLOG_PREFIX"));
 
   if (eventlog_filename) {
-    int ret = snprintf_os(output_file, OUTPUT_FILE_LEN, T("%s.%ld.%d.eventlog"),
+    int ret = snprintf_os(output_file, OUTPUT_FILE_LEN, T("%s-caml-%ld-%d.eventlog"),
 			  eventlog_filename, pid, unique_id);
     if (ret > OUTPUT_FILE_LEN)
       caml_fatal_error("eventlog: specified OCAML_EVENTLOG_PREFIX is too long");

--- a/runtime/eventlog.c
+++ b/runtime/eventlog.c
@@ -80,7 +80,7 @@ struct event_buffer {
 
 #define evbuf Caml_state->eventlog_buffer
 
-static int64_t startup_timestamp;
+static time_t startup_timestamp;
 static int eventlog_enabled = 0;
 
 static __thread uint8_t is_backup_thread = 0;

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -564,7 +564,7 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
     }
   }
 
- CAML_EV_BEGIN(EV_MINOR_REF_TABLES);
+ CAML_EV_BEGIN(EV_MINOR_REMEMBERED_SET);
 
   if( not_alone ) {
     int participating_idx = -1;
@@ -645,8 +645,10 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
   caml_final_do_young_roots (&oldify_one, &st, domain, 0);
   CAML_EV_END(EV_MINOR_FINALIZERS_OLDIFY);
 
+  CAML_EV_BEGIN(EV_MINOR_REMEMBERED_SET_PROMOTE);
   oldify_mopup (&st, 1); /* ephemerons promoted here */
-  CAML_EV_END(EV_MINOR_REF_TABLES);
+  CAML_EV_END(EV_MINOR_REMEMBERED_SET_PROMOTE);
+  CAML_EV_END(EV_MINOR_REMEMBERED_SET);
   caml_gc_log("promoted %d roots, %lu bytes", remembered_roots, st.live_bytes);
 
   CAML_EV_BEGIN(EV_MINOR_FINALIZERS_ADMIN);
@@ -673,7 +675,9 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
   CAML_EV_BEGIN(EV_MINOR_LOCAL_ROOTS);
   caml_do_local_roots(&oldify_one, &st, domain->state->local_roots, domain->state->current_stack, domain->state->gc_regs);
   if (caml_scan_roots_hook != NULL) (*caml_scan_roots_hook)(&oldify_one, &st, domain);
+  CAML_EV_BEGIN(EV_MINOR_LOCAL_ROOTS_PROMOTE);
   oldify_mopup (&st, 0);
+  CAML_EV_END(EV_MINOR_LOCAL_ROOTS_PROMOTE);
   CAML_EV_END(EV_MINOR_LOCAL_ROOTS);
 
   /* we reset these pointers before allowing any mutators to be

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -95,7 +95,6 @@ value caml_startup_common(char_os **argv, int pooling)
 
   /* Determine options */
   caml_parse_ocamlrunparam();
-  CAML_EVENTLOG_INIT();
 #ifdef DEBUG
   caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
 #endif

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -70,3 +70,6 @@ tool-debugger
 
 # since promotion is based on minor heap size now, this test can no longer be correct
 tests/promotion/bigrecmod.ml
+
+# instrumented runtime test is not very useful (and broken on multicore.) (#9413)
+tests/instrumented-runtime/'main.ml' with 1.1 (native)

--- a/tools/eventlog_metadata.in
+++ b/tools/eventlog_metadata.in
@@ -51,8 +51,11 @@ stream {
     id = 0;
     event.header := struct { /* for each event */
         tracing_clock_int_t timestamp;
-        uint32_t pid;
         uint32_t id;
+    };
+    event.context := struct {
+        uint32_t tid;
+	uint8_t is_backup_thread;
     };
 };
 
@@ -94,7 +97,42 @@ enum gc_phase : uint16_t {
     "minor/copy",
     "minor/update_weak",
     "minor/finalized",
-    "explicit/gc_major_slice"
+    "explicit/gc_major_slice",
+    "domain/spawn",
+    "domain/send_interrupt",
+    "domain/idle_wait",
+    "finalise/update_first",
+    "finalise/update_last",
+    "interrupt/gc",
+    "interrupt/remote",
+    "major/ephe_mark",
+    "major/ephe_sweep",
+    "major/finish_marking",
+    "major_gc/cycle_domains",
+    "major_gc/phase_change",
+    "major_gc/stw",
+    "major/mark_opportunistic",
+    "major/slice",
+    "minor/clear",
+    "minor/finalizers/oldify",
+    "minor/global_roots",
+    "minor/leave_barrier",
+    "stw/api_barrier",
+    "stw/handler",
+    "stw/leader",
+    "minor/clear",
+    "minor_finalized",
+    "minor_finalizers_oldify",
+    "minor_global_roots",
+    "minor_leave_barrier",
+    "minor_local_roots",
+    "minor_ref_tables",
+    "minor_update_weak",
+    "stw_api_barrier",
+    "stw_handler",
+    "stw_leader",
+    "major_finish_sweeping",
+    "minor_finalizers_admin"
 };
 
 /*


### PR DESCRIPTION
Still some work to do on this one.

Some bits to refactor:
- I think the core logic is fine, but I may need to stress test it.
- I need to make sure we get similar logs between the previous (`parallel_minor_gc`) eventlog and this one.
- I need to push changes to https://github.com/ocaml-multicore/eventlog-tools

I think I may be missing some events that existed in our previous eventlog implementation, I need to check that.