### PR TITLE
Forcing_tag invalid argument to `Gc.finalise`

### DIFF
--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -339,6 +339,7 @@ static void generic_final_register (struct finalisable *final, value f, value v)
 #ifdef FLAT_FLOAT_ARRAY
       || Tag_val(v) == Double_tag
 #endif
+      || Tag_val(v) == Forcing_tag
       || Tag_val(v) == Forward_tag) {
     caml_invalid_argument ("Gc.finalise");
   }


### PR DESCRIPTION
Lazy values are not valid arguments to the function `Gc.finalise`. The tags `Lazy_tag` and `Forward_tag` are covered in the finaliser function `generic_final_register`. This patch adds `Forcing_tag` which is also a tag lazy values could have when the computation is being forced, so that `Gc.finalise` raises an invalid argument exception when a block with `Forcing_tag` is given as an argument.