### PR TITLE
remove multicore stats collection

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -227,7 +227,6 @@ ASM_CFI_SUPPORTED=@asm_cfi_supported@
 WITH_FRAME_POINTERS=@frame_pointers@
 WITH_PROFINFO=@profinfo@
 PROFINFO_WIDTH=@profinfo_width@
-COLLECT_STATS=@collect_stats@
 LIBUNWIND_AVAILABLE=@libunwind_available@
 LIBUNWIND_INCLUDE_FLAGS=@libunwind_include_flags@
 LIBUNWIND_LINK_FLAGS=@libunwind_link_flags@

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -557,37 +557,22 @@ let emit_instr fallthrough i =
       add_used_symbol s;
       load_symbol_addr s (res i 0)
   | Lop(Icall_ind) ->
-      if Config.stats then begin
-        I.inc (domain_field Domainstate.Domain_call_ind);
-      end;
       I.call (arg i 0);
       record_frame i.live (Dbg_other i.dbg)
   | Lop(Icall_imm { func; }) ->
-      if Config.stats then begin
-        I.inc (domain_field Domainstate.Domain_call_imm);
-      end;
       add_used_symbol func;
       emit_call func;
       record_frame i.live (Dbg_other i.dbg)
   | Lop(Itailcall_ind) ->
       output_epilogue begin fun () ->
-      if Config.stats then begin
-        I.inc (domain_field Domainstate.Domain_tailcall_ind);
-      end;
       I.jmp (arg i 0);
       end
   | Lop(Itailcall_imm { func; }) ->
       begin
         if func = !function_name then begin
-          if Config.stats then begin
-            I.inc (domain_field Domainstate.Domain_tailcall_imm);
-          end;
           I.jmp (label !tailrec_entry_point)
         end else begin
           output_epilogue begin fun () ->
-            if Config.stats then begin
-              I.inc (domain_field Domainstate.Domain_tailcall_imm)
-          end;
           add_used_symbol func;
           emit_jump func
         end
@@ -601,21 +586,12 @@ let emit_instr fallthrough i =
         load_symbol_addr func rax;
         emit_call "caml_c_call_stack_args";
         record_frame i.live (Dbg_other i.dbg);
-        if Config.stats then begin
-          I.inc (domain_field Domainstate.Domain_extcall_alloc_stackargs)
-        end;
       end else if alloc then begin
         load_symbol_addr func rax;
         emit_call "caml_c_call";
         record_frame i.live (Dbg_other i.dbg);
-        if Config.stats then begin
-          I.inc (domain_field Domainstate.Domain_extcall_alloc)
-        end;
       end else begin
         I.mov rsp rbp;
-        if Config.stats then begin
-          I.inc (domain_field Domainstate.Domain_extcall_noalloc);
-        end;
         cfi_remember_state ();
         cfi_def_cfa_register "rbp";
         (* NB: gdb has asserts on contiguous stacks that mean it
@@ -657,10 +633,7 @@ let emit_instr fallthrough i =
       | Double | Double_u ->
           I.movsd (addressing addr REAL8 i 0) dest
       end
-  | Lop(Istore(chunk, addr, is_assignment)) ->
-      if Config.stats && is_assignment then begin
-        I.inc (domain_field Domainstate.Domain_immutable_stores);
-      end;
+  | Lop(Istore(chunk, addr, _)) ->
       begin match chunk with
       | Word_int | Word_val ->
           I.mov (arg i 0) (addressing addr QWORD i 1)
@@ -681,9 +654,6 @@ let emit_instr fallthrough i =
         let lbl_redo = new_label() in
         def_label lbl_redo;
         I.sub (int n) r15;
-        if Config.stats then begin
-          I.inc (domain_field Domainstate.Domain_allocations);
-        end;
         I.cmp (domain_field Domainstate.Domain_young_limit) r15;
         let lbl_call_gc = new_label() in
         let lbl_frame =
@@ -698,9 +668,6 @@ let emit_instr fallthrough i =
             gc_frame = lbl_frame;
             is_poll = false } :: !call_gc_sites
       end else begin
