### PR TITLE
Domain better participants

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1209,6 +1209,8 @@ static void domain_terminate()
     }
     caml_plat_unlock(&all_domains_lock);
   }
+  /* We can not touch domain_self->interruptor after here
+     because it may be reused */
   caml_sample_gc_collect(domain_state);
   caml_remove_generational_global_root(&domain_state->unique_token_root);
   caml_remove_generational_global_root(&domain_state->dls_root);
@@ -1229,9 +1231,6 @@ static void domain_terminate()
   if(domain_state->current_stack != NULL) {
     caml_free_stack(domain_state->current_stack);
   }
-
-  /* we shouldn't have any unserviced interrupts pending */
-  Assert(!domain_self->interruptor.interrupt_pending);
 
   atomic_store_rel(&domain_self->backup_thread_msg, BT_TERMINATE);
   caml_plat_signal(&domain_self->domain_cond);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1033,7 +1033,6 @@ CAMLexport void caml_acquire_domain_lock(void)
 {
   dom_internal* self = domain_self;
   caml_plat_lock(&self->domain_lock);
-  return;
 }
 
 CAMLexport void caml_bt_enter_ocaml(void)
@@ -1045,15 +1044,12 @@ CAMLexport void caml_bt_enter_ocaml(void)
   if (self->backup_thread_running) {
     atomic_store_rel(&self->backup_thread_msg, BT_ENTERING_OCAML);
   }
-
-  return;
 }
 
 CAMLexport void caml_release_domain_lock(void)
 {
   dom_internal* self = domain_self;
   caml_plat_unlock(&self->domain_lock);
-  return;
 }
 
 CAMLexport void caml_bt_exit_ocaml(void)
@@ -1067,25 +1063,19 @@ CAMLexport void caml_bt_exit_ocaml(void)
     /* Wakeup backup thread if it is sleeping */
     caml_plat_signal(&self->domain_cond);
   }
-
-
-  return;
 }
 
 static void caml_enter_blocking_section_default(void)
 {
   caml_bt_exit_ocaml();
   caml_release_domain_lock();
-  return;
 }
 
 static void caml_leave_blocking_section_default(void)
 {
   caml_bt_enter_ocaml();
   caml_acquire_domain_lock();
-  return;
 }
-
 
 CAMLexport void (*caml_enter_blocking_section_hook)(void) =
    caml_enter_blocking_section_default;


### PR DESCRIPTION
This PR looks to remove iterations `O(Max_domains)` from STW signalling and `O(n_running_domains)` from domain creation. 

The design is:
- maintain a structure (`stw_domains`) that holds the list of domains participating in STW sections vs those free.
- `all_domains_lock` provides concurrency protection to `stw_domains` and gives protection between domain creation, termination, and STW sections
- triggering a STW section becomes an `O(n_running_domains)` operation and creation of a domain is `O(1)`; termination is `O(n_running_domains)` involving a scan in the terminating domain.

I believe this PR should allow us to increase `Max_domains` up to larger values; the cost to this is in the intitialization of the `all_domains` array and the extra VM space that is reserved. 