### PR TITLE
Backtrace last exn is val unit

### DIFF
--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -41,7 +41,7 @@ CAMLprim value caml_record_backtrace(value vflag)
       caml_modify_generational_global_root(&Caml_state->backtrace_last_exn, Val_unit);
     } else {
       caml_remove_generational_global_root(&Caml_state->backtrace_last_exn);
-      Caml_state->backtrace_last_exn = (value) NULL;
+      Caml_state->backtrace_last_exn = (value) Val_unit;
     }
   }
   return Val_unit;

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -37,12 +37,7 @@ CAMLprim value caml_record_backtrace(value vflag)
   if (flag != Caml_state->backtrace_active) {
     Caml_state->backtrace_active = flag;
     Caml_state->backtrace_pos = 0;
-    if (flag) {
-      caml_modify_generational_global_root(&Caml_state->backtrace_last_exn, Val_unit);
-    } else {
-      caml_remove_generational_global_root(&Caml_state->backtrace_last_exn);
-      Caml_state->backtrace_last_exn = (value) Val_unit;
-    }
+    caml_modify_generational_global_root(&Caml_state->backtrace_last_exn, Val_unit);
   }
   return Val_unit;
 }


### PR DESCRIPTION
This PR attempts to correct an issue found when running `core's` testsuite, as reported by @emillon in #624.

#### Excerpt from the issue:

What happens is that core links `systhreads` in, so the runtime will go through the process of registering `backtrace_last_exn` as a generational global root.
https://github.com/ocaml-multicore/ocaml-multicore/blob/4.12%2Bdomains%2Beffects/runtime/backtrace.c#L44

This should be fine for any valid values for `backtrace_last_exn`, except there's a codepath that sets it to `NULL` here:
https://github.com/ocaml-multicore/ocaml-multicore/blob/4.12%2Bdomains%2Beffects/runtime/backtrace.c#L44

Which means that later on, when the GC kicks in and this global root was registered with `NULL`, `caml_darken` will crash the runtime because it is an invalid value.

#### Proposed solution

After discussing with @ctk21, it seems that the second branch in `caml_record_backtrace` is a bit odd, as the generational global root may still be accessed elsewhere in the codebase after removal. (as demonstrated by this issue.)

A simple fix would be to remove this branch and just clear `backtrace_last_exn` to `Val_unit` instead everytime the flag is changed, and not remove the generational global root like it is done right now.