### PR TITLE
Systhreads synchronizations use pthread functions

### DIFF
--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -86,8 +86,6 @@ void caml_plat_mutex_free(caml_plat_mutex*);
 typedef struct { pthread_cond_t cond; caml_plat_mutex* mutex; } caml_plat_cond;
 #define CAML_PLAT_COND_INITIALIZER(m) { PTHREAD_COND_INITIALIZER, m }
 void caml_plat_cond_init(caml_plat_cond*, caml_plat_mutex*);
-void caml_plat_cond_init_no_mutex(caml_plat_cond* cond);
-void caml_plat_cond_set_mutex(caml_plat_cond *cond, caml_plat_mutex* m);
 void caml_plat_wait(caml_plat_cond*);
 /* like caml_plat_wait, but if caml_time_counter() surpasses the second parameter
    without a signal, then this function returns 1. */

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -70,21 +70,6 @@ void caml_plat_cond_init(caml_plat_cond* cond, caml_plat_mutex* m)
   cond->mutex = m;
 }
 
-/* TODO: This specific entrypoint is required for systhreads.
-   Refactoring conditions in platform context with support for
-   systhreads style conditions would be useful. */
-void caml_plat_cond_init_no_mutex(caml_plat_cond* cond)
-{
-  caml_plat_cond_init_aux(cond);
-  cond->mutex = NULL;
-}
-
-void caml_plat_cond_set_mutex(caml_plat_cond *cond, caml_plat_mutex* m)
-{
-  if (cond->mutex == NULL)
-    cond->mutex = m;
-}
-
 void caml_plat_wait(caml_plat_cond* cond)
 {
   caml_plat_assert_locked(cond->mutex);


### PR DESCRIPTION
Extending #523, this patch aims to get systhreads error checking in-line with trunk. Currently we use `caml_plat_*` functions in systhreads for synchronizations. They have slightly different error codes than `pthread_*` functions.

In this patch, they are made to use `pthread_*` functions directly and raise `Sys_error` when something goes wrong, in place of `Fatal error` that's raised now.