### PR TITLE
Make signals safe for multicore

### DIFF
--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -41,10 +41,6 @@ void caml_handle_gc_interrupt(void);
 
 void caml_handle_incoming_interrupts(void);
 
-void caml_request_major_slice (void);
-
-void caml_request_minor_gc (void);
-
 void caml_interrupt_self(void);
 
 void caml_print_stats(void);
@@ -56,12 +52,6 @@ CAMLexport void caml_bt_enter_ocaml(void);
 CAMLexport void caml_bt_exit_ocaml(void);
 CAMLexport void caml_acquire_domain_lock(void);
 CAMLexport void caml_release_domain_lock(void);
-
-CAMLextern void caml_enter_blocking_section(void);
-CAMLextern void caml_leave_blocking_section(void);
-
-CAMLextern void (*caml_enter_blocking_section_hook)(void);
-CAMLextern void (*caml_leave_blocking_section_hook)(void);
 
 CAMLextern void (*caml_atfork_hook)(void);
 

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -7,7 +7,6 @@
 #include <string.h>
 #include "config.h"
 #include "mlvalues.h"
-#include "signals.h"
 
 #if defined(MAP_ANON) && !defined(MAP_ANONYMOUS)
 #define MAP_ANONYMOUS MAP_ANON

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -7,6 +7,7 @@
 #include <string.h>
 #include "config.h"
 #include "mlvalues.h"
+#include "signals.h"
 
 #if defined(MAP_ANON) && !defined(MAP_ANONYMOUS)
 #define MAP_ANONYMOUS MAP_ANON

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -16,6 +16,10 @@
 #ifndef CAML_SIGNALS_H
 #define CAML_SIGNALS_H
 
+#if defined(CAML_INTERNALS) && defined(POSIX_SIGNALS)
+#include<signal.h>
+#endif
+
 #ifndef CAML_NAME_SPACE
 #include "compatibility.h"
 #endif
@@ -26,30 +30,55 @@
 extern "C" {
 #endif
 
-#ifdef CAML_INTERNALS
-CAMLextern intnat volatile caml_signals_are_pending;
-CAMLextern intnat volatile caml_pending_signals[];
-CAMLextern int volatile caml_something_to_do;
-int caml_init_signal_stack(void);
-void caml_free_signal_stack(void);
-void caml_init_signal_handling(void);
-/* </private> */
-
 CAMLextern void caml_enter_blocking_section (void);
+CAMLextern void caml_enter_blocking_section_no_pending (void);
 CAMLextern void caml_leave_blocking_section (void);
 
+#ifdef CAML_INTERNALS
+CAMLextern atomic_intnat caml_pending_signals[];
+
+/* When an action is pending, either [caml_something_to_do] is 1, or
+   there is a function currently running which will end by either
+   executing all actions, or set [caml_something_to_do] back to 1. We
+   set it to 0 when starting executing all callbacks.
+
+   In the case there are two different callbacks (say, a signal and a
+   finaliser) arriving at the same time, then the processing of one
+   awaits the return of the other. In case of long-running callbacks,
+   we may want to run the second one without waiting the end of the
+   first one. We do this by provoking an additional polling every
+   minor collection and every major slice. To guarantee a low latency
+   for signals, we avoid delaying signal handlers in that case by
+   calling them first.
+
+   FIXME: We could get into caml_process_pending_actions when
+   caml_something_to_do is seen as set but not caml_pending_signals,
+   making us miss the signal.
+*/
+
+/* Global variables moved to Caml_state in 4.10 */
+#define caml_requested_major_slice (Caml_state_field(requested_major_slice))
+#define caml_requested_minor_gc (Caml_state_field(requested_minor_gc))
+
+void caml_update_young_limit(void);
+void caml_request_major_slice (void);
+void caml_request_minor_gc (void);
 CAMLextern int caml_convert_signal_number (int);
 CAMLextern int caml_rev_convert_signal_number (int);
+value caml_execute_signal_exn(int signal_number, int in_signal_handler);
 CAMLextern void caml_record_signal(int signal_number);
-CAMLextern void caml_process_pending_signals(void);
+CAMLextern value caml_process_pending_signals_exn(void);
+void caml_set_action_pending (void);
 int caml_set_signal_action(int signo, int action);
 
+CAMLextern value caml_process_pending_signals_with_root_exn (value extra_root);
+void caml_init_signal_handling(void);
+int caml_init_signal_stack(void);
+void caml_free_signal_stack(void);
 
-CAMLextern void (* volatile caml_async_action_hook)(void);
+CAMLextern void (*caml_enter_blocking_section_hook)(void);
+CAMLextern void (*caml_leave_blocking_section_hook)(void);
 #endif /* CAML_INTERNALS */
-
-CAMLextern void caml_enter_blocking_section (void);
-CAMLextern void caml_leave_blocking_section (void);
 
 #ifdef __cplusplus
 }

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -37,25 +37,6 @@ CAMLextern void caml_leave_blocking_section (void);
 #ifdef CAML_INTERNALS
 CAMLextern atomic_intnat caml_pending_signals[];
 
