### PR TITLE
Make native stack size limit configurable (and fix Gc.set)

### DIFF
--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -24,6 +24,20 @@
 #define fiber_debug_log(...)
 #endif
 
+void caml_change_max_stack_size (uintnat new_max_size)
+{
+  struct stack_info *current_stack = Caml_state->current_stack;
+  asize_t size = Stack_high(current_stack) - (value*)current_stack->sp
+                 + Stack_threshold / sizeof (value);
+
+  if (new_max_size < size) new_max_size = size;
+  if (new_max_size != caml_max_stack_size){
+    caml_gc_log ("Changing stack limit to %luk bytes",
+                     new_max_size * sizeof (value) / 1024);
+  }
+  caml_max_stack_size = new_max_size;
+}
+
 struct stack_info** caml_alloc_stack_cache () {
   int i;
 
@@ -251,19 +265,6 @@ CAMLprim value caml_ensure_stack_capacity(value required_space)
     if (!caml_try_realloc_stack(req))
       caml_raise_stack_overflow();
   return Val_unit;
-}
-
-void caml_change_max_stack_size (uintnat new_max_size)
-{
-  asize_t size = Stack_high(Caml_state->current_stack) - Caml_state->current_stack->sp
-                 + Stack_threshold / sizeof (value);
-
-  if (new_max_size < size) new_max_size = size;
-  if (new_max_size != caml_max_stack_size){
-    caml_gc_log ("Changing stack limit to %luk bytes",
-                     new_max_size * sizeof (value) / 1024);
-  }
-  caml_max_stack_size = new_max_size;
 }
 
 /*

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -142,9 +142,8 @@ type control =
 
     mutable stack_limit : int;
     [@ocaml.deprecated_mutable "Use {(Gc.get()) with Gc.stack_limit = ...}"]
-    (** The maximum size of the stack (in words).  This is only
-       relevant to the byte-code runtime, as the native code runtime
-       uses the operating system's stack.  Default: 1024k. *)
+    (** The maximum size of the fiber stacks (in words).
+       Default: 1024k. *)
 
     mutable allocation_policy : int;
     [@ocaml.deprecated_mutable

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -69,11 +69,6 @@ tests/lib-threads/'mutex_errors.ml' with 1.2 (native)
 tests/lib-threads/'pr9971.ml' with 1.1 (bytecode)
 tests/lib-threads/'pr9971.ml' with 1.2 (native)
 
-# TODO: our gc.set interface is not fully working (see #9326)
-# which make sense and which don't in multicore?
-tests/regression/pr9326/'gc_set.ml' with 1 (native)
-tests/regression/pr9326/'gc_set.ml' with 2 (bytecode)
-
 # ocamldebug is broken (#34)
 tool-debugger
 

--- a/testsuite/tests/regression/pr9326/gc_set.ml
+++ b/testsuite/tests/regression/pr9326/gc_set.ml
@@ -4,31 +4,35 @@
 open Gc
 
 let min_heap_sz = 524288 (* 512k *)
-let maj_heap_inc = 4194304 (* 4M *)
+let space_overhead = 70
+let stack_limit = 4194304 (* 4M *)
+let custom_major_ratio = 40
+let custom_minor_ratio = 99
+let custom_minor_max_size = 4096
 
 let _ =
   let g1 = Gc.get() in
   (* Do not use { g1 with ... }, so that the code will break if more fields
      are added to the Gc.control record type *)
   Gc.set { minor_heap_size = min_heap_sz;
-           major_heap_increment = maj_heap_inc;
-           space_overhead = g1.space_overhead;
+           major_heap_increment = g1.major_heap_increment;
+           space_overhead = space_overhead;
            verbose = g1.verbose;
            max_overhead = g1.max_overhead;
-           stack_limit = g1.stack_limit;
+           stack_limit = stack_limit;
            allocation_policy = g1.allocation_policy;
            window_size = g1.window_size;
-           custom_major_ratio = g1.custom_major_ratio;
-           custom_minor_ratio = g1.custom_minor_ratio;
-           custom_minor_max_size = g1.custom_minor_max_size };
+           custom_major_ratio = custom_major_ratio;
+           custom_minor_ratio = custom_minor_ratio;
+           custom_minor_max_size = custom_minor_max_size };
   let g2 = Gc.get() in
   assert (g2.minor_heap_size = min_heap_sz);
-  assert (g2.space_overhead = g1.space_overhead);
+  assert (g2.space_overhead = space_overhead);
   assert (g2.verbose = g1.verbose);
   assert (g2.max_overhead = g1.max_overhead);
-  assert (g2.stack_limit = g1.stack_limit);
+  assert (g2.stack_limit = stack_limit);
   assert (g2.allocation_policy = g1.allocation_policy);
   assert (g2.window_size = g1.window_size);
-  assert (g2.custom_major_ratio = g1.custom_major_ratio);
-  assert (g2.custom_minor_ratio = g1.custom_minor_ratio);
-  assert (g2.custom_minor_max_size = g1.custom_minor_max_size)
+  assert (g2.custom_major_ratio = custom_major_ratio);
+  assert (g2.custom_minor_ratio = custom_minor_ratio);
+  assert (g2.custom_minor_max_size = custom_minor_max_size)


### PR DESCRIPTION
This PR makes the stack size limit for fibers configurable in native mode through the `Gc.set` interface. The motivation is to provide a mechanism to programmatically set the maximum stack size (in addition to the existing `OCAMLRUNPARAM=l=1G`); see #529. 

It also fixes a bug we had with `Gc.set` where a minor collection could invalidate `v` (we match upstream by moving the minor collection operation to the end) and enables the `gc_set.ml` test.
