### PR TITLE
Remove struct domain

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -115,9 +115,9 @@ extern void (*caml_termination_hook)(void);
 
 /* Hook for scanning the stacks of the other threads */
 
-static void (*prev_scan_roots_hook) (scanning_action, void *, struct domain *);
+static void (*prev_scan_roots_hook) (scanning_action, void *, caml_domain_state *);
 
-static void caml_thread_scan_roots(scanning_action action, void *fdata, struct domain *self)
+static void caml_thread_scan_roots(scanning_action action, void *fdata, caml_domain_state *domain_state)
 {
   caml_thread_t th;
 
@@ -137,7 +137,7 @@ static void caml_thread_scan_roots(scanning_action action, void *fdata, struct d
 
   };
 
-  if (prev_scan_roots_hook != NULL) (*prev_scan_roots_hook)(action, fdata, self);
+  if (prev_scan_roots_hook != NULL) (*prev_scan_roots_hook)(action, fdata, domain_state);
 
   return;
 }
@@ -204,9 +204,9 @@ static void caml_thread_leave_blocking_section(void)
 static caml_thread_t caml_thread_new_info(void)
 {
   caml_thread_t th;
-  struct domain *d;
+  caml_domain_state *domain_state;
 
-  d = caml_domain_self();
+  domain_state = Caml_state;
   th = NULL;
   th = (caml_thread_t) caml_stat_alloc_noexc(sizeof(struct caml_thread_struct));
   if (th == NULL) return NULL;
@@ -214,7 +214,7 @@ static caml_thread_t caml_thread_new_info(void)
   th->descr = Val_unit;
   th->next = NULL;
   th->prev = NULL;
-  th->domain_id = d->state->id;
+  th->domain_id = domain_state->id;
   th->current_stack = caml_alloc_main_stack(Stack_size / sizeof(value));;
   th->c_stack = NULL;
   th->local_roots = NULL;

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -80,7 +80,7 @@ void caml_init_domains(uintnat minor_heap_size);
 void caml_init_domain_self(int);
 
 struct domain* caml_domain_self();
-struct domain* caml_owner_of_young_block(value);
+caml_domain_state* caml_owner_of_young_block(value);
 
 CAMLextern atomic_uintnat caml_num_domains_running;
 CAMLextern uintnat caml_minor_heaps_base;

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -30,11 +30,6 @@ extern "C" {
 #include "major_gc.h"
 #include "platform.h"
 
-struct domain {
-  struct dom_internal* internals;
-  caml_domain_state* state;
-};
-
 #define Caml_check_gc_interrupt(dom_st)   \
   (CAMLalloc_point_here, \
    CAMLunlikely((uintnat)(dom_st)->young_ptr < (dom_st)->young_limit))
@@ -79,7 +74,6 @@ CAMLextern void (*caml_domain_stop_hook)(void);
 void caml_init_domains(uintnat minor_heap_size);
 void caml_init_domain_self(int);
 
-struct domain* caml_domain_self();
 caml_domain_state* caml_owner_of_young_block(value);
 
 CAMLextern atomic_uintnat caml_num_domains_running;
@@ -91,18 +85,15 @@ INLINE intnat caml_domain_alone()
   return atomic_load_acq(&caml_num_domains_running) == 1;
 }
 
-typedef struct interrupt interrupt;
-typedef void (*domain_rpc_handler)(struct domain*, void*, interrupt*);
-
 #ifdef DEBUG
 int caml_domain_is_in_stw();
 #endif
 
 int caml_try_run_on_all_domains_with_spin_work(
-  void (*handler)(struct domain*, void*, int, struct domain**), void* data,
-  void (*leader_setup)(struct domain*),
-  void (*enter_spin_callback)(struct domain*, void*), void* enter_spin_data);
-int caml_try_run_on_all_domains(void (*handler)(struct domain*, void*, int, struct domain**), void*, void (*leader_setup)(struct domain*));
+  void (*handler)(caml_domain_state*, void*, int, caml_domain_state**), void* data,
+  void (*leader_setup)(caml_domain_state*),
+  void (*enter_spin_callback)(caml_domain_state*, void*), void* enter_spin_data);
+int caml_try_run_on_all_domains(void (*handler)(caml_domain_state*, void*, int, caml_domain_state**), void*, void (*leader_setup)(caml_domain_state*));
 
 /* barriers */
 typedef uintnat barrier_status;

