### PR TITLE
otherlibs: encode_terminal_status does not set all fields

### DIFF
--- a/otherlibs/unix/termios.c
+++ b/otherlibs/unix/termios.c
@@ -198,7 +198,7 @@ static void encode_terminal_status(value *dst)
   long * pc;
   int i;
 
-  for(pc = terminal_io_descr; *pc != End; ) {
+  for(pc = terminal_io_descr; *pc != End; dst++) {
     switch(*pc++) {
     case Bool:
       { int * src = (int *) (*pc++);


### PR DESCRIPTION
This addresses issue #620

This was a small error when we moved from `caml_initialize_field` to `caml_initialize`.

I re-read the commit to check for similar errors, I could not spot any.