### PR TITLE
Expand CI runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,20 +3,10 @@ name: main
 on: [push, pull_request]
 
 jobs:
-  build:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - name: linux-debug
-            os: ubuntu-latest
-            env: OCAMLRUNPARAM=v=0,V=1 USE_RUNTIME=d
-          - name: linux
-            os: ubuntu-latest
-          - name: macos
-            os: macos-latest
 
+  build:
+    name: 'linux'
+    runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -26,6 +16,88 @@ jobs:
       - name: Build
         run: |
           MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build
-      - name: Run the testsuite
+      - name: Prepare Artifact
         run: |
-          ${{ matrix.env }} bash -xe tools/ci/actions/runner.sh test
+          tar -czf /tmp/sources.tar.gz .
+      - uses: actions/upload-artifact@v2
+        with:
+          name: compiler
+          path: /tmp/sources.tar.gz
+          retention-days: 1
+
+  build-misc:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: linux-O0
+            os: ubuntu-latest
+            config_arg: CFLAGS='-O0'
+          - name: linux-debug
+            os: ubuntu-latest
+            env: OCAMLRUNPARAM=v=0,V=1 USE_RUNTIME=d
+          - name: macos
+            os: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: configure tree
+        run: |
+          CONFIG_ARG=${{ matrix.config_arg }} MAKE_ARG=-j XARCH=x64 bash -xe tools/ci/actions/runner.sh configure
+      - name: Build
+        run: |
+          MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build
+      - name: Run the testsuite
+        if: ${{ matrix.name != 'linux-O0' }}
+        run: |
+          bash -xe tools/ci/actions/runner.sh test
+      - name: Run the testsuite (linux-O0, parallel)
+        if: ${{ matrix.name == 'linux-O0' }}
+        env:
+          OCAMLRUNPARAM: v=0,V=1
+          USE_RUNTIME: d
+        run: |
+          bash -xe tools/ci/actions/runner.sh test_multicore 1 "parallel" "lib-threads" "lib-systhreads"
+
+  testsuite:
+    needs: build
+    # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idneeds    strategy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        id:
+          - debug-s4096
+          - taskset
+          - normal
+          - super
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: compiler
+      - name: Unpack Artifact
+        run: |
+          tar xf sources.tar.gz
+      - name: Run the testsuite
+        if: ${{ matrix.id == 'normal' }}
+        run: |
+          bash -xe tools/ci/actions/runner.sh test
+      - name: Run the testsuite (Super Charged)
+        if: ${{ matrix.id == 'super' }}
+        run: |
+          bash -xe tools/ci/actions/runner.sh test_multicore 3 "parallel" \
+          "callback" "gc-roots" "effects" "lib-threads" "lib-systhreads" \
+          "weak-ephe-final"
+      - name: Run the testsuite (s=4096, debug runtime)
+        env:
+          OCAMLRUNPARAM: s=4096,v=0
+          USE_RUNTIME: d
+        if: ${{ matrix.id == 'debug-s4096' }}
+        run: |
+          bash -xe tools/ci/actions/runner.sh test_multicore 1 "parallel" \
+          "effects" "lib-threads" "lib-systhreads" "weak-ephe-final"
+      - name: Run the testsuite (taskset -c 0)
+        if: ${{ matrix.id == 'taskset' }}
+        run: |
+          bash -xe tools/ci/actions/runner.sh test_multicore 1 "parallel" \
+          "effects" "lib-threads" "lib-systhreads" "weak-ephe-final"

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -67,6 +67,20 @@ Test () {
   cd ..
 }
 
+TestLoop () {
+  echo Running testsuite for "$@"
+  rm -f to_test.txt
+  for test in "$@"
+  do
+      echo tests/$test >> to_test.txt
+  done
+  for it in {1..$2}
+  do
+      $MAKE -C testsuite one LIST=../to_test.txt || exit 1
+  done || exit 1
+  cd ..
+}
+
 API_Docs () {
   echo Ensuring that all library documentation compiles
   $MAKE -C ocamldoc html_doc pdf_doc texi_doc
@@ -116,6 +130,7 @@ case $1 in
 configure) Configure;;
 build) Build;;
 test) Test;;
+test_multicore) TestLoop "${@:3}";;
 api-docs) API_Docs;;
 install) Install;;
 other-checks) Checks;;


### PR DESCRIPTION
This PR is aiming to improve our CI runs to make it easier for us to spot bugs in the wild.
This is a follow up to #524 

Currently implemented:
- [x] Running "parallel" "callback" "gc-roots" "effects" "lib-threads" "lib-systhreads" "weak-ephe-final" in a loop, 3 times for now.
- [x] Running the testsuite with `taskset -c 0` (following @sadiqj suggestion, I assume his finding was the `domain_id` test failing in such context.)
- [x] Running the testsuite with a small minor heap (4096 words), debug runtime.
- [x] `-O0` runs 

What needs to be done:
- [ ] maybe add more variants?
- [ ] Maybe reduce the testsuite run to the select few directories, for both the `taskset` and the small minor heap runs.