-/* When an action is pending, either [caml_something_to_do] is 1, or
-   there is a function currently running which will end by either
-   executing all actions, or set [caml_something_to_do] back to 1. We
-   set it to 0 when starting executing all callbacks.
-
-   In the case there are two different callbacks (say, a signal and a
-   finaliser) arriving at the same time, then the processing of one
-   awaits the return of the other. In case of long-running callbacks,
-   we may want to run the second one without waiting the end of the
-   first one. We do this by provoking an additional polling every
-   minor collection and every major slice. To guarantee a low latency
-   for signals, we avoid delaying signal handlers in that case by
-   calling them first.
-
-   FIXME: We could get into caml_process_pending_actions when
-   caml_something_to_do is seen as set but not caml_pending_signals,
-   making us miss the signal.
-*/
-
 /* Global variables moved to Caml_state in 4.10 */
 #define caml_requested_major_slice (Caml_state_field(requested_major_slice))
 #define caml_requested_minor_gc (Caml_state_field(requested_minor_gc))

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -995,22 +995,6 @@ void caml_interrupt_self() {
   interrupt_domain(&domain_self->interruptor);
 }
 
-/* Arrange for a major GC slice to be performed on the current domain
-   as soon as possible */
-void caml_request_major_slice (void)
-{
-  Caml_state->requested_major_slice = 1;
-  caml_interrupt_self();
-}
-
-/* Arrange for a minor GC to be performed on the current domain
-   as soon as possible */
-void caml_request_minor_gc (void)
-{
-  Caml_state->requested_minor_gc = 1;
-  caml_interrupt_self();
-}
-
 static void caml_poll_gc_work()
 {
   CAMLalloc_point_here;
@@ -1115,34 +1099,6 @@ CAMLexport void caml_bt_exit_ocaml(void)
     /* Wakeup backup thread if it is sleeping */
     caml_plat_signal(&self->domain_cond);
   }
-}
-
-static void caml_enter_blocking_section_default(void)
-{
-  caml_bt_exit_ocaml();
-  caml_release_domain_lock();
-}
-
-static void caml_leave_blocking_section_default(void)
-{
-  caml_bt_enter_ocaml();
-  caml_acquire_domain_lock();
-}
-
-CAMLexport void (*caml_enter_blocking_section_hook)(void) =
-   caml_enter_blocking_section_default;
-CAMLexport void (*caml_leave_blocking_section_hook)(void) =
-   caml_leave_blocking_section_default;
-
-CAMLexport void caml_leave_blocking_section() {
-  caml_leave_blocking_section_hook();
-  caml_process_pending_signals();
-}
-
-CAMLexport void caml_enter_blocking_section() {
-
-  caml_process_pending_signals();
-  caml_enter_blocking_section_hook();
 }
 
 /* default handler for unix_fork, will be called by unix_fork. */

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -1012,6 +1012,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
     process_signal:
       Setup_for_event;
       caml_handle_gc_interrupt();
+      caml_raise_if_exception(caml_process_pending_signals_exn());
       Restore_after_event;
       Next;
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -30,6 +30,7 @@
 #include "caml/mlvalues.h"
 #include "caml/platform.h"
 #include "caml/roots.h"
+#include "caml/signals.h"
 #include "caml/shared_heap.h"
 #include "caml/startup_aux.h"
 #include "caml/weak.h"

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -25,6 +25,7 @@
 #include "caml/fail.h"
 #include "caml/memory.h"
 #include "caml/major_gc.h"
