### PR TITLE
Move our usage of inline to Caml_inline (to align with upstream ocaml)

### DIFF
--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -32,16 +32,10 @@
 #include "caml/domain.h"
 #include "caml/printexc.h"
 #include "caml/backtrace.h"
+#include "caml/signals.h"
+
 #include <pthread.h>
 #include <signal.h>
-#include <caml/signals.h>
-
-#ifdef __GNUC__
-#undef INLINE
-#define INLINE inline
-#else
-#define INLINE
-#endif
 
 typedef int st_retcode;
 
@@ -74,7 +68,7 @@ static int st_thread_create(st_thread_id * res,
 
 /* Cleanup at thread exit */
 
-static INLINE void st_thread_cleanup(void)
+Caml_inline void st_thread_cleanup(void)
 {
   return;
 }
@@ -99,12 +93,12 @@ static int st_tls_newkey(st_tlskey * res)
   return pthread_key_create(res, NULL);
 }
 
-static INLINE void * st_tls_get(st_tlskey k)
+Caml_inline void * st_tls_get(st_tlskey k)
 {
   return pthread_getspecific(k);
 }
 
-static INLINE void st_tls_set(st_tlskey k, void * v)
+Caml_inline void st_tls_set(st_tlskey k, void * v)
 {
   pthread_setspecific(k, v);
 }
@@ -202,7 +196,7 @@ static void st_masterlock_release(st_masterlock * m)
    re-wake us later.
 */
 
-static INLINE void st_thread_yield(st_masterlock * m)
+Caml_inline void st_thread_yield(st_masterlock * m)
 {
   uintnat waiters;
 

--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -54,7 +54,7 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
   return result;
 }
 
-static inline void enter_gc_preserving_vals(mlsize_t wosize, value* vals)
+Caml_inline void enter_gc_preserving_vals(mlsize_t wosize, value* vals)
 {
   mlsize_t i;
   CAMLparam0();
@@ -68,7 +68,7 @@ static inline void enter_gc_preserving_vals(mlsize_t wosize, value* vals)
   CAMLreturn0;
 }
 
