### PR TITLE
Don't deliver signals to threads that have blocked them

### DIFF
--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -27,6 +27,11 @@ extern "C" {
 #endif
 
 #ifdef CAML_INTERNALS
+
+#ifndef NSIG
+#define NSIG 64
+#endif
+
 CAMLextern intnat volatile caml_signals_are_pending;
 CAMLextern intnat volatile caml_pending_signals[];
 CAMLextern int volatile caml_something_to_do;

--- a/testsuite/tests/lib-systhreads/eintr.ml
+++ b/testsuite/tests/lib-systhreads/eintr.ml
@@ -19,7 +19,8 @@ let _ = Thread.create (fun () ->
       incr signals_sent
     end else begin
       Thread.yield ()
-    end
+    end;
+    Domain.Sync.poll ()
   done) ()
 let request_signal () = Atomic.incr signals_requested
 
@@ -61,7 +62,8 @@ let () =
     poke_stdout (); Atomic.set r false));
   request_signal ();
   while Atomic.get r do
-    poke_stdout ()
+    poke_stdout ();
+
   done;
   Sys.set_signal Sys.sigint Signal_default;
   print_endline "chan: ok"
@@ -79,7 +81,8 @@ let () =
   begin match
     while true do
       poke_stdout ();
-      Atomic.set during (mklist ())
+      Atomic.set during (mklist ());
+
     done
   with
   | () -> assert false


### PR DESCRIPTION
At present if a thread blocks a signal it might still receive it. This PR incorporates some of the changes from https://github.com/ocaml/ocaml/pull/2211 to fix that.

It's a draft because I _think_ we still need to handle the without-systhreads case. I couldn't find the right initialisation hook to switch out the sigprocmask wrapper (as the ocaml PR does).

cc @Engil @ctk21 