### PR TITLE
Simplify some of the minor_gc code

### DIFF
--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -45,11 +45,8 @@ extern value caml_ephe_none; /* See weak.c */
 struct generic_table CAML_TABLE_STRUCT(char);
 
 static atomic_intnat domains_finished_minor_gc;
-static atomic_intnat domain_finished_root;
 
 static atomic_uintnat caml_minor_cycles_started = 0;
-
-static caml_plat_mutex global_roots_lock = CAML_PLAT_MUTEX_INITIALIZER;
 
 double caml_extra_heap_resources_minor = 0;
 
@@ -532,8 +529,6 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
   caml_domain_state* domain_state = domain->state;
   struct caml_minor_tables *self_minor_tables = domain_state->minor_tables;
   struct caml_custom_elt *elt;
-  unsigned rewrite_successes = 0;
-  unsigned rewrite_failures = 0;
   char* young_ptr = domain_state->young_ptr;
   char* young_end = domain_state->young_end;
   uintnat minor_allocated_bytes = young_end - young_ptr;
@@ -552,16 +547,10 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
   caml_gc_log ("Minor collection of domain %d starting", domain->state->id);
   CAML_EV_BEGIN(EV_MINOR);
 
-  if( participating[0] == caml_domain_self() || !not_alone ) { // TODO: We should distribute this work
-    if(domain_finished_root == 0){
-      if (caml_plat_try_lock(&global_roots_lock)){
-        CAML_EV_BEGIN(EV_MINOR_GLOBAL_ROOTS);
-        caml_scan_global_young_roots(oldify_one, &st);
-        CAML_EV_END(EV_MINOR_GLOBAL_ROOTS);
-        atomic_store_explicit(&domain_finished_root, 1, memory_order_release);
-        caml_plat_unlock(&global_roots_lock);
-      }
-    }
+  if( participating[0] == caml_domain_self() ) { // TODO: We should distribute this work
+    CAML_EV_BEGIN(EV_MINOR_GLOBAL_ROOTS);
+    caml_scan_global_young_roots(oldify_one, &st);
+    CAML_EV_END(EV_MINOR_GLOBAL_ROOTS);
   }
 
  CAML_EV_BEGIN(EV_MINOR_REMEMBERED_SET);
@@ -695,10 +684,10 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
   domain_state->stat_promoted_words += domain_state->allocated_words - prev_alloc_words;
 
   CAML_EV_END(EV_MINOR);
-  caml_gc_log ("Minor collection of domain %d completed: %2.0f%% of %u KB live, rewrite: successes=%u failures=%u",
+  caml_gc_log ("Minor collection of domain %d completed: %2.0f%% of %u KB live",
                domain->state->id,
                100.0 * (double)st.live_bytes / (double)minor_allocated_bytes,
-               (unsigned)(minor_allocated_bytes + 512)/1024, rewrite_successes, rewrite_failures);
+               (unsigned)(minor_allocated_bytes + 512)/1024);
 }
 
 void caml_do_opportunistic_major_slice(struct domain* domain, void* unused)
@@ -718,7 +707,6 @@ void caml_do_opportunistic_major_slice(struct domain* domain, void* unused)
 */
 void caml_empty_minor_heap_setup(struct domain* domain) {
   atomic_store_explicit(&domains_finished_minor_gc, 0, memory_order_release);
-  atomic_store_explicit(&domain_finished_root, 0, memory_order_release);
 }
 
 /* must be called within a STW section */
@@ -730,13 +718,7 @@ static void caml_stw_empty_minor_heap_no_major_slice (struct domain* domain, voi
   CAMLassert(caml_domain_is_in_stw());
   #endif
 
-  if( not_alone ) {
-    if( participating[0] == caml_domain_self() ) {
-      atomic_fetch_add(&caml_minor_cycles_started, 1);
-    }
-  }
-  else
-  {
+  if( participating[0] == caml_domain_self() ) {
     atomic_fetch_add(&caml_minor_cycles_started, 1);
   }
 


### PR DESCRIPTION
This PR is an opportunistic minor simplification of some of the minor_gc code. 

`if( participating[0] == caml_domain_self() || !not_alone )` 
with all the locking gubbins becoming
`if( participating[0] == caml_domain_self())`
with no locking might not be immediately obvious. 

However notice that:
 - when there is one domain `participating[0] == caml_domain_self()` is `true`
 - `!not_alone` iff there is one domain

and so the if condition is actually: 'only the domain which is `participating[0]` should execute this block'
