### PR TITLE
Move allocation size information to frame descriptors

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -277,27 +277,16 @@ let record_frame live dbg =
 (* Record calls to the GC -- we've moved them out of the way *)
 
 type gc_call =
-  { gc_size: int;                       (* Allocation size, in bytes *)
-    gc_lbl: label;                      (* Entry label *)
+  { gc_lbl: label;                      (* Entry label *)
     gc_return_lbl: label;               (* Where to branch after GC *)
     gc_frame: label;                    (* Label of frame descriptor *)
-    is_poll : bool
   }
 
 let call_gc_sites = ref ([] : gc_call list)
 
 let emit_call_gc gc =
   def_label gc.gc_lbl;
-  if gc.is_poll then begin
-    emit_call "caml_call_poll"
-  end else begin
-    match gc.gc_size with
-    | 16 -> emit_call "caml_call_gc1"
-    | 24 -> emit_call "caml_call_gc2"
-    | 32 -> emit_call "caml_call_gc3"
-    | n ->  I.add (int n) r15;
-            emit_call "caml_call_gc"
-  end;
+  emit_call "caml_call_gc";
   def_label gc.gc_frame;
   I.jmp (label gc.gc_return_lbl)
 
@@ -678,8 +667,6 @@ let emit_instr fallthrough i =
       end
   | Lop(Ialloc { bytes = n; dbginfo }) ->
       if !fastcode_flag then begin
-        let lbl_redo = new_label() in
-        def_label lbl_redo;
         I.sub (int n) r15;
         if Config.stats then begin
           I.inc (domain_field Domainstate.Domain_allocations);
@@ -690,13 +677,13 @@ let emit_instr fallthrough i =
           record_frame_label i.live (Dbg_alloc dbginfo)
         in
         I.jb (label lbl_call_gc);
+        let lbl_after_alloc = new_label() in
+        def_label lbl_after_alloc;
         I.lea (mem64 NONE 8 R15) (res i 0);
         call_gc_sites :=
-          { gc_size = n;
-            gc_lbl = lbl_call_gc;
-            gc_return_lbl = lbl_redo;
-            gc_frame = lbl_frame;
-            is_poll = false } :: !call_gc_sites
+          { gc_lbl = lbl_call_gc;
+            gc_return_lbl = lbl_after_alloc;
+            gc_frame = lbl_frame; } :: !call_gc_sites
       end else begin
         if Config.stats then begin
           I.inc (domain_field Domainstate.Domain_allocations);
@@ -792,19 +779,17 @@ let emit_instr fallthrough i =
   | Lop (Inop) -> I.nop ()
   | Lop (Ipoll) ->
       I.cmp (domain_field Domainstate.Domain_young_limit) r15;
-      let gc_call_label = new_label () in
-      let label_after_gc = new_label () in
+      let lbl_call_gc = new_label() in
       let lbl_frame =
-        record_frame_label i.live (Dbg_other i.dbg)
+        record_frame_label i.live (Dbg_alloc [])
       in
-      I.jb (label gc_call_label);
+      I.jb (label lbl_call_gc);
+      let lbl_after_poll = new_label() in
+      def_label lbl_after_poll;
       call_gc_sites :=
-        { gc_size = 0;
-          gc_lbl = gc_call_label;
-          gc_return_lbl = label_after_gc;
-          gc_frame = lbl_frame;
-          is_poll = true } :: !call_gc_sites;
-      def_label label_after_gc;
+        { gc_lbl = lbl_call_gc;
+          gc_return_lbl = lbl_after_poll;
+          gc_frame = lbl_frame; } :: !call_gc_sites;
       ()
   | Lreloadretaddr ->
       ()
@@ -1092,9 +1077,6 @@ let begin_assembly() =
   all_functions := [];
   if system = S_win64 then begin
     D.extrn "caml_call_gc" NEAR;
-    D.extrn "caml_call_gc1" NEAR;
-    D.extrn "caml_call_gc2" NEAR;
-    D.extrn "caml_call_gc3" NEAR;
     D.extrn "caml_c_call" NEAR;
     D.extrn "caml_allocN" NEAR;
     D.extrn "caml_alloc1" NEAR;

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -676,7 +676,7 @@ let emit_instr fallthrough i =
       | Double | Double_u ->
           I.movsd (arg i 0) (addressing addr REAL8 i 1)
       end
-  | Lop(Ialloc { bytes = n; dbginfo = _ }) ->
+  | Lop(Ialloc { bytes = n; dbginfo }) ->
       if !fastcode_flag then begin
         let lbl_redo = new_label() in
         def_label lbl_redo;
@@ -687,7 +687,7 @@ let emit_instr fallthrough i =
         I.cmp (domain_field Domainstate.Domain_young_limit) r15;
         let lbl_call_gc = new_label() in
         let lbl_frame =
-          record_frame_label i.live (Dbg_other i.dbg)
+          record_frame_label i.live (Dbg_alloc dbginfo)
         in
         I.jb (label lbl_call_gc);
         I.lea (mem64 NONE 8 R15) (res i 0);
@@ -709,7 +709,7 @@ let emit_instr fallthrough i =
           I.mov (int n) rax;
           emit_call "caml_allocN"
         end;
-        let label = record_frame_label i.live (Dbg_other i.dbg) in
+        let label = record_frame_label i.live (Dbg_alloc dbginfo) in
         def_label label;
         I.lea (mem64 NONE 8 R15) (res i 0)
       end

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -39,6 +39,7 @@ val emit_debug_info_gen :
   (file_num:int -> line:int -> col:int -> unit) -> unit
 
 type frame_debuginfo =
+| Dbg_alloc of Debuginfo.alloc_dbginfo
   | Dbg_raise of Debuginfo.t
   | Dbg_other of Debuginfo.t
 

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -39,7 +39,7 @@ val emit_debug_info_gen :
   (file_num:int -> line:int -> col:int -> unit) -> unit
 
 type frame_debuginfo =
-| Dbg_alloc of Debuginfo.alloc_dbginfo
+  | Dbg_alloc of Debuginfo.alloc_dbginfo
   | Dbg_raise of Debuginfo.t
   | Dbg_other of Debuginfo.t
 

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -483,45 +483,25 @@ ENDFUNCTION(G(caml_call_realloc_stack))
 
 FUNCTION(G(caml_call_gc))
 CFI_STARTPROC
-        movq    $0, %rax
-        jmp     LBL(call_gc_and_retry_alloc)
+LBL(caml_call_gc):
+        SAVE_ALL_REGS
+        movq    %r15, Caml_state(gc_regs)
+        SWITCH_OCAML_TO_C_NO_CTXT(0)
+        C_call (GCALL(caml_garbage_collection))
+        SWITCH_C_TO_OCAML_NO_CTXT
+        movq    Caml_state(gc_regs), %r15
+        RESTORE_ALL_REGS
+        ret
 CFI_ENDPROC
 ENDFUNCTION(G(caml_call_gc))
-
-FUNCTION(G(caml_call_gc1))
-CFI_STARTPROC
-        addq    $16, %r15
-        movq    $0, %rax
-        jmp     LBL(call_gc_and_retry_alloc)
-CFI_ENDPROC
-ENDFUNCTION(G(caml_call_gc1))
-
-FUNCTION(G(caml_call_gc2))
-CFI_STARTPROC
-        addq    $24, %r15
-        movq    $0, %rax
-        jmp     LBL(call_gc_and_retry_alloc)
-CFI_ENDPROC
-ENDFUNCTION(G(caml_call_gc2))
-
-FUNCTION(G(caml_call_gc3))
-CFI_STARTPROC
-        addq    $32, %r15
-        movq    $0, %rax
-        jmp     LBL(call_gc_and_retry_alloc)
-CFI_ENDPROC
-ENDFUNCTION(G(caml_call_gc3))
 
 FUNCTION(G(caml_alloc1))
 CFI_STARTPROC
 LBL(caml_alloc1):
         subq    $16, %r15
         cmpq    Caml_state(young_limit), %r15
-        jb      LBL(100)
+        jb      LBL(caml_call_gc)
         ret
-LBL(100):
-        movq    $16, %rax
-        jmp     LBL(call_gc_and_retry_alloc)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_alloc1))
 