+#include "caml/signals.h"
 #include "caml/shared_heap.h"
 #include "caml/domain.h"
 #include "caml/roots.h"

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -19,7 +19,6 @@
 
 #include <signal.h>
 #include <errno.h>
-#include <string.h>
 #include "caml/alloc.h"
 #include "caml/callback.h"
 #include "caml/config.h"
@@ -29,7 +28,10 @@
 #include "caml/mlvalues.h"
 #include "caml/roots.h"
 #include "caml/signals.h"
+#include "caml/signals_machdep.h"
 #include "caml/sys.h"
+#include "caml/memprof.h"
+#include "caml/finalise.h"
 
 #ifndef NSIG
 #define NSIG 64
@@ -37,93 +39,134 @@
 
 /* The set of pending signals (received but not yet processed) */
 
-CAMLexport intnat volatile caml_signals_are_pending = 0;
-CAMLexport intnat volatile caml_pending_signals[NSIG];
+static atomic_intnat total_signals_pending = 0;
+CAMLexport atomic_intnat caml_pending_signals[NSIG];
+caml_plat_mutex signal_install_mutex = CAML_PLAT_MUTEX_INITIALIZER;
+
+static int check_for_pending_signals(void)
+{
+  int i;
+  for (i = 0; i < NSIG; i++) {
+    if (atomic_load_explicit(&caml_pending_signals[i], memory_order_acquire)) return 1;
+  }
+  return 0;
+}
 
 /* Execute all pending signals */
 
