### PR TITLE
Thread-safe skiplist insert and remove methods for codefrag

### DIFF
--- a/runtime/caml/skiplist.h
+++ b/runtime/caml/skiplist.h
@@ -74,10 +74,15 @@ extern int caml_skiplist_find_below(struct skiplist * sk, uintnat k,
 extern int caml_skiplist_insert(struct skiplist * sk,
                                 uintnat key, uintnat data);
 
+extern int caml_skiplist_insert_ts(struct skiplist* sk,
+                            uintnat key, uintnat data);
+
 /* Deletion in a skip list.
    If [key] was there, remove it and return 1.
    If [key] was not there, leave the skip list unchanged and return 0. */
 extern int caml_skiplist_remove(struct skiplist * sk, uintnat key);
+
+extern int caml_skiplist_remove_ts(struct skiplist * sk, uintnat key);
 
 /* Empty an already initialized skip list. */
 extern void caml_skiplist_empty(struct skiplist * sk);

--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -54,17 +54,17 @@ int caml_register_code_fragment(char * start, char * end,
   }
   cf->digest_status = digest_kind;
   cf->fragnum = code_fragments_counter++;
-  caml_skiplist_insert(&code_fragments_by_pc,
+  caml_skiplist_insert_ts(&code_fragments_by_pc,
                        (uintnat) start, (uintnat) cf);
-  caml_skiplist_insert(&code_fragments_by_num,
+  caml_skiplist_insert_ts(&code_fragments_by_num,
                        (uintnat) cf->fragnum, (uintnat) cf);
   return cf->fragnum;
 }
 
 void caml_remove_code_fragment(struct code_fragment * cf)
 {
-  caml_skiplist_remove(&code_fragments_by_pc, (uintnat) cf->code_start);
-  caml_skiplist_remove(&code_fragments_by_num, cf->fragnum);
+  caml_skiplist_remove_ts(&code_fragments_by_pc, (uintnat) cf->code_start);
+  caml_skiplist_remove_ts(&code_fragments_by_num, cf->fragnum);
   caml_stat_free(cf);
 }
 


### PR DESCRIPTION
This is an attempt at making codefrag thread-safe (fixes #570) . This patch introduces two new methods in the skiplist structure for thread-safe insertion and deletion operations, codefrag uses these methods, so registering and removing code fragments from multiple threads should be safe to do. Searching remains unaltered and is lockfree, thereby can be used along with signal handlers.