### PR TITLE
Expose a few more GC variables in headers

### DIFF
--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -39,12 +39,6 @@ value caml_gc_major(value);
 #define caml_stat_major_words Caml_state->stat_major_words
 #define caml_stat_minor_words Caml_state->stat_minor_words
 
-#define caml_young_end Caml_state->young_end
-#define caml_young_ptr Caml_state->young_ptr
-#define caml_young_start Caml_state->young_start
-#define caml_young_limit Caml_state->young_limit
-#define caml_minor_heap_wsz Caml_state->minor_heap_wsz
-
 #ifdef DEBUG
 void caml_heap_check (void);
 #endif

--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -43,6 +43,7 @@ value caml_gc_major(value);
 #define caml_young_ptr Caml_state->young_ptr
 #define caml_young_start Caml_state->young_start
 #define caml_young_limit Caml_state->young_limit
+#define caml_minor_heap_wsz Caml_state->minor_heap_wsz
 
 #ifdef DEBUG
 void caml_heap_check (void);

--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -41,6 +41,8 @@ value caml_gc_major(value);
 
 #define caml_young_end Caml_state->young_end
 #define caml_young_ptr Caml_state->young_ptr
+#define caml_young_start Caml_state->young_start
+#define caml_young_limit Caml_state->young_limit
 
 #ifdef DEBUG
 void caml_heap_check (void);

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -19,6 +19,12 @@
 #include "misc.h"
 #include "config.h"
 
+#define caml_young_end Caml_state->young_end
+#define caml_young_ptr Caml_state->young_ptr
+#define caml_young_start Caml_state->young_start
+#define caml_young_limit Caml_state->young_limit
+#define caml_minor_heap_wsz Caml_state->minor_heap_wsz
+
 
 #define CAML_TABLE_STRUCT(t) { \
   t *base;                     \


### PR DESCRIPTION
This PR exposes a few more internals that seems to be used by the outside world, from what I gather from the Opam CI:
http://check.ocamllabs.io:8082/log/1624377054-df20c61009ce6b16d04ffcfe43ef26c629c2599c/4.12+domains+gc_stubs/bad/grenier.0.12
See #448 as well.