### PR TITLE
Including git hash in runtime 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,22 +7,15 @@ assignees: ''
 
 ---
 <!--
-Welcome to OCaml's Issue tracker!
+Welcome to OCaml multicore's Issue tracker!
 
-OCaml's developers use this tracker for bugs and feature requests only, rather
-than user support.
+One thing that can greatly assist in debugging issues is if the
+OCaml multicore build version information is included. You can determine
+the OCaml multicore build version information with `ocamlrun -version`.
 
 If you have questions about *using* OCaml, please ask at
 https://discuss.ocaml.org (more people read Discuss than this tracker, and
 you'll get confirmation of whether you've really found a bug or need a new
 feature).
 
-If your error came from the OCaml package manager, opam, (messages beginning
-`[ERROR] The compilation of ...`), please start at
-https://github.com/ocaml/opam-repository/issues/new.
-
-Some libraries and tools which used to be part of OCaml are now maintained
-separately. Please post questions about Graphics, Num, camlp4, LablTk, CamlDBM
-or OCamlTopWin on Discuss or on their respective issue trackers (see [README.adoc](https://github.com/ocaml/ocaml/blob/trunk/README.adoc#separately-maintained-components)
-for a full list).
 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,24 +1,14 @@
 ---
 name: Feature request
-about: Suggest a new feature for OCaml.
+about: Suggest a new feature for OCaml multicore.
 title: ''
 labels: 'feature-wish'
 assignees: ''
 
 ---
 <!--
-Welcome to OCaml's Issue tracker!
+Welcome to OCaml multicore's Issue tracker!
 
-We welcome all suggestions for improvements to OCaml. It is helpful if
-discussions on new features can initially begin on our community forums
-(see https://discuss.ocaml.org and https://ocaml.org/community), mainly because
-their readership is wider than this issue tracker, and you'll get better
-feedback as to whether your suggestion is a good idea or has been considered
-before. You may even end up with volunteers to help implement it!
+We welcome all suggestions for improvements to OCaml multicore.
 
-It is often easier to propose changes to the language than it is to design those
-changes: if you are proposing an alteration to the language, please be aware
-that we may need to have a more complete proposal of how the change will be
-implemented than "It would be nice to be able to X in OCaml" (see also
-https://github.com/ocaml/RFCs)
 -->

--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,8 @@ _build
 /runtime/.dep
 /runtime/domain_state32.inc
 /runtime/domain_state64.inc
+/runtime/GIT_HASH
+/runtime/GIT_HASH.new
 
 /stdlib/camlheader
 /stdlib/target_camlheader

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -205,6 +205,7 @@ clean:
 	rm -f ocamlrun ocamlrund ocamlruni
 	rm -f ocamlrun.exe ocamlrund.exe ocamlruni.exe
 	rm -f primitives primitives.new prims.c $(GENERATED_HEADERS)
+	rm -f GIT_HASH GIT_HASH.new
 	rm -f domain_state*.inc
 	rm -rf $(DEPDIR)
 
@@ -268,8 +269,14 @@ caml/jumptbl.h : caml/instruct.h
 	sed -n -e '/^  /s/ \([A-Z]\)/ \&\&lbl_\1/gp' \
 	       -e '/^}/q' > $@
 
-caml/version.h : $(ROOTDIR)/tools/make-version-header.sh $(ROOTDIR)/VERSION
-	$^ > $@
+# Avoid building due to GIT_HASH when it hasn't changed
+GIT_HASH: $(shell (git rev-parse --short HEAD || echo "<hash unavailable>") > GIT_HASH.new; \
+        cmp -s GIT_HASH GIT_HASH.new || echo GIT_HASH.new)
+	cp $^ $@
+
+caml/version.h : $(ROOTDIR)/tools/make-version-header.sh $(ROOTDIR)/VERSION GIT_HASH
+	$(ROOTDIR)/tools/make-version-header.sh $(ROOTDIR)/VERSION > $@
+	echo "#define OCAML_BUILD_GIT_HASH \"`cat GIT_HASH`\"" >> $@
 
 # Libraries and programs
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -276,7 +276,9 @@ GIT_HASH: $(shell (git rev-parse --short HEAD || echo "<hash unavailable>") > GI
 
 caml/version.h : $(ROOTDIR)/tools/make-version-header.sh $(ROOTDIR)/VERSION GIT_HASH
 	$(ROOTDIR)/tools/make-version-header.sh $(ROOTDIR)/VERSION > $@
-	echo "#define OCAML_BUILD_GIT_HASH \"`cat GIT_HASH`\"" >> $@
+	echo "#define OCAML_RUNTIME_BUILD_GIT_HASH \"`cat GIT_HASH`\"" >> $@
+	echo "#define OCAML_RUNTIME_BUILD_GIT_BRANCH \"`(git symbolic-ref -q --short HEAD || echo "<branch unavailable>")`\"" >> $@
+	echo "#define OCAML_RUNTIME_BUILD_GIT_TAG \"`(git describe --tags --exact-match || echo "<tag unavailable>")`\"" >> $@
 
 # Libraries and programs
 

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -59,6 +59,8 @@ struct caml_params {
 
 extern const struct caml_params* const caml_params;
 
+extern const char* caml_runtime_build_git_hash_is;
+
 extern void caml_parse_ocamlrunparam (void);
 extern int caml_parse_command_line (char_os **argv);
 

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -59,8 +59,6 @@ struct caml_params {
 
 extern const struct caml_params* const caml_params;
 
-extern const char* caml_runtime_build_git_hash_is;
-
 extern void caml_parse_ocamlrunparam (void);
 extern int caml_parse_command_line (char_os **argv);
 

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -36,7 +36,6 @@ __declspec(noreturn) void __cdecl abort(void);
 #include "caml/misc.h"
 #include "caml/memory.h"
 #include "caml/osdeps.h"
-#include "caml/version.h"
 #include "caml/domain.h"
 #include "caml/startup.h"
 #include "caml/startup_aux.h"

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -46,7 +46,11 @@ const struct caml_params* const caml_params = &params;
 /* this variable is intended to appear in the text segment to
    find the runtime git hash of the build */
 const char* caml_runtime_build_git_hash_is =
-  "OCAML_RUNTIME_BUILD_GIT_HASH_IS_" OCAML_BUILD_GIT_HASH;
+  "OCAML_RUNTIME_BUILD_GIT_HASH_IS_" OCAML_RUNTIME_BUILD_GIT_HASH;
+const char* caml_runtime_build_git_branch_is =
+  "OCAML_RUNTIME_BUILD_GIT_BRANCH_IS_" OCAML_RUNTIME_BUILD_GIT_BRANCH;
+const char* caml_runtime_build_git_tag_is =
+  "OCAML_RUNTIME_BUILD_GIT_TAG_IS_" OCAML_RUNTIME_BUILD_GIT_TAG;
 
 static void init_startup_params()
 {
@@ -227,7 +231,10 @@ int caml_parse_command_line(char_os **argv)
     case 'v':
       if (!strcmp_os (argv[i], T("-version"))){
         printf ("The OCaml runtime, version " OCAML_VERSION_STRING "\n");
-        printf ("built with git hash " OCAML_BUILD_GIT_HASH "\n");
+        printf ("Built with git hash '" OCAML_RUNTIME_BUILD_GIT_HASH
+                "' on branch '" OCAML_RUNTIME_BUILD_GIT_BRANCH
+                "' with tag '" OCAML_RUNTIME_BUILD_GIT_TAG
+                "'\n");
         exit (0);
       }else if (!strcmp_os (argv[i], T("-vnum"))){
         printf (OCAML_VERSION_STRING "\n");

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -46,7 +46,7 @@ const struct caml_params* const caml_params = &params;
 /* this variable is intended to appear in the text segment to
    find the runtime git hash of the build */
 const char* caml_runtime_build_git_hash_is =
-  "RUNTIME_BUILD_GIT_HASH_IS_" OCAML_BUILD_GIT_HASH;
+  "OCAML_RUNTIME_BUILD_GIT_HASH_IS_" OCAML_BUILD_GIT_HASH;
 
 static void init_startup_params()
 {

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -43,6 +43,11 @@ extern void caml_win32_unregister_overflow_detection (void);
 static struct caml_params params;
 const struct caml_params* const caml_params = &params;
 
+/* this variable is intended to appear in the text segment to
+   find the runtime git hash of the build */
+const char* caml_runtime_build_git_hash_is =
+  "RUNTIME_BUILD_GIT_HASH_IS_" OCAML_BUILD_GIT_HASH;
+
 static void init_startup_params()
 {
 #ifndef NATIVE_CODE
@@ -222,6 +227,7 @@ int caml_parse_command_line(char_os **argv)
     case 'v':
       if (!strcmp_os (argv[i], T("-version"))){
         printf ("The OCaml runtime, version " OCAML_VERSION_STRING "\n");
+        printf ("built with git hash " OCAML_BUILD_GIT_HASH "\n");
         exit (0);
       }else if (!strcmp_os (argv[i], T("-vnum"))){
         printf (OCAML_VERSION_STRING "\n");

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -58,7 +58,6 @@
 #include "caml/signals.h"
 #include "caml/sys.h"
 #include "caml/startup.h"
-#include "caml/version.h"
 
 #ifndef O_BINARY
 #define O_BINARY 0

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -56,7 +56,6 @@
 #include "caml/fiber.h"
 #include "caml/sys.h"
 #include "caml/startup.h"
-#include "caml/version.h"
 #include "caml/callback.h"
 #include "caml/startup_aux.h"
 #include "caml/major_gc.h"


### PR DESCRIPTION
This PR adds a git hash into the runtime. 

It allows the following:
```sh
$ ./boot/ocamlrun -version
The OCaml runtime, version 4.12.0+multicore
built with git hash af0cda130
```
and 
```sh
$ strings ./boot/ocamlrun | grep OCAML_RUNTIME_BUILD_GIT_HASH_IS
OCAML_RUNTIME_BUILD_GIT_HASH_IS_af0cda130
```

Fixes #554.

This approach looks much better than that in #575 because when the commit changes, there is only a quick rebuild of an object file and link of the runtime. 