### PR TITLE
Import fixes to the minor heap allocation code from DLABs.

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -150,13 +150,11 @@ CAMLexport __thread caml_domain_state* Caml_state;
 
 asize_t caml_norm_minor_heap_size (intnat wsize)
 {
-  asize_t page_size = caml_mem_round_up_pages(1);
   asize_t bs, max;
   if (wsize < Minor_heap_min) wsize = Minor_heap_min;
   bs = caml_mem_round_up_pages(Bsize_wsize (wsize));
 
-  Assert(page_size * 2 < Minor_heap_max);
-  max = Minor_heap_max - page_size * 2;
+  max = Bsize_wsize(Minor_heap_max);
 
   if (bs > max) bs = max;
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -355,7 +355,7 @@ void caml_init_domains(uintnat minor_heap_wsz) {
     caml_fatal_error("Minor_heap_max misconfigured for this platform");
 
   /* reserve memory space for minor heaps and tls_areas */
-  size = (uintnat)Minor_heap_max * Max_domains;
+  size = (uintnat)Bsize_wsize(Minor_heap_max) * Max_domains;
   tls_size = caml_mem_round_up_pages(sizeof(caml_domain_state));
   tls_areas_size = tls_size * Max_domains;
 
@@ -387,12 +387,12 @@ void caml_init_domains(uintnat minor_heap_wsz) {
     dom->backup_thread_msg = BT_INIT;
 
     domain_minor_heap_base = caml_minor_heaps_base +
-      (uintnat)Minor_heap_max * (uintnat)i;
+      (uintnat)Bsize_wsize(Minor_heap_max) * (uintnat)i;
     domain_tls_base = caml_tls_areas_base + tls_size * (uintnat)i;
     dom->tls_area = domain_tls_base;
     dom->tls_area_end = domain_tls_base + tls_size;
     dom->minor_heap_area = domain_minor_heap_base;
-    dom->minor_heap_area_end = domain_minor_heap_base + Minor_heap_max;
+    dom->minor_heap_area_end = domain_minor_heap_base + Bsize_wsize(Minor_heap_max);
   }
 
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -617,7 +617,7 @@ struct domain* caml_domain_self()
 struct domain* caml_owner_of_young_block(value v) {
   int heap_id;
   Assert(Is_young(v));
-  heap_id = ((uintnat)v - caml_minor_heaps_base) / Minor_heap_max;
+  heap_id = ((uintnat)v - caml_minor_heaps_base) / Bsize_wsize(Minor_heap_max);
   return &all_domains[heap_id].state;
 }
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -359,7 +359,7 @@ void caml_init_domains(uintnat minor_heap_wsz) {
   tls_size = caml_mem_round_up_pages(sizeof(caml_domain_state));
   tls_areas_size = tls_size * Max_domains;
 
-  heaps_base = caml_mem_map(size*2, size*2, 1 /* reserve_only */);
+  heaps_base = caml_mem_map(size, size, 1 /* reserve_only */);
   tls_base = caml_mem_map(tls_areas_size, tls_areas_size, 1 /* reserve_only */);
   if (!heaps_base || !tls_base) caml_raise_out_of_memory();
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -349,7 +349,7 @@ void caml_init_domains(uintnat minor_heap_wsz) {
   void* tls_base;
 
   /* sanity check configuration */
-  if (caml_mem_round_up_pages(Minor_heap_max) != Minor_heap_max)
+  if (caml_mem_round_up_pages(Bsize_wsize(Minor_heap_max)) != Bsize_wsize(Minor_heap_max))
     caml_fatal_error("Minor_heap_max misconfigured for this platform");
 
   /* reserve memory space for minor heaps and tls_areas */


### PR DESCRIPTION
This PR provides two fixes to the way the minor heap is allocated on Multicore OCaml.

The first fix removes a multiplication by two to the overall size of the minor, which I assume is related to earlier experiments on our minor heap code.

The second fix make sure that we do convert the `Minor_heap_max` limit from `config.h` toa byte size where appropriate in the codebase.
Before this fix, it turns out we allocate the minor heaps segment in word size and not byte size, which leads to an oversized minor heaps segment
