### PR TITLE
Make +domains+effects and +domains distinguishable

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
-4.12.0+multicore
+4.12.0+effects
 
 # The version string is the first line of this file.
 # It must be in the format described in stdlib/sys.mli


### PR DESCRIPTION
Just a proposal to help fix https://github.com/ocaml-multicore/ocaml-multicore/issues/599 more easily.
Currently +domains and +domains+effects are not distinguishable by `ocaml --version`. Both return `4.12.0+multicore`.