### PR TITLE
Addition of test for finaliser callback with major cycle

### DIFF
--- a/testsuite/tests/callback/test_finaliser_gc.ml
+++ b/testsuite/tests/callback/test_finaliser_gc.ml
@@ -1,15 +1,12 @@
 (* TEST
 *)
 
-let rec tak (x, y, z as _tuple) =
-  if x > y then tak(tak (x-1, y, z), tak (y-1, z, x), tak (z-1, x, y))
-           else z
-
-let finaliser_status = ref "Finaliser NOT run"
 let z = ref (0, 1, 2, 3, 4, 5, 6, 7)
+let finaliser_pending = ref true
 
 let force_gc_fn _ =
-  finaliser_status := "Finaliser has run!";
+  print_string "Finaliser has run!"; print_newline();
+  finaliser_pending := false;
   Gc.full_major ()
 
 let trigger_finaliser () =
@@ -20,12 +17,15 @@ let trigger_finaliser () =
   let s = String.make 5 'b' in
   (* Spin on the minor heap allocating but keep [s] in a
     register and force a major cycle such that the
-    finaliser runs *)
-  for x = 0 to 10_000_000 do
-    z := (x, x, x, x, x, x, x, x);
+    finaliser runs.
+    NB: we quit after ~8B words allocated should something
+    be broken with finalisers *)
+  let x = ref 0 in
+  while (!x < 1_000_000_000) && !finaliser_pending do
+    z := (!x, !x, !x, !x, !x, !x, !x, !x);
+    incr x;
   done;
   s
 
 let _ =
   print_string (trigger_finaliser ()); print_newline();
-  print_string (!finaliser_status); print_newline()

--- a/testsuite/tests/callback/test_finaliser_gc.ml
+++ b/testsuite/tests/callback/test_finaliser_gc.ml
@@ -1,0 +1,31 @@
+(* TEST
+*)
+
+let rec tak (x, y, z as _tuple) =
+  if x > y then tak(tak (x-1, y, z), tak (y-1, z, x), tak (z-1, x, y))
+           else z
+
+let finaliser_status = ref "Finaliser NOT run"
+let z = ref (0, 1, 2, 3, 4, 5, 6, 7)
+
+let force_gc_fn _ =
+  finaliser_status := "Finaliser has run!";
+  Gc.full_major ()
+
+let trigger_finaliser () =
+  (* Construct finaliser which when run will force
+     a major cycle *)
+  Gc.finalise force_gc_fn (ref 0);
+  (* Allocate a block in the minor heap *)
+  let s = String.make 5 'b' in
+  (* Spin on the minor heap allocating but keep [s] in a
+    register and force a major cycle such that the
+    finaliser runs *)
+  for x = 0 to 10_000_000 do
+    z := (x, x, x, x, x, x, x, x);
+  done;
+  s
+
+let _ =
+  print_string (trigger_finaliser ()); print_newline();
+  print_string (!finaliser_status); print_newline()

--- a/testsuite/tests/callback/test_finaliser_gc.reference
+++ b/testsuite/tests/callback/test_finaliser_gc.reference
@@ -1,2 +1,2 @@
-bbbbb
 Finaliser has run!
+bbbbb

--- a/testsuite/tests/callback/test_finaliser_gc.reference
+++ b/testsuite/tests/callback/test_finaliser_gc.reference
@@ -1,0 +1,2 @@
+bbbbb
+Finaliser has run!


### PR DESCRIPTION
This is a follow up to #530 which adds a test where a finaliser is run with a root in a register; which was the source of the bug in #517. 

This is the same bug, but is slightly different in how it manifests because the register root is missed by the major collector when the finaliser forces a complete cycling of the heap. 