--- a/runtime/caml/finalise.h
+++ b/runtime/caml/finalise.h
@@ -68,15 +68,15 @@ struct caml_final_info {
 
 void caml_final_merge_finalisable (struct finalisable *source,
                                    struct finalisable *target);
-int caml_final_update_first (struct domain* d);
-int caml_final_update_last (struct domain* d);
+int caml_final_update_first (caml_domain_state* d);
+int caml_final_update_last (caml_domain_state* d);
 void caml_final_do_calls (void);
 void caml_final_do_roots (scanning_action f, void* fdata,
-                          struct domain* domain, int do_val);
+                          caml_domain_state* domain, int do_val);
 void caml_final_do_young_roots (scanning_action f, void* fdata,
-                                struct domain* d, int do_last_val);
-void caml_final_empty_young (struct domain* d);
-void caml_final_update_last_minor (struct domain* d);
+                                caml_domain_state* d, int do_last_val);
+void caml_final_empty_young (caml_domain_state* d);
+void caml_final_update_last_minor (caml_domain_state* d);
 value caml_final_register (value f, value v);
 struct caml_final_info* caml_alloc_final_info(void);
 

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -52,13 +52,11 @@ struct caml_minor_tables {
   struct caml_custom_table custom;
 };
 
-struct domain;
-
 CAMLextern void caml_minor_collection (void);
 
 #ifdef CAML_INTERNALS
 extern void caml_set_minor_heap_size (asize_t); /* size in bytes */
-extern void caml_empty_minor_heap_no_major_slice_from_stw (struct domain* domain, void* unused, int participating_count, struct domain** participating); /* in STW */
+extern void caml_empty_minor_heap_no_major_slice_from_stw (caml_domain_state* domain, void* unused, int participating_count, caml_domain_state** participating); /* in STW */
 extern int caml_try_stw_empty_minor_heap_on_all_domains(); /* out STW */
 extern void caml_empty_minor_heaps_once(); /* out STW */
 CAMLextern void garbage_collection (void); /* def in asmrun/signals.c */
@@ -69,7 +67,7 @@ extern void caml_realloc_ephe_ref_table (struct caml_ephe_ref_table *);
 extern void caml_realloc_custom_table (struct caml_custom_table *);
 struct caml_minor_tables* caml_alloc_minor_tables();
 void caml_free_minor_tables(struct caml_minor_tables*);
-void caml_empty_minor_heap_setup(struct domain* domain);
+void caml_empty_minor_heap_setup(caml_domain_state* domain);
 
 #ifdef DEBUG
 extern int caml_debug_is_minor(value val);

--- a/runtime/caml/roots.h
+++ b/runtime/caml/roots.h
@@ -22,9 +22,9 @@
 #include "memory.h"
 
 typedef void (*scanning_action) (void*, value, value *);
-CAMLextern void (*caml_scan_roots_hook)(scanning_action, void*, struct domain*);
+CAMLextern void (*caml_scan_roots_hook)(scanning_action, void*, caml_domain_state*);
 
-void caml_do_roots (scanning_action f, void* data, struct domain* d,
+void caml_do_roots (scanning_action f, void* data, caml_domain_state* d,
                     int do_final_val);
 void caml_do_local_roots(scanning_action f, void* data,
 						struct caml__roots_block* local_roots,

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -23,7 +23,6 @@ uintnat caml_top_heap_words(struct caml_heap_state*);
 uintnat caml_heap_blocks(struct caml_heap_state*);
 
 struct pool* caml_pool_of_shared_block(value v);
-struct domain* caml_owner_of_shared_block(value v);
 
 void caml_shared_unpin(value v);
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -22,7 +22,6 @@
 #include <string.h>
 #include "caml/alloc.h"
 #include "caml/callback.h"
-#include "caml/custom.h"
 #include "caml/domain.h"
 #include "caml/domain_state.h"
 #include "caml/eventlog.h"
@@ -575,8 +574,6 @@ static void* domain_thread_func(void* v)
   }
   return 0;
 }
