### PR TITLE
in link_channel, channel->prev should be set to NULL

### DIFF
--- a/runtime/io.c
+++ b/runtime/io.c
@@ -80,6 +80,7 @@ static void link_channel (struct channel* channel)
 {
   caml_plat_lock (&caml_all_opened_channels_mutex);
   channel->next = caml_all_opened_channels;
+  channel->prev = NULL;
   if (caml_all_opened_channels != NULL)
     caml_all_opened_channels->prev = channel;
   caml_all_opened_channels = channel;

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -80,7 +80,7 @@ static void link_channel (struct channel* channel)
 {
   caml_plat_lock (&caml_all_opened_channels_mutex);
   channel->next = caml_all_opened_channels;
-  channel->prev = NULL;
+  CAMLassert(channel->prev == NULL);
   if (caml_all_opened_channels != NULL)
     caml_all_opened_channels->prev = channel;
   caml_all_opened_channels = channel;
@@ -99,6 +99,8 @@ static void unlink_channel(struct channel *channel)
     channel->prev->next = channel->next;
     if (channel->next != NULL) channel->next->prev = channel->prev;
   }
+  channel->next = NULL;
+  channel->prev = NULL;
   caml_plat_unlock (&caml_all_opened_channels_mutex);
 }
 


### PR DESCRIPTION
This PR attempt to fix #627.

The problem we are seeing on that issue is related to how `caml_close_channel` can re-link a channel using `link_channel`.

In any circumstances, when linking a channel, `channel->prev` should be NULL, as `link_channel` and `unlink_channels` are the one doing the accounting work on the list.

The interactions between `unlink_channel` and `link_channel` and where they are called may benefit from further proofreading.