### PR TITLE
Exposing caml_channel_mutex_* hooks

### DIFF
--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -106,6 +106,12 @@ CAMLextern intnat caml_really_getblock (struct channel *, char *, intnat);
 
 #define Channel(v) (*((struct channel **) (Data_custom_val(v))))
 
+/* The locking machinery */
+
+CAMLextern void (*caml_channel_mutex_lock) (struct channel *);
+CAMLextern void (*caml_channel_mutex_unlock) (struct channel *);
+CAMLextern void (*caml_channel_mutex_unlock_exn) (void);
+
 CAMLextern struct channel * caml_all_opened_channels;
 
 /* Conversion between file_offset and int64_t */

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -54,6 +54,20 @@
 #define lseek _lseeki64
 #endif
 
+static void channel_lock (struct channel *chan) {
+  caml_plat_lock(&chan->mutex);
+  return ;
+}
+
+static void channel_unlock (struct channel *chan) {
+  caml_plat_unlock(&chan->mutex);
+  return ;
+}
+
+/* Hooks for locking channels */
+CAMLexport void (*caml_channel_mutex_lock) (struct channel *) = channel_lock;
+CAMLexport void (*caml_channel_mutex_unlock) (struct channel *) = channel_unlock;
+
 /* List of opened channels and its mutex */
 CAMLexport caml_plat_mutex
   caml_all_opened_channels_mutex = CAML_PLAT_MUTEX_INITIALIZER;

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -54,6 +54,11 @@
 #define lseek _lseeki64
 #endif
 
+/* For compatibility purpose, we need to set caml_channel_mutex_lock/unlock.
+   This will tell external code that it needs to handle concurrent
+   channel accesses properly.
+*/
+
 static void channel_lock (struct channel *chan) {
   caml_plat_lock(&chan->mutex);
   return ;


### PR DESCRIPTION
This PR attempt implementing some missing pieces of the runtime's interface.

The idea is that, on trunk, there exists a set of four hooks that are used to handle locking channel when required.
- `caml_channel_mutex_lock`: will lock a channel's mutex (`chan->mutex`)
- `caml_channel_mutex_unlock`: will unlock the mutex
- `caml_channel_mutex_free`: will be called then the channel is being freed.
- `caml_channel_mutex_unlock_exn`: I'm not a 100% sure, but it looks like to me this one is meant to unlock the last locked channel when an exception is being raised. (see [trunk's fail_nat.c](https://github.com/ocaml/ocaml/blob/trunk/runtime/fail_nat.c#L64) and the hook set by [systhreads](https://github.com/ocaml/ocaml/blob/trunk/otherlibs/systhreads/st_stubs.c#L296))

On trunk, these hooks are by default doing nothing.
However, when systhreads is linked in, [it will setup these hooks to handle potential concurrent accesses to channels](https://github.com/ocaml/ocaml/blob/trunk/otherlibs/systhreads/st_stubs.c#L254)

On Multicore, we do not have these because channel are already being locked by default. (because many domains may try to access the same channels.)
However, we need to expose these hooks still, because some libraries may take the freedom to handle locking on channels themselves:
See for instance [core's bigstring implementation](https://github.com/janestreet/core/blob/master/bigstring_unix/src/bigstring_unix_stubs.c#L307) where IO and processing on the channel are done with custom code and as such, the hooks are called to ensure that concurrent accesses are kept in check.

This PR aims to devise what we actually need to expose for the ecosystem to be happy, and I started by implementing `mutex_lock` and `mutex_unlock`: these are pretty straightforward and I think this implementation is valid in the context of the bigstring example: we just set the hooks to `lock` or `unlock` the channel's mutex, by default.

Three pieces are missing still and may need discussion and investigation:
- `caml_channel_mutex_free`: is it used outside of the runtime code (systhreads) included, in any meaningful way besides freeing the mutex (which Multicore's runtime already does)?
- `caml_channel_mutex_unlock_exn`: My understanding is that this is used in trunk as a way to unlock the last locked channel when an exception is being raised. (see previously in this message). Is it required in our context? We do not seem to perform any channel unlocks when raising an exception.
- Linking the two previous points: do we need to restore systhreads's specifics hooks in Multicore? Most of it revolves around `last_channel_locked_key` in systhreads which is used to unlock a channel when an exception has been thrown.