-        if Config.stats then begin
-          I.inc (domain_field Domainstate.Domain_allocations);
-        end;
         begin match n with
         | 16 -> emit_call "caml_alloc1"
         | 24 -> emit_call "caml_alloc2"
@@ -1022,9 +989,6 @@ let fundecl fundecl =
     let (overflow,ret) = new_label(), new_label() in
     let threshold_offset = Domainstate.stack_ctx_words * 8 + stack_threshold_size in
     I.lea (mem64 NONE (-(max_stack_size + threshold_offset)) RSP) r10;
-    if Config.stats then begin
-      I.inc (domain_field Domainstate.Domain_stackoverflow_checks);
-    end;
     I.cmp (domain_field Domainstate.Domain_current_stack) r10;
     I.jb (label overflow);
     def_label ret;

--- a/configure
+++ b/configure
@@ -821,7 +821,6 @@ outputobj
 outputexe
 unixlib
 unix_or_win32
-collect_stats
 systhread_support
 system
 model
@@ -897,7 +896,6 @@ enable_naked_pointers_checker
 enable_cfi
 enable_installing_source_artifacts
 enable_installing_bytecode_programs
-enable_stats
 enable_native_compiler
 enable_flambda
 enable_flambda_invariants
@@ -1569,7 +1567,6 @@ Optional Features:
                           install *.cmt* and *.mli files
   --enable-installing-bytecode-programs
                           also install the bytecode versions of programs
-  --enable-stats          enable multicore stats
   --disable-native-compiler
                           do not build the native compiler
   --enable-flambda        enable flambda optimizations
@@ -3205,13 +3202,6 @@ fi
 if test "${enable_installing_bytecode_programs+set}" = set; then :
   enableval=$enable_installing_bytecode_programs;
 fi
-
-
-# Check whether --enable-stats was given.
-if test "${enable_stats+set}" = set; then :
-  enableval=$enable_stats;
-fi
-
 
 # Check whether --enable-native-compiler was given.
 if test "${enable_native_compiler+set}" = set; then :
@@ -16816,16 +16806,6 @@ else
   { $as_echo "$as_me:${as_lineno-$LINENO}: not using frame pointers" >&5
 $as_echo "$as_me: not using frame pointers" >&6;}
   frame_pointers=false
-fi
-
-## Collect multicore stats
-
-if test x"$enable_stats" = "xyes" ; then :
-  $as_echo "#define COLLECT_STATS 1" >>confdefs.h
-
-  collect_stats=true
-else
-  collect_stats=false
 fi
 
 if test x"$enable_naked_pointers_checker" = "xyes" ; then :

--- a/configure.ac
+++ b/configure.ac
@@ -93,7 +93,6 @@ AC_SUBST([arch64])
 AC_SUBST([model])
 AC_SUBST([system])
 AC_SUBST([systhread_support])
-AC_SUBST([collect_stats])
 AC_SUBST([unix_or_win32])
 AC_SUBST([unixlib])
 AC_SUBST([outputexe])
