### PR TITLE
runtime: CAML_TRACE_VERSION is now set to a Multicore specific value

### DIFF
--- a/runtime/eventlog.c
+++ b/runtime/eventlog.c
@@ -40,7 +40,7 @@
 #ifdef CAML_INSTR
 
 #define CTF_MAGIC 0xc1fc1fc1
-#define CAML_TRACE_VERSION 0x1
+#define CAML_TRACE_VERSION 0x100 /* Multicore OCaml WIP */
 
 struct ctf_stream_header {
   uint32_t magic;


### PR DESCRIPTION
This is required in order to work on ocaml-bench/sandmark#218
We need to distinguish a Multicore OCaml trace and a trunk one, as the format varies ever so slightly.
This difference is handled in ocaml-multicore/eventlog-tools#2
I've set it to a number we are likely not to reach, bumping upstream's trace version, as it is for our own development purposes.