@@ -530,11 +510,8 @@ CFI_STARTPROC
 LBL(caml_alloc2):
         subq    $24, %r15
         cmpq    Caml_state(young_limit), %r15
-        jb      LBL(101)
+        jb      LBL(caml_call_gc)
         ret
-LBL(101):
-        movq    $24, %rax
-        jmp     LBL(call_gc_and_retry_alloc)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_alloc2))
 
@@ -543,11 +520,8 @@ CFI_STARTPROC
 LBL(caml_alloc3):
         subq    $32, %r15
         cmpq    Caml_state(young_limit), %r15
-        jb      LBL(102)
+        jb      LBL(caml_call_gc)
         ret
-LBL(102):
-        movq    $32, %rax
-        jmp     LBL(call_gc_and_retry_alloc)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_alloc3))
 
@@ -557,34 +531,10 @@ CFI_STARTPROC
 LBL(caml_allocN):
         subq    %rax, %r15
         cmpq    Caml_state(young_limit), %r15
-        jb      LBL(call_gc_and_retry_alloc)
+        jb      LBL(caml_call_gc)
         ret
-LBL(call_gc_and_retry_alloc):
-        addq    %rax, %r15
-        SAVE_ALL_REGS
-        movq    %r15, Caml_state(gc_regs)
-        SWITCH_OCAML_TO_C_NO_CTXT(0)
-        C_call (GCALL(caml_garbage_collection))
-        SWITCH_C_TO_OCAML_NO_CTXT
-        movq    Caml_state(gc_regs), %r15
-        RESTORE_ALL_REGS
-        jmp     LBL(caml_allocN)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_allocN))
-
-FUNCTION(G(caml_call_poll))
-CFI_STARTPROC
-LBL(caml_call_poll):
-        SAVE_ALL_REGS
-        movq    %r15, Caml_state(gc_regs)
-        SWITCH_OCAML_TO_C_NO_CTXT(0)
-        C_call (GCALL(caml_garbage_collection))
-        SWITCH_C_TO_OCAML_NO_CTXT
-        movq    Caml_state(gc_regs), %r15
-        RESTORE_ALL_REGS
-        ret
-CFI_ENDPROC
-ENDFUNCTION(G(caml_call_poll))
 
 /******************************************************************************/
 /* Call a C function from OCaml */

