### PR TITLE
systhreads: do st_thread_id after initializing the thread descriptor

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -495,9 +495,9 @@ CAMLexport int caml_c_thread_register(void)
   }
   /* Associate the thread descriptor with the thread */
   st_tls_set(Thread_key, (void *) th);
-  st_thread_set_id(Ident(th->descr));
   /* Allocate the thread descriptor on the heap */
   th->descr = caml_thread_new_descriptor(Val_unit);  /* no closure */
+  st_thread_set_id(Ident(th->descr));
   /* Release the master lock */
   st_masterlock_release(&Thread_main_lock);
   return 1;


### PR DESCRIPTION
This PR address the issue found at #528 (`linux-O0` build.)

The mistake is pretty easy to spot, the thread id was set before initializing the related thread descriptor.

I'm not quite sure why this is only showing up in the `O0` build, I would guess some checks or accesses are elided during a following optimization pass.