-static void caml_execute_signal(int signal_number);
-void caml_process_pending_signals(void)
+CAMLexport value caml_process_pending_signals_exn(void)
 {
   int i;
-  /* this function preserves errno (PR#5982) */
-  int saved_errno = errno;
+  intnat specific_signal_pending, total_signals_pending;
+  value exn;
+#ifdef POSIX_SIGNALS
+  sigset_t set;
+#endif
 
-  if (caml_signals_are_pending) {
-    caml_signals_are_pending = 0;
-    for (i = 0; i < NSIG; i++) {
-      if (caml_pending_signals[i]) {
-        caml_pending_signals[i] = 0;
-        caml_execute_signal(i);
+total_signals_pending = atomic_load_explicit(&total_signals_pending, memory_order_acquire);
+if( total_signals_pending == 0 )
+  return Val_unit;
+
+/* Check that there is indeed a pending signal before issuing the
+    syscall in [pthread_sigmask]. It is possible for there to be a
+    race between checking [total_signals_pending] and checking the 
+    actual pending signals so there may not be a signal to handle. */
+if (!check_for_pending_signals())
+  return Val_unit;
+
+#ifdef POSIX_SIGNALS
+  pthread_sigmask(/* dummy */ SIG_BLOCK, NULL, &set);
+#endif
+  for (i = 0; i < NSIG; i++) {
+    if ( atomic_load_explicit(&caml_pending_signals[i], memory_order_acquire) == 0 )
+      continue;
+#ifdef POSIX_SIGNALS
+    if(sigismember(&set, i))
+      continue;
+#endif
+  again:
+    specific_signal_pending = atomic_load_explicit(&caml_pending_signals[i], memory_order_acquire);
+    if( specific_signal_pending > 0 ) {
+      if( !atomic_compare_exchange_strong(
+            &caml_pending_signals[i], 
+             &specific_signal_pending, specific_signal_pending - 1) ) {
+        /* We failed our CAS because another thread beat us to processing
+           this signal. Try again to see if there are more of this signal
+           to process. */
+        goto again;
       }
+
+      atomic_fetch_sub_explicit(&total_signals_pending, 1, memory_order_relaxed);
+
+      exn = caml_execute_signal_exn(i, 0);
+      if (Is_exception_result(exn)) return exn;
     }
   }
-  errno = saved_errno;
+  return Val_unit;
 }
 
 /* Record the delivery of a signal, and arrange for it to be processed
    as soon as possible:
-   - in bytecode: via caml_something_to_do, processed in caml_process_event
-   - in native-code: by playing with the allocation limit, processed
-       in caml_garbage_collection
+   - via total_signals_are_pending, processed in
+     caml_process_pending_signals_exn.
+   - by playing with the allocation limit, processed in
+     caml_garbage_collection
 */
 
+CAMLno_tsan
 CAMLexport void caml_record_signal(int signal_number)
 {
-  caml_pending_signals[signal_number] = 1;
-  caml_signals_are_pending = 1;
+  atomic_fetch_add_explicit(&caml_pending_signals[signal_number], 1, memory_order_relaxed);
+  atomic_fetch_add_explicit(&total_signals_pending, 1, memory_order_release);
   caml_interrupt_self();
 }
 
-int caml_init_signal_stack()
-{
-#ifdef POSIX_SIGNALS
-  stack_t stk;
-  stk.ss_flags = 0;
-  stk.ss_size = SIGSTKSZ;
-  stk.ss_sp = caml_stat_alloc_noexc(stk.ss_size);
-  if(stk.ss_sp == NULL) {
-    return -1;
-  }
-  if (sigaltstack(&stk, NULL) < 0) {
-    caml_stat_free(stk.ss_sp);
-    return -1;
-  }
+/* Management of blocking sections. */
 
-  /* gprof installs a signal handler for SIGPROF.
-     Make it run on the alternate signal stack, to prevent segfaults. */
-  {
-    struct sigaction act;
-    sigaction(SIGPROF, NULL, &act);
-    if ((act.sa_flags & SA_SIGINFO) ||
-        (act.sa_handler != SIG_IGN && act.sa_handler != SIG_DFL)) {
-      /* found a handler */
-      if ((act.sa_flags & SA_ONSTACK) == 0) {
-        act.sa_flags |= SA_ONSTACK;
-        sigaction(SIGPROF, &act, NULL);
-      }
-    }
-  }
-#endif
-  return 0;
+static void caml_enter_blocking_section_default(void)
+{
+  caml_bt_exit_ocaml();
+  caml_release_domain_lock();
 }
 
-void caml_free_signal_stack()
+static void caml_leave_blocking_section_default(void)
 {
-#ifdef POSIX_SIGNALS
-  stack_t stk, disable = {0};
-  disable.ss_flags = SS_DISABLE;
-  /* POSIX says ss_size is ignored when SS_DISABLE is set,
-     but OSX/Darwin fails if the size isn't set. */
-  disable.ss_size = SIGSTKSZ;
-  if (sigaltstack(&disable, &stk) < 0) {
-    caml_fatal_error_arg("Failed to reset signal stack: %s", strerror(errno));
-  }
-  caml_stat_free(stk.ss_sp);
-#endif
+  caml_bt_enter_ocaml();
+  caml_acquire_domain_lock();
 }
 
-/* Execute a signal handler immediately */
+CAMLexport void (*caml_enter_blocking_section_hook)(void) =
+   caml_enter_blocking_section_default;
+CAMLexport void (*caml_leave_blocking_section_hook)(void) =
+   caml_leave_blocking_section_default;
+
+CAMLexport void caml_enter_blocking_section(void)
+{
+  while (1){
+    /* Process all pending signals now */
+    caml_raise_if_exception(caml_process_pending_signals_exn());
+    caml_enter_blocking_section_hook ();
+    /* Check again for pending signals.
+       If none, done; otherwise, try again */
+    if ( atomic_load_explicit(&total_signals_pending, memory_order_relaxed) == 0 ) break;
+    caml_leave_blocking_section_hook ();
+  }
+}
+
+CAMLexport void caml_enter_blocking_section_no_pending(void)
+{
+  caml_enter_blocking_section_hook ();
+}
+
+CAMLexport void caml_leave_blocking_section(void)
+{
+  int saved_errno;
+  /* Save the value of errno (PR#5982). */
+  saved_errno = errno;
+  caml_leave_blocking_section_hook ();
+
+  errno = saved_errno;
+}
 
 static value caml_signal_handlers;
 
@@ -132,29 +175,63 @@ void caml_init_signal_handling() {
   caml_register_generational_global_root(&caml_signal_handlers);
 }
 
-static void caml_execute_signal(int signal_number)
+/* Execute a signal handler immediately */
+
+value caml_execute_signal_exn(int signal_number, int in_signal_handler)
 {
-  CAMLparam0 ();
-  CAMLlocal2 (res, handler);
+  value res;
+  value handler;
 #ifdef POSIX_SIGNALS
   sigset_t nsigs, sigs;
   /* Block the signal before executing the handler, and record in sigs
      the original signal mask */
   sigemptyset(&nsigs);
   sigaddset(&nsigs, signal_number);
-  sigprocmask(SIG_BLOCK, &nsigs, &sigs);
+  pthread_sigmask(SIG_BLOCK, &nsigs, &sigs);
 #endif
-  caml_read_field(caml_signal_handlers, signal_number, &handler);
-  res = caml_callback_exn(
-           handler,
-           Val_int(caml_rev_convert_signal_number(signal_number)));
+  handler = Field(caml_signal_handlers, signal_number);
+    res = caml_callback_exn(
+             handler,
+             Val_int(caml_rev_convert_signal_number(signal_number)));
 #ifdef POSIX_SIGNALS
-  /* Restore the original signal mask */
-  sigprocmask(SIG_SETMASK, &sigs, NULL);
+  if (! in_signal_handler) {
+    /* Restore the original signal mask */
+    pthread_sigmask(SIG_SETMASK, &sigs, NULL);
+  } else if (Is_exception_result(res)) {
+    /* Restore the original signal mask and unblock the signal itself */
+    sigdelset(&sigs, signal_number);
+    pthread_sigmask(SIG_SETMASK, &sigs, NULL);
+  }
 #endif
-  if (Is_exception_result(res)) caml_raise(Extract_exception(res));
-  CAMLreturn0;
+  return res;
 }
+
+/* Arrange for a garbage collection to be performed as soon as possible */
+
+void caml_request_major_slice (void)
+{
+  Caml_state->requested_major_slice = 1;
+  caml_interrupt_self();
+}
+
+void caml_request_minor_gc (void)
+{
+  Caml_state->requested_minor_gc = 1;
+  caml_interrupt_self();
+}
+
+CAMLextern value caml_process_pending_signals_with_root_exn(value extra_root)
+{
+  if (atomic_load_explicit(&total_signals_pending, memory_order_acquire) > 0) {
+    CAMLparam1(extra_root);
+    value exn = caml_process_pending_signals_exn();
+    if (Is_exception_result(exn))
+      CAMLreturn(exn);
+    CAMLdrop;
+  }
+  return extra_root;
+}
+
 
 /* OS-independent numbering of signals */
 
@@ -266,12 +343,60 @@ CAMLexport int caml_rev_convert_signal_number(int signo)
   return signo;
 }
 
+int caml_init_signal_stack()
+{
+#ifdef POSIX_SIGNALS
+  stack_t stk;
+  stk.ss_flags = 0;
+  stk.ss_size = SIGSTKSZ;
+  stk.ss_sp = caml_stat_alloc_noexc(stk.ss_size);
+  if(stk.ss_sp == NULL) {
+    return -1;
+  }
+  if (sigaltstack(&stk, NULL) < 0) {
+    caml_stat_free(stk.ss_sp);
+    return -1;
+  }
+
+  /* gprof installs a signal handler for SIGPROF.
+     Make it run on the alternate signal stack, to prevent segfaults. */
+  {
+    struct sigaction act;
+    sigaction(SIGPROF, NULL, &act);
+    if ((act.sa_flags & SA_SIGINFO) ||
+        (act.sa_handler != SIG_IGN && act.sa_handler != SIG_DFL)) {
+      /* found a handler */
+      if ((act.sa_flags & SA_ONSTACK) == 0) {
+        act.sa_flags |= SA_ONSTACK;
+        sigaction(SIGPROF, &act, NULL);
+      }
+    }
+  }
+#endif
+  return 0;
+}
+
+void caml_free_signal_stack()
+{
+#ifdef POSIX_SIGNALS
+  stack_t stk, disable = {0};
+  disable.ss_flags = SS_DISABLE;
+  /* POSIX says ss_size is ignored when SS_DISABLE is set,
+     but OSX/Darwin fails if the size isn't set. */
+  disable.ss_size = SIGSTKSZ;
+  if (sigaltstack(&disable, &stk) < 0) {
+    caml_fatal_error_arg("Failed to reset signal stack: %s", strerror(errno));
+  }
+  caml_stat_free(stk.ss_sp);
+#endif
+}
+
 /* Installation of a signal handler (as per [Sys.signal]) */
 
 CAMLprim value caml_install_signal_handler(value signal_number, value action)
 {
   CAMLparam2 (signal_number, action);
-  CAMLlocal2 (res, handler);
+  CAMLlocal2 (res, tmp_signal_handlers);
   int sig, act, oldact;
 
   sig = caml_convert_signal_number(Int_val(signal_number));
@@ -297,15 +422,28 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
     res = Val_int(1);
     break;
   case 2:                       /* was Signal_handle */
-    caml_read_field(caml_signal_handlers, sig, &handler);
-    res = caml_alloc_1 (0, handler);
+    res = caml_alloc_small (1, 0);
+    Field(res, 0) = Field(caml_signal_handlers, sig);
     break;
   default:                      /* error in caml_set_signal_action */
     caml_sys_error(NO_ARG);
   }
   if (Is_block(action)) {
+    /* Speculatively allocate this so we don't hold the lock for
+       a GC */
+    if (caml_signal_handlers == 0) {
+      tmp_signal_handlers = caml_alloc(NSIG, 0);
+    }
+    caml_plat_lock(&signal_install_mutex);
+    if (caml_signal_handlers == 0) {
+      /* caml_alloc cannot raise asynchronous exceptions from signals
+         so this is safe */
+      caml_signal_handlers = tmp_signal_handlers;
+      caml_register_global_root(&caml_signal_handlers);
+    }
     caml_modify(&Field(caml_signal_handlers, sig), Field(action, 0));
+    caml_plat_unlock(&signal_install_mutex);
   }
-  caml_process_pending_signals();
+  caml_raise_if_exception(caml_process_pending_signals_exn());
   CAMLreturn (res);
 }

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -57,14 +57,13 @@ static int check_for_pending_signals(void)
 CAMLexport value caml_process_pending_signals_exn(void)
 {
   int i;
-  intnat specific_signal_pending, total_signals_pending;
+  intnat specific_signal_pending;
   value exn;
 #ifdef POSIX_SIGNALS
   sigset_t set;
 #endif
 
-total_signals_pending = atomic_load_explicit(&total_signals_pending, memory_order_acquire);
-if( total_signals_pending == 0 )
+if( atomic_load_explicit(&total_signals_pending, memory_order_acquire) == 0 )
   return Val_unit;
 
 /* Check that there is indeed a pending signal before issuing the

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -113,7 +113,7 @@ void caml_garbage_collection()
   /* Re-do the allocation: we now have enough space in the minor heap. */
   Caml_state->young_ptr -= alloc_bsize;
 
-  caml_process_pending_signals();
+  caml_raise_if_exception(caml_process_pending_signals_exn());
 }
 
 DECLARE_SIGNAL_HANDLER(handle_signal)

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -67,5 +67,5 @@ tests/promotion/bigrecmod.ml
 tests/instrumented-runtime/'main.ml' with 1.1 (native)
 
 # disabled until the follow-up EINTR PR
-tests/lib-systhreads/'eintr.ml' with 1.1.2 (native) 
-tests/lib-systhreads/'eintr.ml' with 1.1.1 (bytecode) 
+tests/lib-systhreads/'eintr.ml' with 1.1.2 (native)
+tests/lib-systhreads/'eintr.ml' with 1.1.1 (bytecode)

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -65,3 +65,7 @@ tests/promotion/bigrecmod.ml
 
 # instrumented runtime test is not very useful (and broken on multicore.) (#9413)
 tests/instrumented-runtime/'main.ml' with 1.1 (native)
+
+# disabled until the follow-up EINTR PR
+tests/lib-systhreads/'eintr.ml' with 1.1.2 (native) 
+tests/lib-systhreads/'eintr.ml' with 1.1.1 (bytecode) 


### PR DESCRIPTION
This is the first of three PRs that overhaul Multicore's signals implementation to:

1. Take components that have diverged from trunk back to trunk with minimal changes (where trunk is ocaml/ocaml 4.12 branch)
2. Provide some clear semantics around how signals should work in the presence of multiple Domains and a correct implementation for that

The following PRs deal with asynchronous exceptions and changes to IO to make it safe in their presence.

---

**Behaviour of signals in the presence of multiple domains**

The intended behaviour for this PR is that:

1. Signal behaviour should behave no differently from trunk OCaml if there is only one domain
2. If there is more than one domain, any domain may execute the OCaml signal handler i.e there is no guarantee that the thread that receives a signal is the one that executes it

This is achieved by changing the existing flags implementation into one that uses atomic counters and a CAS when executing a signal to handle races. I would appreciate someone checking the memory orderings.

**Code motion**

There is a little code motion around signals/domains, which attempts to line things up as they are in 4.12 trunk.