-
-#define Domainthreadptr_val(val) ((struct domain_thread**)Data_custom_val(val))
 
 CAMLprim value caml_domain_spawn(value callback, value mutex)
 {

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -627,11 +627,11 @@ struct domain* caml_domain_self()
   return domain_self ? &domain_self->state : 0;
 }
 
-struct domain* caml_owner_of_young_block(value v) {
+caml_domain_state* caml_owner_of_young_block(value v) {
   int heap_id;
   Assert(Is_young(v));
   heap_id = ((uintnat)v - caml_minor_heaps_base) / Bsize_wsize(Minor_heap_max);
-  return &all_domains[heap_id].state;
+  return all_domains[heap_id].state.state;
 }
 
 CAMLprim value caml_ml_domain_id(value unit)

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -140,7 +140,7 @@ void caml_set_minor_heap_size (asize_t wsize)
 struct oldify_state {
   value todo_list;
   uintnat live_bytes;
-  struct domain* promote_domain;
+  caml_domain_state* domain;
 };
 
 static value alloc_shared(mlsize_t wosize, tag_t tag)
@@ -419,8 +419,7 @@ static void oldify_mopup (struct oldify_state* st, int do_ephemerons)
 {
   value v, new_v, f;
   mlsize_t i;
-  caml_domain_state* domain_state =
-    st->promote_domain ? st->promote_domain->state : Caml_state;
+  caml_domain_state* domain_state = st->domain;
   struct caml_ephe_ref_table ephe_ref_table = domain_state->minor_tables->ephe_ref;
   struct caml_ephe_ref_elt *re;
   int redo = 0;
@@ -481,7 +480,7 @@ static void oldify_mopup (struct oldify_state* st, int do_ephemerons)
 
 
 
-void caml_minor_heap_domain_finalizers_admin (struct domain* domain, void* unused)
+void caml_minor_heap_domain_finalizers_admin (caml_domain_state* domain, void* unused)
 {
   /* need to do the finalizer data structure book-keeping */
   caml_final_update_last_minor(domain);
@@ -504,10 +503,9 @@ void caml_minor_heap_domain_finalizers_admin (struct domain* domain, void* unuse
   }*/
 }
 
-void caml_empty_minor_heap_domain_clear (struct domain* domain, void* unused)
+void caml_empty_minor_heap_domain_clear (caml_domain_state* domain, void* unused)
 {
-  caml_domain_state* domain_state = domain->state;
-  struct caml_minor_tables *minor_tables = domain_state->minor_tables;
+  struct caml_minor_tables *minor_tables = domain->minor_tables;
 
   caml_final_empty_young(domain);
 
@@ -517,20 +515,19 @@ void caml_empty_minor_heap_domain_clear (struct domain* domain, void* unused)
 
 #ifdef DEBUG
   {
-    uintnat* p = (uintnat*)domain_state->young_start;
-    for (; p < (uintnat*)domain_state->young_end; p++)
+    uintnat* p = (uintnat*)domain->young_start;
+    for (; p < (uintnat*)domain->young_end; p++)
       *p = Debug_uninit_align;
   }
 #endif
 }
 
-void caml_empty_minor_heap_promote (struct domain* domain, int participating_count, struct domain** participating)
+void caml_empty_minor_heap_promote (caml_domain_state* domain, int participating_count, caml_domain_state** participating)
 {
-  caml_domain_state* domain_state = domain->state;
-  struct caml_minor_tables *self_minor_tables = domain_state->minor_tables;
+  struct caml_minor_tables *self_minor_tables = domain->minor_tables;
   struct caml_custom_elt *elt;
-  char* young_ptr = domain_state->young_ptr;
-  char* young_end = domain_state->young_end;
+  char* young_ptr = domain->young_ptr;
+  char* young_end = domain->young_end;
   uintnat minor_allocated_bytes = young_end - young_ptr;
   uintnat prev_alloc_words;
   struct oldify_state st = {0};
@@ -538,16 +535,16 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
   intnat c, curr_idx;
   int remembered_roots = 0;
 
-  st.promote_domain = domain;
+  st.domain = domain;
 
   /* TODO: are there any optimizations we can make where we don't need to scan
      when minor heaps can reference each other? */
-  prev_alloc_words = domain_state->allocated_words;
+  prev_alloc_words = domain->allocated_words;
 
-  caml_gc_log ("Minor collection of domain %d starting", domain->state->id);
+  caml_gc_log ("Minor collection of domain %d starting", domain->id);
   CAML_EV_BEGIN(EV_MINOR);
 
-  if( participating[0] == caml_domain_self() ) { // TODO: We should distribute this work
+  if( participating[0] == Caml_state ) { // TODO: We should distribute this work
     CAML_EV_BEGIN(EV_MINOR_GLOBAL_ROOTS);
     caml_scan_global_young_roots(oldify_one, &st);
     CAML_EV_END(EV_MINOR_GLOBAL_ROOTS);
@@ -557,10 +554,10 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
 
   if( participating_count > 1 ) {
     int participating_idx = -1;
-    struct domain* domain_self = caml_domain_self();
+    CAMLassert(domain == Caml_state);
 
     for( int i = 0; i < participating_count ; i++ ) {
-      if( participating[i] == domain_self ) {
+      if( participating[i] == domain ) {
         participating_idx = i;
         break;
       }
@@ -570,8 +567,8 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
 
     // We use this rather odd scheme because it better smoothes the remainder
     for( curr_idx = 0, c = participating_idx; curr_idx < participating_count; curr_idx++) {
-      struct domain* foreign_domain = participating[c];
-      struct caml_minor_tables* foreign_minor_tables = foreign_domain->state->minor_tables;
+      caml_domain_state* foreign_domain = participating[c];
+      struct caml_minor_tables* foreign_minor_tables = foreign_domain->minor_tables;
       struct caml_ref_table* foreign_major_ref = &foreign_minor_tables->major_ref;
       // calculate the size of the remembered set
       intnat major_ref_size = foreign_major_ref->ptr - foreign_major_ref->base;
@@ -588,7 +585,7 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
       }
 
       caml_gc_log("idx: %d, foreign_domain: %d, ref_size: %"ARCH_INTNAT_PRINTF_FORMAT"d, refs_per_domain: %"ARCH_INTNAT_PRINTF_FORMAT"d, ref_base: %p, ref_ptr: %p, ref_start: %p, ref_end: %p",
-        participating_idx, foreign_domain->state->id, major_ref_size, refs_per_domain, foreign_major_ref->base, foreign_major_ref->ptr, ref_start, ref_end);
+        participating_idx, foreign_domain->id, major_ref_size, refs_per_domain, foreign_major_ref->base, foreign_major_ref->ptr, ref_start, ref_end);
 
       for( r = ref_start ; r < foreign_major_ref->ptr && r < ref_end ; r++ )
       {
@@ -662,7 +659,7 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
 #endif
 
   CAML_EV_BEGIN(EV_MINOR_LOCAL_ROOTS);
-  caml_do_local_roots(&oldify_one, &st, domain->state->local_roots, domain->state->current_stack, domain->state->gc_regs);
+  caml_do_local_roots(&oldify_one, &st, domain->local_roots, domain->current_stack, domain->gc_regs);
   if (caml_scan_roots_hook != NULL) (*caml_scan_roots_hook)(&oldify_one, &st, domain);
   CAML_EV_BEGIN(EV_MINOR_LOCAL_ROOTS_PROMOTE);
   oldify_mopup (&st, 0);
@@ -672,25 +669,25 @@ void caml_empty_minor_heap_promote (struct domain* domain, int participating_cou
   /* we reset these pointers before allowing any mutators to be
      released to avoid races where another domain signals an interrupt
      and we clobber it */
-  atomic_store_rel((atomic_uintnat*)&domain_state->young_limit, (uintnat)domain_state->young_start);
-  atomic_store_rel((atomic_uintnat*)&domain_state->young_ptr, (uintnat)domain_state->young_end);
+  atomic_store_rel((atomic_uintnat*)&domain->young_limit, (uintnat)domain->young_start);
+  atomic_store_rel((atomic_uintnat*)&domain->young_ptr, (uintnat)domain->young_end);
 
   if( participating_count > 1 ) {
     atomic_fetch_add_explicit(&domains_finished_minor_gc, 1, memory_order_release);
   }
 
-  domain_state->stat_minor_words += Wsize_bsize (minor_allocated_bytes);
-  domain_state->stat_minor_collections++;
-  domain_state->stat_promoted_words += domain_state->allocated_words - prev_alloc_words;
+  domain->stat_minor_words += Wsize_bsize (minor_allocated_bytes);
+  domain->stat_minor_collections++;
+  domain->stat_promoted_words += domain->allocated_words - prev_alloc_words;
 
   CAML_EV_END(EV_MINOR);
   caml_gc_log ("Minor collection of domain %d completed: %2.0f%% of %u KB live",
-               domain->state->id,
+               domain->id,
                100.0 * (double)st.live_bytes / (double)minor_allocated_bytes,
                (unsigned)(minor_allocated_bytes + 512)/1024);
 }
 
-void caml_do_opportunistic_major_slice(struct domain* domain, void* unused)
+void caml_do_opportunistic_major_slice(caml_domain_state* domain_unused, void* unused)
 {
   /* NB: need to put guard around the ev logs to prevent
     spam when we poll */
@@ -705,18 +702,18 @@ void caml_do_opportunistic_major_slice(struct domain* domain, void* unused)
 /* Make sure the minor heap is empty by performing a minor collection
    if needed.
 */
-void caml_empty_minor_heap_setup(struct domain* domain) {
+void caml_empty_minor_heap_setup(caml_domain_state* domain_unused) {
   atomic_store_explicit(&domains_finished_minor_gc, 0, memory_order_release);
 }
 
 /* must be called within a STW section */
-static void caml_stw_empty_minor_heap_no_major_slice (struct domain* domain, void* unused, int participating_count, struct domain** participating)
+static void caml_stw_empty_minor_heap_no_major_slice (caml_domain_state* domain, void* unused, int participating_count, caml_domain_state** participating)
 {
   #ifdef DEBUG
   CAMLassert(caml_domain_is_in_stw());
   #endif
 
-  if( participating[0] == caml_domain_self() ) {
+  if( participating[0] == Caml_state ) {
     atomic_fetch_add(&caml_minor_cycles_started, 1);
   }
 
@@ -724,7 +721,7 @@ static void caml_stw_empty_minor_heap_no_major_slice (struct domain* domain, voi
   caml_empty_minor_heap_promote(domain, participating_count, participating);
 
   /* collect gc stats before leaving the barrier */
-  caml_sample_gc_collect(domain->state);
+  caml_sample_gc_collect(domain);
 
   if( participating_count > 1 ) {
     CAML_EV_BEGIN(EV_MINOR_LEAVE_BARRIER);
@@ -747,7 +744,7 @@ static void caml_stw_empty_minor_heap_no_major_slice (struct domain* domain, voi
   caml_gc_log("finished stw empty_minor_heap");
 }
 
-static void caml_stw_empty_minor_heap (struct domain* domain, void* unused, int participating_count, struct domain** participating)
+static void caml_stw_empty_minor_heap (caml_domain_state* domain, void* unused, int participating_count, caml_domain_state** participating)
 {
   caml_stw_empty_minor_heap_no_major_slice(domain, unused, participating_count, participating);
 
@@ -755,11 +752,11 @@ static void caml_stw_empty_minor_heap (struct domain* domain, void* unused, int 
   caml_request_major_slice();
 
   /* can change how we account clock in future, here just do raw count */
-  domain->state->major_gc_clock += 1.0;
+  domain->major_gc_clock += 1.0;
 }
 
 /* must be called within a STW section  */
-void caml_empty_minor_heap_no_major_slice_from_stw (struct domain* domain, void* unused, int participating_count, struct domain** participating)
+void caml_empty_minor_heap_no_major_slice_from_stw (caml_domain_state* domain, void* unused, int participating_count, caml_domain_state** participating)
 {
   barrier_status b = caml_global_barrier_begin();
   if( caml_global_barrier_is_final(b) ) {

--- a/runtime/roots.c
+++ b/runtime/roots.c
@@ -42,11 +42,11 @@
 intnat caml_globals_inited = 0;
 #endif
 
-CAMLexport void (*caml_scan_roots_hook)(scanning_action, void* fdata, struct domain *) = NULL;
+CAMLexport void (*caml_scan_roots_hook)(scanning_action, void* fdata, caml_domain_state *) = NULL;
 
-void caml_do_roots (scanning_action f, void* fdata, struct domain* d, int do_final_val)
+void caml_do_roots (scanning_action f, void* fdata, caml_domain_state* d, int do_final_val)
 {
-  caml_do_local_roots(f, fdata, d->state->local_roots, d->state->current_stack, d->state->gc_regs);
+  caml_do_local_roots(f, fdata, d->local_roots, d->current_stack, d->gc_regs);
   if (caml_scan_roots_hook != NULL) (*caml_scan_roots_hook)(f, fdata, d);
   caml_final_do_roots(f, fdata, d, do_final_val);
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -23,14 +23,14 @@ struct global_heap_state global = {0 << 8, 1 << 8, 2 << 8};
 typedef struct pool {
   struct pool* next;
   value* next_obj;
-  struct domain* owner;
+  caml_domain_state* owner;
   sizeclass sz;
 } pool;
 CAML_STATIC_ASSERT(sizeof(pool) == Bsize_wsize(POOL_HEADER_WSIZE));
 #define POOL_HEADER_SZ sizeof(pool)
 
 typedef struct large_alloc {
-  struct domain* owner;
+  caml_domain_state* owner;
   struct large_alloc* next;
 } large_alloc;
 CAML_STATIC_ASSERT(sizeof(large_alloc) % sizeof(value) == 0);
@@ -66,7 +66,7 @@ struct caml_heap_state {
 
   sizeclass next_to_sweep;
 
-  struct domain* owner;
+  caml_domain_state* owner;
 
   struct heap_stats stats;
 };
@@ -84,13 +84,13 @@ struct caml_heap_state* caml_init_shared_heap() {
     heap->next_to_sweep = 0;
     heap->swept_large = 0;
     heap->unswept_large = 0;
-    heap->owner = caml_domain_self();
+    heap->owner = Caml_state;
     memset(&heap->stats, 0, sizeof(heap->stats));
   }
   return heap;
 }
 
-static int move_all_pools(pool** src, pool** dst, struct domain* new_owner) {
+static int move_all_pools(pool** src, pool** dst, caml_domain_state* new_owner) {
   int count = 0;
   while (*src) {
     pool* p = *src;
@@ -201,7 +201,7 @@ static void calc_pool_stats(pool* a, sizeclass sz, struct heap_stats* s) {
 }
 
 /* Initialize a pool and its object freelist */
-static inline void pool_initialize(pool* r, sizeclass sz, struct domain* owner)
+static inline void pool_initialize(pool* r, sizeclass sz, caml_domain_state* owner)
 {
   mlsize_t wh = wsize_sizeclass[sz];
   value* p = (value*)((char*)r + POOL_HEADER_SZ);
@@ -297,7 +297,7 @@ static pool* pool_global_adopt(struct caml_heap_state* local, sizeclass sz)
   caml_plat_unlock(&pool_freelist.lock);
 
   if( !r && adopted_pool ) {
-    Caml_state->major_work_todo -=
+    local->owner->major_work_todo -=
       pool_sweep(local, &local->full_pools[sz], sz, 0);
     r = local->avail_pools[sz];
   }
@@ -314,7 +314,7 @@ static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
 
   /* Otherwise, try to sweep until we find one */
   while (!local->avail_pools[sz] && local->unswept_avail_pools[sz]) {
-    Caml_state->major_work_todo -=
+    local->owner->major_work_todo -=
       pool_sweep(local, &local->unswept_avail_pools[sz], sz, 0);
   }
 
@@ -459,7 +459,7 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist, sizeclass 
         /* update stats */
         s->pool_live_blocks--;
         s->pool_live_words -= Whsize_hd(hd);
-        local->owner->state->swept_words += Whsize_hd(hd);
+        local->owner->swept_words += Whsize_hd(hd);
         s->pool_frag_words -= (wh - Whsize_hd(hd));
       } else {
         /* still live, the pool can't be released to the global freelist */
@@ -498,7 +498,7 @@ static intnat large_alloc_sweep(struct caml_heap_state* local) {
 
     local->stats.large_words -=
       Whsize_hd(hd) + Wsize_bsize(LARGE_ALLOC_HEADER_SZ);
-    local->owner->state->swept_words +=
+    local->owner->swept_words +=
       Whsize_hd(hd) + Wsize_bsize(LARGE_ALLOC_HEADER_SZ);
     local->stats.large_blocks--;
     free(a);
@@ -640,10 +640,10 @@ void verify_push(void* st_v, value v, value* p)
   if (!Is_block(v)) return;
 
   if( Is_young(v) ) {
-    struct domain* domain;
+    caml_domain_state* domain_state;
     caml_gc_log("minor in heap: %p, hd_val: %lx, p: %p", (value*)v, Hd_val(v), p);
-    domain = caml_owner_of_young_block(v);
-    caml_gc_log("owner: %d, young_start: %p, young_end: %p, young_ptr: %p, young_limit: %p", domain->state->id, domain->state->young_start, domain->state->young_end, domain->state->young_ptr, (void *)domain->state->young_limit);
+    domain_state = caml_owner_of_young_block(v);
+    caml_gc_log("owner: %d, young_start: %p, young_end: %p, young_ptr: %p, young_limit: %p", domain_state->id, domain_state->young_start, domain_state->young_end, domain_state->young_ptr, (void *)domain_state->young_limit);
   }
 
   if (st->sp == st->stack_len) {
@@ -808,7 +808,7 @@ void caml_cycle_heap_stw() {
 void caml_cycle_heap(struct caml_heap_state* local) {
   int i, received_p = 0, received_l = 0;
 
-  caml_gc_log("Cycling heap [%02d]", local->owner->state->id);
+  caml_gc_log("Cycling heap [%02d]", local->owner->id);
   for (i = 0; i < NUM_SIZECLASSES; i++) {
     Assert(local->unswept_avail_pools[i] == 0);
     local->unswept_avail_pools[i] = local->avail_pools[i];


### PR DESCRIPTION
This PR simplifies the situation regarding how we represent the data for a domain. It removes `struct domain` and makes `caml_domain_state` the single source of domain information outside of `domain.c`. `struct dom_internal` also becomes an implementation detail of `domain.c` no longer leaking across the runtime. 

Before this PR there are three structures:
 - `caml_domain_state` in `domain_state.h` (`Caml_state` is a pointer to one of these)
 - `struct domain` in `domain.h` (this is got at with `caml_domain_self ()`)
 - `struct dom_internal` in `domain.c` but leaks out in `domain.h`

`struct domain` contains `caml_domain_state` and `struct dom_internal`. We have a slightly confusing situation where code outside of `domain.c` is indirecting through `struct domain` to get at `caml_domain_state` and actually the `struct dom_internal` is never used outside `domain.c`.
We also use pointers to `struct domain` to represent the id (or key) of a domain in a domain set (see `handler` for `caml_try_run_on_all_domains_with_spin_work` in `domain.h`).

The refactor here is mostly mechanical; we remove the indirection through `struct domain` and move all the interfaces to `caml_domain_state`. I also took the liberty to avoid calling `Caml_state` when we already have the `caml_domain_state` object; this could be important on platforms where TLS is more expensive, e.g. Mac OS where `Caml_state` resolves to a pthread function call. 

