### PR TITLE
Add std gnu11 common cflags

### DIFF
--- a/configure
+++ b/configure
@@ -12686,7 +12686,7 @@ case $host in #(
     internal_cflags="-Wno-unused $cc_warnings \
 -fexcess-precision=standard"
         # TODO: see whether the code can be fixed to avoid -Wno-unused
-        common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
+        common_cflags="-std=gnu11 -O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
         internal_cppflags='-D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE'
         internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
         internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
@@ -12696,7 +12696,7 @@ esac ;; #(
   *) :
     case $ocaml_cv_cc_vendor in #(
   clang-*) :
-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
+    common_cflags="-std=gnu11 -O2 -fno-strict-aliasing -fwrapv";
       internal_cflags="$cc_warnings -fno-common" ;; #(
   gcc-[012]-*) :
     # Some versions known to miscompile OCaml, e,g, 2.7.2.1, some 2.96.
@@ -12721,7 +12721,7 @@ $as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
 -fno-builtin-memcmp";
       internal_cflags="$cc_warnings -fexcess-precision=standard" ;; #(
   gcc-*) :
-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
+    common_cflags="-std=gnu11 -O2 -fno-strict-aliasing -fwrapv";
       internal_cflags="$cc_warnings -fno-common \
 -fexcess-precision=standard" ;; #(
   msvc-*) :

--- a/configure.ac
+++ b/configure.ac
@@ -596,14 +596,14 @@ AS_CASE([$host],
         [internal_cflags="-Wno-unused $cc_warnings \
 -fexcess-precision=standard"
         # TODO: see whether the code can be fixed to avoid -Wno-unused
-        common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
+        common_cflags="-std=gnu11 -O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
         internal_cppflags='-D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE'
         internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
         internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
       [AC_MSG_ERROR([Unsupported C compiler for a Mingw build])])],
   [AS_CASE([$ocaml_cv_cc_vendor],
     [clang-*],
-      [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
+      [common_cflags="-std=gnu11 -O2 -fno-strict-aliasing -fwrapv";
       internal_cflags="$cc_warnings -fno-common"],
     [gcc-[[012]]-*],
       # Some versions known to miscompile OCaml, e,g, 2.7.2.1, some 2.96.
@@ -628,7 +628,7 @@ AS_CASE([$host],
 -fno-builtin-memcmp";
       internal_cflags="$cc_warnings -fexcess-precision=standard"],
     [gcc-*],
-      [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
+      [common_cflags="-std=gnu11 -O2 -fno-strict-aliasing -fwrapv";
       internal_cflags="$cc_warnings -fno-common \
 -fexcess-precision=standard"],
     [msvc-*],


### PR DESCRIPTION
While looking at https://github.com/ocaml-multicore/ocaml-multicore/issues/574 with @Kate and @Sudha247 we noticed that it seems there's a discrepancy in what kind of flags OCaml packages are using to build C stubs against the runtime.

This does not address further issues in the ecosystem (I'll update #574 with the problematic packages.), but at least it allows people using `ocamlc -config` to retrieve the correct C flags to select the right C variant.

For now I added it to Clang and GCC, and I'm not quite sure this is entirely required, however I feel like that being explicit on it is better than not.

