### PR TITLE
Reintroduce adjust_gc_speed

### DIFF
--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -114,6 +114,8 @@ DOMAIN_STATE(value, dls_root)
 
 DOMAIN_STATE(value, unique_token_root)
 
+DOMAIN_STATE(double, extra_heap_resources)
+
 /*****************************************************************************/
 /* GC stats (see gc_ctrl.c and the Gc module) */
 /*****************************************************************************/

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -115,6 +115,7 @@ DOMAIN_STATE(value, dls_root)
 DOMAIN_STATE(value, unique_token_root)
 
 DOMAIN_STATE(double, extra_heap_resources)
+DOMAIN_STATE(double, extra_heap_resources_minor)
 
 /*****************************************************************************/
 /* GC stats (see gc_ctrl.c and the Gc module) */

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -588,6 +588,7 @@ CAMLextern void caml_remove_generational_global_root (value *);
 
 CAMLextern void caml_modify_generational_global_root(value *r, value newval);
 
+CAMLextern void caml_adjust_gc_speed (mlsize_t, mlsize_t);
 
 #ifdef __cplusplus
 }

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -50,16 +50,12 @@ static value alloc_custom_gen (const struct custom_operations * ops,
     result = caml_alloc_small(wosize, Custom_tag);
     Custom_ops_val(result) = ops;
     if (ops->finalize != NULL || mem != 0) {
-      /* Remember that the block needs processing after minor GC. */
-      add_to_custom_table (&Caml_state->minor_tables->custom, result, mem, max_major);
-#if 0 /* XXX TODO KC */
       if (mem > mem_minor) {
         caml_adjust_gc_speed (mem - mem_minor, max_major);
       }
       /* The remaining [mem_minor] will be counted if the block survives a
          minor GC */
-      add_to_custom_table (Caml_state->custom_table, result,
-                           mem_minor, max_major);
+      add_to_custom_table (&Caml_state->minor_tables->custom, result, mem, max_major);
       /* Keep track of extra resources held by custom block in
          minor heap. */
       if (mem_minor != 0) {
@@ -68,10 +64,8 @@ static value alloc_custom_gen (const struct custom_operations * ops,
           (double) mem_minor / (double) max_minor;
         if (Caml_state->extra_heap_resources_minor > 1.0) {
           caml_request_minor_gc ();
-          caml_gc_dispatch ();
         }
       }
-#endif
     }
   } else {
     result = caml_alloc_shr(wosize, Custom_tag);

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -76,7 +76,7 @@ static value alloc_custom_gen (const struct custom_operations * ops,
   } else {
     result = caml_alloc_shr(wosize, Custom_tag);
     Custom_ops_val(result) = ops;
-    /* !!caml_adjust_gc_speed(mem, max_major); */
+    caml_adjust_gc_speed(mem, max_major);
     result = caml_check_urgent_gc(result);
   }
   CAMLreturn(result);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -331,6 +331,7 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
     Assert(!d->interruptor.interrupt_pending);
 
     domain_state->extra_heap_resources = 0.0;
+    domain_state->extra_heap_resources_minor = 0.0;
 
     if (caml_init_signal_stack() < 0) {
       goto init_signal_stack_failure;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -330,6 +330,8 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
     d->state = domain_state;
     Assert(!d->interruptor.interrupt_pending);
 
+    domain_state->extra_heap_resources = 0.0;
+
     if (caml_init_signal_stack() < 0) {
       goto init_signal_stack_failure;
     }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -369,8 +369,9 @@ static void update_major_slice_work() {
   if( saved_terminated_words > 0 ) {
     while(!atomic_compare_exchange_strong(&terminated_domains_allocated_words, &saved_terminated_words, 0));
   }
-
   p = (double) (saved_terminated_words + dom_st->allocated_words) * 3.0 * (100 + caml_percent_free) / heap_words / caml_percent_free / 2.0;
+
+  if (p < dom_st->extra_heap_resources) p = dom_st->extra_heap_resources;
 
   if (p > 0.3) p = 0.3;
 
@@ -416,6 +417,7 @@ static void update_major_slice_work() {
 
   dom_st->stat_major_words += dom_st->allocated_words;
   dom_st->allocated_words = 0;
+  dom_st->extra_heap_resources = 0.0;
 }
 
 static intnat get_major_slice_work(intnat howmuch) {

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -344,7 +344,7 @@ static void update_major_slice_work() {
                     = dom_st->allocated_words * 3 * (100 + caml_percent_free)
                       / (2 * heap_words * caml_percent_free)
      Proportion of extra-heap resources consumed since the previous slice:
-                 PE = caml_extra_heap_resources
+                 PE = dom_st->extra_heap_resources
      Proportion of total work to do in this slice:
                  P  = max (PH, PE)
      Amount of marking work for the GC cycle:
@@ -397,6 +397,9 @@ static void update_major_slice_work() {
   caml_gc_message (0x40, "raw work-to-do = %"
                          ARCH_INTNAT_PRINTF_FORMAT "uu\n",
                    (uintnat) (p * 1000000));
+  caml_gc_message (0x40, "extra_heap_resources = %"
+		   ARCH_INTNAT_PRINTF_FORMAT "uu\n",
+		   (uintnat) (dom_st->extra_heap_resources * 1000000));
   caml_gc_message (0x40, "computed work = %"
                          ARCH_INTNAT_PRINTF_FORMAT "d words\n",
                    computed_work);

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -689,3 +689,14 @@ CAMLexport wchar_t* caml_stat_wcsconcat(int n, ...)
 }
 
 #endif
+
+CAMLexport void caml_adjust_gc_speed (mlsize_t res, mlsize_t max)
+{
+  if (max == 0) max = 1;
+  if (res > max) res = max;
+  Caml_state->extra_heap_resources += (double) res / (double) max;
+  if (Caml_state->extra_heap_resources > 1.0){
+    Caml_state->extra_heap_resources = 1.0;
+    caml_request_major_slice ();
+  }
+}

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -47,8 +47,6 @@ static atomic_intnat domains_finished_minor_gc;
 
 static atomic_uintnat caml_minor_cycles_started = 0;
 
-double caml_extra_heap_resources_minor = 0;
-
 /* [sz] and [rsv] are numbers of entries */
 static void alloc_generic_table (struct generic_table *tbl, asize_t sz,
                                  asize_t rsv, asize_t element_size)

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -512,6 +512,8 @@ void caml_empty_minor_heap_domain_clear (caml_domain_state* domain, void* unused
   clear_table ((struct generic_table *)&minor_tables->ephe_ref);
   clear_table ((struct generic_table *)&minor_tables->custom);
 
+  Caml_state->extra_heap_resources_minor = 0.0;
+
 #ifdef DEBUG
   {
     uintnat* p = (uintnat*)domain->young_start;
@@ -622,6 +624,7 @@ void caml_empty_minor_heap_promote (caml_domain_state* domain, int participating
     if (Is_block(*v) && Is_young(*v)) {
       if (get_header_val(*v) == 0) { /* value copied to major heap */
         *v = Field(*v, 0);
+        caml_adjust_gc_speed(elt->mem, elt->max);
       } else {
         oldify_one(&st, *v, v);
       }

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -512,7 +512,7 @@ void caml_empty_minor_heap_domain_clear (caml_domain_state* domain, void* unused
   clear_table ((struct generic_table *)&minor_tables->ephe_ref);
   clear_table ((struct generic_table *)&minor_tables->custom);
 
-  Caml_state->extra_heap_resources_minor = 0.0;
+  domain->extra_heap_resources_minor = 0.0;
 
 #ifdef DEBUG
   {

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -622,9 +622,9 @@ void caml_empty_minor_heap_promote (caml_domain_state* domain, int participating
   for (elt = self_minor_tables->custom.base; elt < self_minor_tables->custom.ptr; elt++) {
     value *v = &elt->block;
     if (Is_block(*v) && Is_young(*v)) {
+      caml_adjust_gc_speed(elt->mem, elt->max);
       if (get_header_val(*v) == 0) { /* value copied to major heap */
         *v = Field(*v, 0);
-        caml_adjust_gc_speed(elt->mem, elt->max);
       } else {
         oldify_one(&st, *v, v);
       }


### PR DESCRIPTION
This PR reintroduce the `caml_adjust_gc_speed` function in the runtime.
The core logic of the function is mostly unchanged from trunk.

`Caml_state` now holds a specific variable (extra_heap_resources) to track additional work to be done by the garbage collector during a major collection.
`caml_adjust_gc_speed` will set this variable to a desired factor, that will be taken into account in `update_major_slice_work`.
It will be as well reset (to 0.0) at the end of work computation.

I've reintroduced the call to `adjust_gc_speed` in `alloc_custom_gen` as well. (in the default branch where custom values are allocated onto the shared heap, since the minor heap case is commented away.)
