### PR TITLE
Removing interrupt queues

### DIFF
--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -26,8 +26,6 @@ extern "C" {
 #include "config.h"
 #include "mlvalues.h"
 #include "domain_state.h"
-#include "memory.h"
-#include "major_gc.h"
 #include "platform.h"
 
 #define Caml_check_gc_interrupt(dom_st)   \
@@ -49,7 +47,6 @@ void caml_request_minor_gc (void);
 
 void caml_interrupt_self(void);
 
-void caml_sample_gc_stats(struct gc_stats* buf);
 void caml_print_stats(void);
 
 CAMLexport void caml_reset_domain_lock(void);

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -5,7 +5,6 @@
 
 #include "misc.h"
 #include "mlvalues.h"
-#include "memory.h"
 #include "roots.h"
 
 struct stack_info;

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -17,7 +17,6 @@
 #define CAML_MINOR_GC_H
 
 #include "misc.h"
-#include "addrmap.h"
 #include "config.h"
 
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -607,10 +607,17 @@ CAMLprim value caml_domain_spawn(value callback, value mutex)
     caml_failwith("failed to create domain thread");
   }
 
+  /* while waiting for the child thread to startup
+     we need to servicing any STW if they come in */
   caml_plat_lock(&domain_self->interruptor.lock);
   while (p.status == Dom_starting) {
-    if (handle_incoming(&domain_self->interruptor) == 0)
+    if (caml_incoming_interrupts_queued()) {
+      caml_plat_unlock(&domain_self->interruptor.lock);
+      handle_incoming(&domain_self->interruptor);
+      caml_plat_lock(&domain_self->interruptor.lock);
+    } else {
       caml_plat_wait(&domain_self->interruptor.cond);
+    }
   }
   caml_plat_unlock(&domain_self->interruptor.lock);
 
@@ -1054,32 +1061,15 @@ void caml_print_stats () {
     Caml_state->stat_major_collections);
 }
 
-/* Sending interrupts between domains.
-
-   To avoid deadlock, some rules are important:
-
-   - Don't hold interruptor locks for long
-   - Don't hold two interruptor locks at the same time
- */
-
-/* must be called with s->lock held */
+/* must NOT be called with s->lock held */
 static uintnat handle_incoming(struct interruptor* s)
 {
-  uintnat handled = 0;
+  uintnat handled = atomic_load_acq(&s->interrupt_pending);
   Assert (s->running);
-  if (atomic_load_acq(&s->interrupt_pending)) {
+  if (handled) {
     atomic_store_rel(&s->interrupt_pending, 0);
 
-    /* Unlock s while the handler runs, to allow other
-       domains to send us messages. This is necessary to
-       avoid deadlocks, since the handler might send
-       interrupts */
-    caml_plat_unlock(&s->lock);
-
     stw_handler(domain_self->state);
-
-    caml_plat_lock(&s->lock);
-    handled++;
   }
   return handled;
 }
@@ -1155,7 +1145,7 @@ static void domain_terminate()
      * fail, which forces this domain to finish marking and sweeping again.
      */
 
-    if (handle_incoming(s) == 0 &&
+    if (!caml_incoming_interrupts_queued() &&
         Caml_state->marking_done &&
         Caml_state->sweeping_done) {
 
@@ -1216,9 +1206,7 @@ int caml_incoming_interrupts_queued()
 static inline void handle_incoming_interrupts(struct interruptor* s, int otherwise_relax)
 {
   if (atomic_load_acq(&s->interrupt_pending)) {
-    caml_plat_lock(&s->lock);
     handle_incoming(s);
-    caml_plat_unlock(&s->lock);
   } else if (otherwise_relax) {
     cpu_relax();
   }
@@ -1254,12 +1242,15 @@ static void caml_wait_interrupt_serviced (struct interruptor* self,
       handle_incoming_otherwise_relax(self);
     }
   }
-
-  return;
 }
 
 int caml_send_interrupt(struct interruptor* target)
 {
+  /* we have blocked new domains joining as the STW is in progress
+   * a target domain can not go from 'not running' to 'running'
+   */
+  if (!target->running) return 0;
+
   caml_plat_lock(&target->lock);
   if (!target->running) {
     caml_plat_unlock(&target->lock);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -808,8 +808,6 @@ static void stw_handler(caml_domain_state* domain)
 
       if (stw_request.enter_spin_callback)
         stw_request.enter_spin_callback(domain, stw_request.enter_spin_data);
-      else
-        cpu_relax();
     }
   }
   CAML_EV_END(EV_STW_API_BARRIER);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -721,10 +721,11 @@ static void stw_handler(caml_domain_state* domain)
     SPIN_WAIT {
       if (atomic_load_acq(&stw_request.domains_still_running) == 0)
         break;
-      caml_handle_incoming_interrupts();
 
       if (stw_request.enter_spin_callback)
         stw_request.enter_spin_callback(domain, stw_request.enter_spin_data);
+      else
+        cpu_relax();
     }
   }
   CAML_EV_END(EV_STW_API_BARRIER);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -19,7 +19,6 @@
 #include <string.h>
 #include <math.h>
 
-#include "caml/addrmap.h"
 #include "caml/config.h"
 #include "caml/domain.h"
 #include "caml/eventlog.h"

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -27,7 +27,6 @@
 #include "caml/major_gc.h"
 #include "caml/shared_heap.h"
 #include "caml/domain.h"
-#include "caml/addrmap.h"
 #include "caml/roots.h"
 #include "caml/alloc.h"
 #include "caml/fiber.h"

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -18,7 +18,6 @@
 #include <string.h>
 #include <stdio.h>
 
-#include "caml/addrmap.h"
 #include "caml/config.h"
 #include "caml/custom.h"
 #include "caml/domain.h"


### PR DESCRIPTION
This PR simplifies our implementation of domains by removing interrupt request queues, since the only runtime interrupt that signals another domain is a stop-the-world section. 

This PR:
- removes `struct interrupt`
- removes locking of `struct interruptor` when receiving interrupts
- removes the duplication between `interrupt_word` and `interrupt_word_address`
- cleans out usages of `addrmap.h` when it is not used (bonus feature)