### PR TITLE
runtime: stub caml_stat_* interfaces in gc_ctrl

### DIFF
--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -30,7 +30,7 @@ value caml_gc_major(value);
 
 #define caml_stat_top_heap_wsz caml_top_heap_words(Caml_state->shared_heap)
 #define caml_stat_compactions 0
-#define caml_stat_heap_wsz caml_heap_size(Caml_state->shared_heap)
+#define caml_stat_heap_wsz Wsize_bsize(caml_heap_size(Caml_state->shared_heap))
 #define caml_stat_heap_chunks caml_heap_blocks(Caml_state->shared_heap)
 #define caml_stat_major_collections Caml_state->stat_major_collections
 #define caml_stat_minor_collections Caml_state->stat_minor_collections

--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -27,6 +27,21 @@ void caml_init_gc ();
 value caml_gc_stat(value);
 value caml_gc_major(value);
 
+
+#define caml_stat_top_heap_wsz caml_top_heap_words(Caml_state->shared_heap)
+#define caml_stat_compactions 0
+#define caml_stat_heap_wsz caml_heap_size(Caml_state->shared_heap)
+#define caml_stat_heap_chunks caml_heap_blocks(Caml_state->shared_heap)
+#define caml_stat_major_collections Caml_state->stat_major_collections
+#define caml_stat_minor_collections Caml_state->stat_minor_collections
+#define caml_stat_promoted_words Caml_state->stat_promoted_words
+#define caml_allocated_words Caml_state->allocated_words
+#define caml_stat_major_words Caml_state->stat_major_words
+#define caml_stat_minor_words Caml_state->stat_minor_words
+
+#define caml_young_end Caml_state->young_end
+#define caml_young_ptr Caml_state->young_ptr
+
 #ifdef DEBUG
 void caml_heap_check (void);
 #endif


### PR DESCRIPTION
This PR pushes toward introducing a compatibility layer to some gc stat utilities exposed by trunk.

With #589, this PR enables the successful compilation of stock `core_kernel` (and `async` and `core`), as well as `batteries`.

Notes:
- `caml_stat_top_heap_wsz` and `caml_stat_heap_chunks` are the obvious weird cases here. It introduces an extra level of indirection. I am also unsure if these are the semantically correct equivalents to what happens in trunk.
- I decided to opt for a similar approach to `trunk` and have these definitions sit in `gc_ctrl.h`.
It is unclear, however, if it is really the best location for `caml_young_end` and `caml_young_ptr`.