-static inline value do_alloc_small(mlsize_t wosize, tag_t tag, value* vals)
+Caml_inline value do_alloc_small(mlsize_t wosize, tag_t tag, value* vals)
 {
   value v;
   mlsize_t i;

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -37,14 +37,14 @@ static __thread int callback_depth = 0;
  * is executing to ensure that the garbage collector follows the
  * stack parent
  */
-static inline value save_and_clear_stack_parent(caml_domain_state* domain_state) {
+Caml_inline value save_and_clear_stack_parent(caml_domain_state* domain_state) {
   struct stack_info* parent_stack = Stack_parent(domain_state->current_stack);
   value cont = caml_alloc_1(Cont_tag, Val_ptr(parent_stack));
   Stack_parent(domain_state->current_stack) = NULL;
   return cont;
 }
 
-static inline void restore_stack_parent(caml_domain_state* domain_state, value cont) {
+Caml_inline void restore_stack_parent(caml_domain_state* domain_state, value cont) {
   struct stack_info* parent_stack = Ptr_val(Op_val(cont)[0]);
   Assert(Stack_parent(domain_state->current_stack) == NULL);
   Stack_parent(domain_state->current_stack) = parent_stack;

--- a/runtime/caml/addrmap.h
+++ b/runtime/caml/addrmap.h
@@ -31,7 +31,7 @@ void caml_addrmap_iter(struct addrmap* t, void (*f)(value, value));
 
 /* iteration */
 typedef uintnat addrmap_iterator;
-static inline addrmap_iterator caml_addrmap_iter_ok(struct addrmap* t, addrmap_iterator i)
+Caml_inline addrmap_iterator caml_addrmap_iter_ok(struct addrmap* t, addrmap_iterator i)
 {
   if (i < t->size) {
     Assert(t->entries[i].key != ADDRMAP_INVALID_KEY);
@@ -41,7 +41,7 @@ static inline addrmap_iterator caml_addrmap_iter_ok(struct addrmap* t, addrmap_i
   }
 }
 
-static inline addrmap_iterator caml_addrmap_next(struct addrmap* t, addrmap_iterator i)
+Caml_inline addrmap_iterator caml_addrmap_next(struct addrmap* t, addrmap_iterator i)
 {
   if (!t->entries) return (uintnat)(-1);
   i++;
@@ -52,25 +52,25 @@ static inline addrmap_iterator caml_addrmap_next(struct addrmap* t, addrmap_iter
   return i;
 }
 
-static inline value caml_addrmap_iter_key(struct addrmap* t, addrmap_iterator i)
+Caml_inline value caml_addrmap_iter_key(struct addrmap* t, addrmap_iterator i)
 {
   Assert(caml_addrmap_iter_ok(t, i));
   return t->entries[i].key;
 }
 
-static inline value caml_addrmap_iter_value(struct addrmap* t, addrmap_iterator i)
+Caml_inline value caml_addrmap_iter_value(struct addrmap* t, addrmap_iterator i)
 {
   Assert(caml_addrmap_iter_ok(t, i));
   return t->entries[i].value;
 }
 
-static inline value* caml_addrmap_iter_val_pos(struct addrmap* t, addrmap_iterator i)
+Caml_inline value* caml_addrmap_iter_val_pos(struct addrmap* t, addrmap_iterator i)
 {
   Assert(caml_addrmap_iter_ok(t, i));
   return &t->entries[i].value;
 }
 
-static inline addrmap_iterator caml_addrmap_iterator(struct addrmap* t)
+Caml_inline addrmap_iterator caml_addrmap_iterator(struct addrmap* t)
 {
   return caml_addrmap_next(t, (uintnat)(-1));
 }

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -39,12 +39,6 @@
 #define Caml_inline static inline
 #endif
 
-#if defined(_MSC_VER) && !defined(__cplusplus)
-#define Caml_inline static __inline
-#else
-#define Caml_inline static inline
-#endif
-
 #include "s.h"
 
 #ifdef BOOTSTRAPPING_FLEXLINK

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -77,7 +77,7 @@ CAMLextern atomic_uintnat caml_num_domains_running;
 CAMLextern uintnat caml_minor_heaps_base;
 CAMLextern uintnat caml_minor_heaps_end;
 
-INLINE intnat caml_domain_alone()
+Caml_inline intnat caml_domain_alone()
 {
   return atomic_load_acq(&caml_num_domains_running) == 1;
 }

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -25,7 +25,7 @@ typedef enum {
 } gc_phase_t;
 extern gc_phase_t caml_gc_phase;
 
-static inline char caml_gc_phase_char(gc_phase_t phase) {
+Caml_inline char caml_gc_phase_char(gc_phase_t phase) {
   switch (phase) {
     case Phase_sweep_and_mark_main:
       return 'M';

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -82,7 +82,7 @@ extern int caml_debug_is_major(value val);
     *ref->ptr++ = (x);                                                  \
   } while (0)
 
-static inline void add_to_ephe_ref_table (struct caml_ephe_ref_table *tbl,
+Caml_inline void add_to_ephe_ref_table (struct caml_ephe_ref_table *tbl,
                                           value ar, mlsize_t offset)
 {
   struct caml_ephe_ref_elt *ephe_ref;
@@ -96,7 +96,7 @@ static inline void add_to_ephe_ref_table (struct caml_ephe_ref_table *tbl,
   CAMLassert(ephe_ref->offset < Wosize_val(ephe_ref->ephe));
 }
 
-static inline void add_to_custom_table (struct caml_custom_table *tbl, value v,
+Caml_inline void add_to_custom_table (struct caml_custom_table *tbl, value v,
                                         mlsize_t mem, mlsize_t max)
 {
   struct caml_custom_elt *elt;

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -245,12 +245,12 @@ CAMLextern value caml_get_public_method (value obj, value tag);
    Note however that tags being hashed, same tag does not necessarily mean
    same method name. */
 
-static inline value Val_ptr(void* p)
+Caml_inline value Val_ptr(void* p)
 {
   CAMLassert(((value)p & 1) == 0);
   return (value)p + 1;
 }
-static inline void* Ptr_val(value val)
+Caml_inline void* Ptr_val(value val)
 {
   CAMLassert(val & 1);
   return (void*)(val - 1);

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -37,23 +37,23 @@ extern struct global_heap_state global;
 /* CR mshinwell: ensure this matches [Emitaux] */
 enum {NOT_MARKABLE = 3 << 8};
 
-static inline int Has_status_hd(header_t hd, status s) {
+Caml_inline int Has_status_hd(header_t hd, status s) {
   return (hd & (3 << 8)) == s;
 }
 
-static inline header_t With_status_hd(header_t hd, status s) {
+Caml_inline header_t With_status_hd(header_t hd, status s) {
   return (hd & ~(3 << 8)) | s;
 }
 
-static inline int is_garbage(value v) {
+Caml_inline int is_garbage(value v) {
   return Has_status_hd(Hd_val(v), global.GARBAGE);
 }
 
-static inline int is_unmarked(value v) {
+Caml_inline int is_unmarked(value v) {
   return Has_status_hd(Hd_val(v), global.UNMARKED);
 }
 
-static inline int is_marked(value v) {
+Caml_inline int is_marked(value v) {
   return Has_status_hd(Hd_val(v), global.MARKED);
 }
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1013,7 +1013,7 @@ void caml_handle_gc_interrupt()
   CAML_EV_END(EV_INTERRUPT_GC);
 }
 
-CAMLexport inline int caml_bt_is_in_blocking_section(void)
+CAMLexport int caml_bt_is_in_blocking_section(void)
 {
   dom_internal* self = domain_self;
   uintnat status = atomic_load_acq(&self->backup_thread_msg);
@@ -1024,7 +1024,7 @@ CAMLexport inline int caml_bt_is_in_blocking_section(void)
 
 }
 
-CAMLexport inline intnat caml_domain_is_multicore ()
+CAMLexport intnat caml_domain_is_multicore ()
 {
   dom_internal *self = domain_self;
   return (!caml_domain_alone() || self->backup_thread_running);

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -52,7 +52,7 @@ struct stack_info** caml_alloc_stack_cache () {
   return stack_cache;
 }
 
-static inline struct stack_info* alloc_for_stack (mlsize_t wosize)
+Caml_inline struct stack_info* alloc_for_stack (mlsize_t wosize)
 {
   return caml_stat_alloc_noexc(sizeof(struct stack_info) +
                                sizeof(value) * wosize +
@@ -60,7 +60,7 @@ static inline struct stack_info* alloc_for_stack (mlsize_t wosize)
                                sizeof(struct stack_handler));
 }
 
-static inline struct stack_info** stack_cache_bucket (mlsize_t wosize) {
+Caml_inline struct stack_info** stack_cache_bucket (mlsize_t wosize) {
   mlsize_t size_bucket_wsz = caml_fiber_wsz;
   struct stack_info** size_bucket = Caml_state->stack_cache;
   struct stack_info** end = size_bucket + NUM_STACK_SIZE_CLASSES;
@@ -146,7 +146,7 @@ void caml_get_stack_sp_pc (struct stack_info* stack, char** sp /* out */, uintna
   *pc = Saved_return_address(*sp);
 }
 
-static inline void scan_stack_frames(scanning_action f, void* fdata, struct stack_info* stack, value* gc_regs)
+Caml_inline void scan_stack_frames(scanning_action f, void* fdata, struct stack_info* stack, value* gc_regs)
 {
   char * sp;
   uintnat retaddr;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -186,7 +186,7 @@ void caml_orphan_allocated_words() {
     atomic_fetch_add(&terminated_domains_allocated_words, Caml_state->allocated_words);
 }
 
-static inline value ephe_list_tail(value e)
+Caml_inline value ephe_list_tail(value e)
 {
   value last = 0;
   while (e != 0) {

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -123,11 +123,9 @@
    generated.
 */
 
-__attribute__((always_inline)) inline static void write_barrier(value obj, intnat field, value old_val, value new_val) ;
-
 /* The write barrier does not read or write the heap, it just
    modifies domain-local data structures. */
-static void write_barrier(value obj, intnat field, value old_val, value new_val)
+Caml_inline void write_barrier(value obj, intnat field, value old_val, value new_val)
 {
   /* HACK: can't assert when get old C-api style pointers
     Assert (Is_block(obj)); */

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -154,7 +154,7 @@ static value alloc_shared(caml_domain_state* d, mlsize_t wosize, tag_t tag)
 }
 
 #if 0
-static inline void log_gc_value(const char* prefix, value v)
+Caml_inline void log_gc_value(const char* prefix, value v)
 {
   if (Is_block(v)) {
     header_t hd = Hd_val(v);
@@ -179,7 +179,7 @@ static void spin_on_header(value v) {
   }
 }
 
-static inline header_t get_header_val(value v) {
+Caml_inline header_t get_header_val(value v) {
   header_t hd = atomic_load_explicit(Hp_atomic_val(v), memory_order_relaxed);
   if (!Is_update_in_progress(hd))
     return hd;
@@ -237,7 +237,7 @@ static int try_update_object_header(value v, value *p, value result, mlsize_t in
 
 /* If [*v] is an [Infix_tag] object, [v] is updated to point to the first
  * object in the block. */
-static inline void resolve_infix_val (value* v)
+Caml_inline void resolve_infix_val (value* v)
 {
   int offset = 0;
   if (get_header_val(*v) == Infix_tag) {
@@ -389,7 +389,7 @@ static void oldify_one (void* st_v, value v, value *p)
 /* Care needed with this test. It will only make sense if
    all minor heaps have been promoted
    as the liveness of the keys can only be known at that point */
-static inline int ephe_check_alive_data (struct caml_ephe_ref_elt *re)
+Caml_inline int ephe_check_alive_data (struct caml_ephe_ref_elt *re)
 {
   mlsize_t i;
   value child;

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -201,7 +201,7 @@ static void calc_pool_stats(pool* a, sizeclass sz, struct heap_stats* s) {
 }
 
 /* Initialize a pool and its object freelist */
-static inline void pool_initialize(pool* r, sizeclass sz, caml_domain_state* owner)
+Caml_inline void pool_initialize(pool* r, sizeclass sz, caml_domain_state* owner)
 {
   mlsize_t wh = wsize_sizeclass[sz];
   value* p = (value*)((char*)r + POOL_HEADER_SZ);


### PR DESCRIPTION
This PR moves multicore to use `Caml_inline` for all C inlining in the runtime. This also matches us up with upstream ocaml. 