### PR TITLE
Fix two issues with ephemerons

### DIFF
--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -62,7 +62,6 @@ void caml_orphan_allocated_words();
 void caml_add_to_orphaned_ephe_list(struct caml_ephe_info* ephe_info);
 void caml_add_orphaned_finalisers (struct caml_final_info*);
 void caml_final_domain_terminate (caml_domain_state *domain_state);
-void caml_adopt_orphaned_work (void);
 
 struct heap_stats {
   intnat pool_words;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1119,11 +1119,8 @@ static void handover_ephemerons(caml_domain_state* domain_state)
     return;
 
   caml_add_to_orphaned_ephe_list(domain_state->ephe_info);
-  if (domain_state->ephe_info->todo != 0) {
-    caml_ephe_todo_list_emptied();
-  }
-  domain_state->ephe_info->live = 0;
-  domain_state->ephe_info->todo = 0;
+  Assert (domain_state->ephe_info->live == 0);
+  Assert (domain_state->ephe_info->todo == 0);
 }
 
 static void handover_finalisers(caml_domain_state* domain_state)

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1027,6 +1027,11 @@ static void cycle_all_domains_callback(struct domain* domain, void* unused,
       atomic_store_rel(&num_domains_to_final_update_first, num_domains_in_stw);
       atomic_store_rel(&num_domains_to_final_update_last, num_domains_in_stw);
 
+      // Adopt orphaned work from domains that were spawned and terminated in
+      // the previous cycle.
+      CAMLassert (orph_structs.ephe_list_todo == 0);
+      caml_adopt_orphaned_work ();
+
       atomic_store(&domain_global_roots_started, WORK_UNSTARTED);
     }
     // should interrupts be processed here or not?

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -110,15 +110,17 @@ static void ephe_next_cycle ()
 void caml_ephe_todo_list_emptied ()
 {
   caml_plat_lock(&ephe_lock);
-  /* Force next ephemeron cycle in order to avoid reasoning about whether the
-   * domain has already incremented [ephe_cycle_info.num_domains_done] counter
-   */
+
+  /* Force next ephemeron marking cycle in order to avoid reasoning about
+   * whether the domain has already incremented
+   * [ephe_cycle_info.num_domains_done] counter. */
   atomic_store(&ephe_cycle_info.num_domains_done, 0);
   atomic_fetch_add(&ephe_cycle_info.ephe_cycle, +1);
   atomic_fetch_add(&ephe_cycle_info.num_domains_todo, -1);
   atomic_fetch_add_verify_ge0(&num_domains_to_ephe_sweep, -1);
   CAMLassert(atomic_load_acq(&ephe_cycle_info.num_domains_done) <=
              atomic_load_acq(&ephe_cycle_info.num_domains_todo));
+
   caml_plat_unlock(&ephe_lock);
 }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -110,6 +110,11 @@ static void ephe_next_cycle ()
 void caml_ephe_todo_list_emptied ()
 {
   caml_plat_lock(&ephe_lock);
+  /* Force next ephemeron cycle in order to avoid reasoning about whether the
+   * domain has already incremented [ephe_cycle_info.num_domains_done] counter
+   */
+  atomic_store(&ephe_cycle_info.num_domains_done, 0);
+  atomic_fetch_add(&ephe_cycle_info.ephe_cycle, +1);
   atomic_fetch_add(&ephe_cycle_info.num_domains_todo, -1);
   atomic_fetch_add_verify_ge0(&num_domains_to_ephe_sweep, -1);
   CAMLassert(atomic_load_acq(&ephe_cycle_info.num_domains_done) <=
@@ -1034,7 +1039,7 @@ static void cycle_all_domains_callback(caml_domain_state* domain, void* unused,
 
       caml_gc_phase = Phase_sweep_and_mark_main;
       atomic_store(&ephe_cycle_info.num_domains_todo, num_domains_in_stw);
-      atomic_store(&ephe_cycle_info.ephe_cycle, 0);
+      atomic_store(&ephe_cycle_info.ephe_cycle, 1);
       atomic_store(&ephe_cycle_info.num_domains_done, 0);
       atomic_store_rel(&num_domains_to_ephe_sweep, num_domains_in_stw);
       atomic_store_rel(&num_domains_to_final_update_first, num_domains_in_stw);

--- a/testsuite/tests/weak-ephe-final/ephetest6.ml
+++ b/testsuite/tests/weak-ephe-final/ephetest6.ml
@@ -2,19 +2,24 @@
 
 module E = Ephemeron.Kn
 
-let test1 =
+let test1 () =
   let e1 = E.create 16 in
   for i = 0 to 15 do
     E.set_key e1 i i
   done;
-  let d = Domain.spawn (fun () ->
+  let d = Array.init 8 (fun _ -> Domain.spawn (fun () ->
     let e2 = E.create 16 in
     E.blit_key e1 0 e2 0 16;
     match E.get_key e2 1 with
     | Some 1 -> ()
-    | _ -> assert false)
+    | _ -> assert false))
   in
-  Domain.join d;
+  Array.iter Domain.join d
+
+let _ =
+  for _ = 0 to 10 do
+    test1 ();
+  done;
   print_endline "test1: ok"
 
 let _ = Gc.full_major ()


### PR DESCRIPTION
This PR simplifies ephemeron handover during termination. 

Primarily, we no longer hand over ephemerons that are yet to be processed in the current cycle (in the `todo` list). Instead, we force the ephemerons yet to be processed and their data to be live in the current cycle such that there is no work to be done for those ephemerons in the current cycle. This moves all the ephemerons to the `live` list. This simplifies invariants quite a bit. The downside is that ephemerons and their data on a domain that is currently terminating will be GCed in the next cycle. This cost is small compared to the simplification benefits. 

Fixes #545 and #588.