@@ -294,10 +293,6 @@ AC_ARG_ENABLE([installing-source-artifacts],
 AC_ARG_ENABLE([installing-bytecode-programs],
   [AS_HELP_STRING([--enable-installing-bytecode-programs],
     [also install the bytecode versions of programs])])
-
-AC_ARG_ENABLE([stats],
-  [AS_HELP_STRING([--enable-stats],
-    [enable multicore stats])])
 
 AC_ARG_ENABLE([native-compiler],
   [AS_HELP_STRING([--disable-native-compiler],
@@ -1721,13 +1716,6 @@ AS_IF([test x"$enable_frame_pointers" = "xyes"],
   )],
   [AC_MSG_NOTICE([not using frame pointers])
   frame_pointers=false])
-
-## Collect multicore stats
-
-AS_IF([test x"$enable_stats" = "xyes" ],
-  [AC_DEFINE([COLLECT_STATS])
-  collect_stats=true],
-  [collect_stats=false])
 
 AS_IF([test x"$enable_naked_pointers_checker" = "xyes" ],
   [AS_IF([test x"$enable_naked_pointers" = "xno" ],

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -54,29 +54,6 @@ void caml_request_minor_gc (void);
 
 void caml_interrupt_self(void);
 
-#if defined(COLLECT_STATS) && defined(NATIVE_CODE)
-struct detailed_stats {
-  uint64 allocations;
-
-  uint64 mutable_loads;
-  uint64 immutable_loads;
-
-  uint64 mutable_stores;
-  uint64 immutable_stores;
-
-  uint64 extcall_noalloc;
-  uint64 extcall_alloc;
-  uint64 extcall_alloc_stackargs;
-
-  uint64 tailcall_imm;
-  uint64 tailcall_ind;
-  uint64 call_imm;
-  uint64 call_ind;
-
-  uint64 stackoverflow_checks;
-};
-#endif
-
 void caml_sample_gc_stats(struct gc_stats* buf);
 void caml_print_stats(void);
 

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -129,23 +129,6 @@ DOMAIN_STATE(intnat, stat_major_collections)
 DOMAIN_STATE(intnat, stat_forced_major_collections)
 DOMAIN_STATE(uintnat, stat_blocks_marked)
 
-/*****************************************************************************/
-/* Detailed stats */
-/*****************************************************************************/
-DOMAIN_STATE(uintnat, allocations)
-DOMAIN_STATE(uintnat, mutable_loads)
-DOMAIN_STATE(uintnat, immutable_loads)
-DOMAIN_STATE(uintnat, mutable_stores)
-DOMAIN_STATE(uintnat, immutable_stores)
-DOMAIN_STATE(uintnat, extcall_noalloc)
-DOMAIN_STATE(uintnat, extcall_alloc)
-DOMAIN_STATE(uintnat, extcall_alloc_stackargs)
-DOMAIN_STATE(uintnat, tailcall_imm)
-DOMAIN_STATE(uintnat, tailcall_ind)
-DOMAIN_STATE(uintnat, call_imm)
-DOMAIN_STATE(uintnat, call_ind)
-DOMAIN_STATE(uintnat, stackoverflow_checks)
-
 DOMAIN_STATE(uintnat, eventlog_startup_timestamp)
 DOMAIN_STATE(long, eventlog_startup_pid)
 DOMAIN_STATE(uintnat, eventlog_paused)

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -213,11 +213,7 @@ extern uintnat caml_use_huge_pages;
 #define DEBUG_clear(result, wosize)
 #endif
 
-#if defined(COLLECT_STATS) && defined(NATIVE_CODE)
-#define Count_alloc dom_st->allocations++
-#else
 #define Count_alloc
-#endif
 
 #define Alloc_small_with_profinfo(result, wosize, tag, GC, profinfo) do{    \
   caml_domain_state* dom_st;                                                \

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -64,8 +64,6 @@
 
 #undef HAS_STDATOMIC_H
 
-#undef COLLECT_STATS
-
 /* 2. For the Unix library. */
 
 #undef HAS_SOCKETS

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1083,12 +1083,6 @@ CAMLexport void (*caml_atfork_hook)(void) = caml_atfork_default;
 
 void caml_print_stats () {
   struct gc_stats s;
-#if defined(COLLECT_STATS) && defined(NATIVE_CODE)
-  struct detailed_stats ds;
-  caml_domain_state* st;
-  uint64_t total;
-  int i;
-#endif
 
   caml_gc_stat(Val_unit);
   caml_sample_gc_stats(&s);
@@ -1103,61 +1097,6 @@ void caml_print_stats () {
     (uintnat)s.minor_collections);
   fprintf(stderr, "Major collections:\t%"ARCH_INTNAT_PRINTF_FORMAT"u\n",
     Caml_state->stat_major_collections);
-
-#if defined(COLLECT_STATS) && defined(NATIVE_CODE)
-  memset(&ds,0,sizeof(struct detailed_stats));
-  for (i=0; i<Max_domains; i++) {
-    st = all_domains[i].state.state;
-    if (st) {
-      ds.allocations += st->allocations;
-
-      ds.mutable_stores += st->mutable_stores;
-      ds.immutable_stores += st->immutable_stores;
-
-      ds.mutable_loads += st->mutable_loads;
-      ds.immutable_loads += st->immutable_loads;
-
-      ds.extcall_noalloc += st->extcall_noalloc;
-      ds.extcall_alloc += st->extcall_alloc;
-      ds.extcall_alloc_stackargs += st->extcall_alloc_stackargs;
-
-      ds.tailcall_imm += st->tailcall_imm;
-      ds.tailcall_ind += st->tailcall_ind;
-      ds.call_imm += st->call_imm;
-      ds.call_ind += st->call_ind;
-
-      ds.stackoverflow_checks += st->stackoverflow_checks;
-    }
-  }
-  fprintf(stderr, "\n**** Other stats ****\n");
-  fprintf(stderr, "Allocations:\t\t%"ARCH_INTNAT_PRINTF_FORMAT"u\n", ds.allocations);
-
-  total = ds.mutable_loads + ds.immutable_loads;
-  fprintf(stderr, "\nLoads:\t\t\t%"ARCH_INTNAT_PRINTF_FORMAT"u\n", total);
-  fprintf(stderr, "Mutable loads:\t\t%"ARCH_INTNAT_PRINTF_FORMAT"u (%.2lf%%)\n", ds.mutable_loads, (double)ds.mutable_loads * 100.0 / total);
-  fprintf(stderr, "Immutable loads:\t%"ARCH_INTNAT_PRINTF_FORMAT"u (%.2lf%%)\n", ds.immutable_loads, (double)ds.immutable_loads * 100.0 / total);
-
-  total = ds.mutable_stores + ds.immutable_stores;
-  fprintf(stderr, "\nStores:\t\t\t%"ARCH_INTNAT_PRINTF_FORMAT"u\n", total);
-  fprintf(stderr, "Mutable stores:\t\t%"ARCH_INTNAT_PRINTF_FORMAT"u (%.2lf%%)\n", ds.mutable_stores, (double)ds.mutable_stores * 100.0 / total);
-  fprintf(stderr, "Immutable stores:\t%"ARCH_INTNAT_PRINTF_FORMAT"u (%.2lf%%)\n", ds.immutable_stores, (double)ds.immutable_stores * 100.0 / total);
-
-  total = ds.extcall_noalloc + ds.extcall_alloc + ds.extcall_alloc_stackargs;
-  fprintf(stderr, "\nExternal calls:\t\t%"ARCH_INTNAT_PRINTF_FORMAT"u\n", total);
-  fprintf(stderr, "NoAlloc:\t\t%"ARCH_INTNAT_PRINTF_FORMAT"u (%.2lf%%)\n", ds.extcall_noalloc, (double)ds.extcall_noalloc * 100.0 / total);
-  fprintf(stderr, "Alloc:\t\t\t%"ARCH_INTNAT_PRINTF_FORMAT"u (%.2lf%%)\n", ds.extcall_alloc, (double)ds.extcall_alloc * 100.0 / total);
-  fprintf(stderr, "Alloc + stack args:\t%"ARCH_INTNAT_PRINTF_FORMAT"u (%.2lf%%)\n", ds.extcall_alloc_stackargs, (double)ds.extcall_alloc_stackargs * 100.0 / total);
-
-  total = ds.tailcall_imm + ds.tailcall_ind + ds.call_imm + ds.call_ind;
-  fprintf(stderr, "\nCalls:\t\t\t%"ARCH_INTNAT_PRINTF_FORMAT"u\n", total);
-  fprintf(stderr, "Imm tail:\t\t%"ARCH_INTNAT_PRINTF_FORMAT"u (%.2lf%%)\n", ds.tailcall_imm, (double)ds.tailcall_imm * 100.0 / total);
-  fprintf(stderr, "Ind tail:\t\t%"ARCH_INTNAT_PRINTF_FORMAT"u (%.2lf%%)\n", ds.tailcall_ind, (double)ds.tailcall_ind * 100.0 / total);
-  fprintf(stderr, "Imm non-tail:\t\t%"ARCH_INTNAT_PRINTF_FORMAT"u (%.2lf%%)\n", ds.call_imm, (double)ds.call_imm * 100.0 / total);
-  fprintf(stderr, "Ind non-tail:\t\t%"ARCH_INTNAT_PRINTF_FORMAT"u (%.2lf%%)\n", ds.call_ind, (double)ds.call_ind * 100.0 / total);
-
-  fprintf(stderr, "\nStackoverflow checks:\t%"ARCH_INTNAT_PRINTF_FORMAT"u (%.2lf%%)\n", ds.stackoverflow_checks, (double)ds.stackoverflow_checks * 100.0 / total);
-
-#endif
 }
 
 CAMLexport int caml_domain_rpc(struct domain* domain,

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -151,9 +151,6 @@ static void write_barrier(value obj, intnat field, value old_val, value new_val)
 CAMLexport CAMLweakdef void caml_modify (value *fp, value val)
 {
   write_barrier((value)fp, 0, *fp, val);
-  #if defined(COLLECT_STATS) && defined(NATIVE_CODE)
-  Caml_state->mutable_stores++;
-  #endif
 
   /* See Note [MM] above */
   atomic_thread_fence(memory_order_acquire);
@@ -334,9 +331,6 @@ Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, int noexc)
       Op_hp(v)[i] = init_val;
     }
   }
-#if defined(COLLECT_STATS) && defined(NATIVE_CODE)
-  dom_st->allocations++;
-#endif
   return Val_hp(v);
 }
 

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -82,7 +82,6 @@ config.ml: config.mlp $(ROOTDIR)/Makefile.config Makefile
 	    $(call SUBST,SUPPORTS_SHARED_LIBRARIES) \
 	    $(call SUBST,SYSTEM) \
 	    $(call SUBST,SYSTHREAD_SUPPORT) \
-	    $(call SUBST,COLLECT_STATS) \
 	    $(call SUBST,TARGET) \
 	    $(call SUBST,WITH_FRAME_POINTERS) \
 	    $(call SUBST,WITH_PROFINFO) \

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -194,10 +194,6 @@ val host : string
 val target : string
 (** Whether the compiler is a cross-compiler *)
 
-val stats : bool
-        (* Whether the compiler records detailed statistics about the program.
-           Warning: Expect a substantial performance hit. *)
-
 val flambda : bool
 (** Whether the compiler was configured for flambda *)
 

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -145,7 +145,6 @@ let default_executable_name =
 
 let systhread_supported = %%SYSTHREAD_SUPPORT%%;;
 
-let stats = %%COLLECT_STATS%%;;
 let flexdll_dirs = [%%FLEXDLL_DIR%%];;
 
 type configuration_value =
@@ -189,7 +188,6 @@ let configuration_variables =
   p "os_type" Sys.os_type;
   p "default_executable_name" default_executable_name;
   p_bool "systhread_supported" systhread_supported;
-  p_bool "stats" stats;
   p "host" host;
   p "target" target;
   p_bool "flambda" flambda;


### PR DESCRIPTION
This PR removes the configurable stats collection functionality from multicore.

Removing because it shrinks the diffs to trunk in several places and it's unlikely we'll want to keep it when upstreaming.