### PR TITLE
Implement caml_alloc_dependent_memory and caml_free_dependent_memory

### DIFF
--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -117,6 +117,9 @@ DOMAIN_STATE(value, unique_token_root)
 DOMAIN_STATE(double, extra_heap_resources)
 DOMAIN_STATE(double, extra_heap_resources_minor)
 
+DOMAIN_STATE(uintnat, dependent_size)
+DOMAIN_STATE(uintnat, dependent_allocated)
+
 /*****************************************************************************/
 /* GC stats (see gc_ctrl.c and the Gc module) */
 /*****************************************************************************/

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -49,6 +49,7 @@ CAMLextern value caml_alloc_shr_preserving_profinfo (mlsize_t, tag_t,
   caml_alloc_shr(size, tag)
 #endif /* WITH_PROFINFO */
 CAMLextern value caml_alloc_shr_no_raise (mlsize_t wosize, tag_t);
+CAMLextern void caml_adjust_gc_speed (mlsize_t, mlsize_t);
 CAMLextern void caml_alloc_dependent_memory (mlsize_t);
 CAMLextern void caml_free_dependent_memory (mlsize_t);
 CAMLextern int caml_atomic_cas_field (value, intnat, value, value);
@@ -587,8 +588,6 @@ CAMLextern void caml_remove_generational_global_root (value *);
    previously registered with [caml_register_generational_global_root]. */
 
 CAMLextern void caml_modify_generational_global_root(value *r, value newval);
-
-CAMLextern void caml_adjust_gc_speed (mlsize_t, mlsize_t);
 
 #ifdef __cplusplus
 }

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -333,6 +333,9 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
     domain_state->extra_heap_resources = 0.0;
     domain_state->extra_heap_resources_minor = 0.0;
 
+    domain_state->dependent_size = 0;
+    domain_state->dependent_allocated = 0;
+
     if (caml_init_signal_stack() < 0) {
       goto init_signal_stack_failure;
     }


### PR DESCRIPTION
This PR fixes #512. 

`caml_adjust_gc_speed` was handled in #589 and this PR just gives implementations (matching upstream OCaml) for `caml_alloc_dependent_memory` and `caml_free_dependent_memory`.
