### PR TITLE
Fix off-by-1 with gc_regs buckets

### DIFF
--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -145,14 +145,13 @@ static inline void scan_stack_frames(scanning_action f, void* fdata, struct stac
   caml_frame_descrs fds = caml_get_frame_descrs();
 
   sp = (char*)stack->sp;
+  regs = gc_regs;
 
 next_chunk:
   if (sp == (char*)Stack_high(stack)) return;
 
   retaddr = *(uintnat*)sp;
   sp += sizeof(value);
-
-  regs = gc_regs;
 
   while(1) {
     /* Find the descriptor corresponding to the return address */
@@ -178,11 +177,11 @@ next_chunk:
       retaddr = Saved_return_address(sp);
       /* XXX KC: disabled already scanned optimization. */
     } else {
-      /* This marks the top of an ML stack chunk. Move sp to the previous stack
-       * chunk. This includes skipping over the trap frame (2 words). */
-      sp += 2 * sizeof(value); /* trap frame */
-      regs = *(value**)sp;
-      sp += 2 * sizeof(value); /* DWARF and gc_regs */
+      /* This marks the top of an ML stack chunk. Move sp to the previous
+       * stack chunk.  */
+      sp += 3 * sizeof(value); /* trap frame & DWARF pointer */
+      regs = *(value**)sp;     /* update gc_regs */
+      sp += 1 * sizeof(value); /* gc_regs */
       goto next_chunk;
     }
   }

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -79,7 +79,3 @@ tool-debugger
 
 # since promotion is based on minor heap size now, this test can no longer be correct
 tests/promotion/bigrecmod.ml
-
-# TODO: disabled as there's a bug with signal handlers
-# https://github.com/ocaml-multicore/ocaml-multicore/issues/517
-tests/callback/'test_signalhandler.ml' with 1.2 (native)


### PR DESCRIPTION
This PR fixes #517. 

The bug is an off-by-1 on the location of the previous `gc_regs` bucket when scanning the stack. The location of the previous `gc_regs` bucket is setup in `caml_start_program` (in amd64.S) when we enter OCaml from C. We also had a bug where we dropped the `regs` update when looping through `next_chunk`.