--- a/runtime/frame_descriptors.h
+++ b/runtime/frame_descriptors.h
@@ -19,6 +19,9 @@ typedef struct {
     Debug info is stored as a relative offset to a debuginfo structure. */
 } frame_descr;
 
+/* Allocation lengths are encoded as 0-255, giving sizes 1-256 */
+#define Wosize_encoded_alloc_len(n) ((uintnat)(n) + 1)
+
 /* Used to compute offsets in frame tables.
    ty must have power-of-2 size */
 #define Align_to(p, ty) \

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -116,12 +116,6 @@ void caml_garbage_collection()
   /* Re-do the allocation: we now have enough space in the minor heap. */
   Caml_state->young_ptr -= alloc_bsize;
 
-#ifdef WITH_SPACETIME
-  if (caml_young_ptr == caml_young_alloc_end) {
-    caml_spacetime_automatic_snapshot();
-  }
-#endif
-
   caml_process_pending_signals();
 }
 

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -29,10 +29,12 @@
 #include "caml/codefrag.h"
 #include "caml/domain.h"
 #include "caml/fail.h"
+#include "caml/fiber.h"
 #include "caml/memory.h"
 #include "caml/osdeps.h"
 #include "caml/signals.h"
 #include "caml/stack.h"
+#include "frame_descriptors.h"
 
 #ifndef NSIG
 #define NSIG 64
@@ -57,7 +59,51 @@ extern signal_handler caml_win32_signal(int sig, signal_handler action);
 
 void caml_garbage_collection()
 {
+  frame_descr* d;
+  intnat allocsz = 0;
+  char *sp;
+  uintnat retaddr;
+  intnat whsize;
+
+  caml_frame_descrs fds = caml_get_frame_descrs();
+  struct stack_info* stack = Caml_state->current_stack;
+
+  sp = (char*)stack->sp;
+  retaddr = *(uintnat*)sp;
+
+  { /* Find the frame descriptor for the current allocation */
+    uintnat h = Hash_retaddr(retaddr, fds.mask);
+    while (1) {
+      d = fds.descriptors[h];
+      if (d->retaddr == retaddr) break;
+      h = (h + 1) & fds.mask;
+    }
+    /* Must be an allocation frame */
+    CAMLassert(d && d->frame_size != 0xFFFF && (d->frame_size & 2));
+  }
+
+  { /* Compute the total allocation size at this point,
+       including allocations combined by Comballoc */
+    unsigned char* alloc_len = (unsigned char*)(&d->live_ofs[d->num_live]);
+    int i, nallocs = *alloc_len++;
+    for (i = 0; i < nallocs; i++) {
+      /* Since 2 words is the smallest allocation, sizes are
+         encoded as (wosize - 2).
+         See Emitaux.emit_frames and caml/stack.h */
+      allocsz += alloc_len[i] + 2;
+    }
+    /* We have computed whsize (including header), but need wosize (without) */
+    allocsz -= 1;
+  }
+
+  whsize = Whsize_wosize(allocsz);
+
+  Caml_state->young_ptr += whsize * sizeof(value);
+
   caml_handle_gc_interrupt();
+
+  /* Re-do the allocation: we now have enough space in the minor heap. */
+  Caml_state->young_ptr -= whsize * sizeof(value);
 
 #ifdef WITH_SPACETIME
   if (caml_young_ptr == caml_young_alloc_end) {

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -88,10 +88,7 @@ void caml_garbage_collection()
     unsigned char* alloc_len = (unsigned char*)(&d->live_ofs[d->num_live]);
     int i, nallocs = *alloc_len++;
     for (i = 0; i < nallocs; i++) {
-      /* Since 2 words is the smallest allocation, sizes are
-         encoded as (wosize - 2).
-         See Emitaux.emit_frames and caml/stack.h */
-      allocsz += alloc_len[i] + 2;
+      allocsz += Whsize_wosize(Wosize_encoded_alloc_len(alloc_len[i]));
     }
     /* We have computed whsize (including header), but need wosize (without) */
     allocsz -= 1;

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -108,7 +108,7 @@ void caml_garbage_collection()
      in a loop to ensure it. */
   do {
     caml_handle_gc_interrupt();
-  } while( Caml_state->young_ptr - alloc_bsize <= Caml_state->young_limit );
+  } while( Caml_state->young_ptr - alloc_bsize <= (char*)Caml_state->young_limit );
 
   /* Re-do the allocation: we now have enough space in the minor heap. */
   Caml_state->young_ptr -= alloc_bsize;


### PR DESCRIPTION
This PR implements the changes in https://github.com/ocaml/ocaml/pull/8805 

The allocation size information is now propagated using the frame descriptors, which enables it to be tracked by statmemprof (when that finally works on multicore).

To simplify the changes, I've also unified the runtime entry so polls now go through the same mechanism but with no allocations in the debug information. This is the same thing we do on https://github.com/ocaml/ocaml/pull/10039 and so should make that eventual merge back into multicore easier as well. 