### PR TITLE
Don't raise asynchronous exceptions from signals in caml_alloc C functions

### DIFF
--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -40,7 +40,7 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
   if (wosize == 0){
     result = Atom (tag);
   } else if (wosize <= Max_young_wosize) {
-    Alloc_small (result, wosize, tag, { caml_handle_gc_interrupt(); });
+    Alloc_small (result, wosize, tag, { caml_handle_gc_interrupt_no_async_exceptions(); });
     if (tag < No_scan_tag){
       for (i = 0; i < wosize; i++) {
         Field(result, i) = Val_unit;
@@ -63,7 +63,7 @@ Caml_inline void enter_gc_preserving_vals(mlsize_t wosize, value* vals)
      the fast path. */
   CAMLlocalN(vals_copy, wosize);
   for (i = 0; i < wosize; i++) vals_copy[i] = vals[i];
-  caml_handle_gc_interrupt();
+  caml_handle_gc_interrupt_no_async_exceptions();
   for (i = 0; i < wosize; i++) vals[i] = vals_copy[i];
   CAMLreturn0;
 }
@@ -241,7 +241,7 @@ value caml_alloc_float_array(mlsize_t len)
   if (wosize == 0) {
     return Atom(0);
   } else if (wosize <= Max_young_wosize) {
-    Alloc_small (result, wosize, Double_array_tag, { caml_handle_gc_interrupt(); });
+    Alloc_small (result, wosize, Double_array_tag, { caml_handle_gc_interrupt_no_async_exceptions(); });
   } else {
     result = caml_alloc_shr (wosize, Double_array_tag);
     result = caml_check_urgent_gc (result);

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -68,7 +68,7 @@ CAMLprim value caml_array_get_float(value array, value index)
   if (idx < 0 || idx >= Wosize_val(array) / Double_wosize)
     caml_array_bound_error();
   d = Double_flat_field(array, idx);
-  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt(); });
+  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt_no_async_exceptions(); });
   Store_double_val(res, d);
   return res;
 #else
@@ -101,7 +101,7 @@ CAMLprim value caml_floatarray_get(value array, value index)
   if (idx < 0 || idx >= Wosize_val(array) / Double_wosize)
     caml_array_bound_error();
   d = Double_flat_field(array, idx);
-  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt(); });
+  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt_no_async_exceptions(); });
   Store_double_val(res, d);
   return res;
 }
@@ -165,7 +165,7 @@ CAMLprim value caml_array_unsafe_get_float(value array, value index)
   value res;
 
   d = Double_flat_field(array, idx);
-  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt(); });
+  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt_no_async_exceptions(); });
   Store_double_val(res, d);
   return res;
 #else /* FLAT_FLOAT_ARRAY */
@@ -195,7 +195,7 @@ CAMLprim value caml_floatarray_unsafe_get(value array, value index)
 
   CAMLassert (Tag_val(array) == Double_array_tag);
   d = Double_flat_field(array, idx);
-  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt(); });
+  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt_no_async_exceptions(); });
   Store_double_val(res, d);
   return res;
 }
@@ -252,7 +252,7 @@ CAMLprim value caml_floatarray_create(value len)
     if (wosize == 0)
       return Atom(0);
     else
-      Alloc_small (result, wosize, Double_array_tag, { caml_handle_gc_interrupt(); });
+      Alloc_small (result, wosize, Double_array_tag, { caml_handle_gc_interrupt_no_async_exceptions(); });
   }else if (wosize > Max_wosize)
     caml_invalid_argument("Float.Array.create");
   else {

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -38,9 +38,10 @@ int caml_reallocate_minor_heap(asize_t);
 int caml_incoming_interrupts_queued(void);
 
 void caml_handle_gc_interrupt(void);
-
+void caml_handle_gc_interrupt_no_async_exceptions(void);
+int  caml_check_pending_actions();
 void caml_handle_incoming_interrupts(void);
-
+ 
 void caml_request_major_slice (void);
 
 void caml_request_minor_gc (void);

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -39,9 +39,8 @@ int caml_incoming_interrupts_queued(void);
 
 void caml_handle_gc_interrupt(void);
 void caml_handle_gc_interrupt_no_async_exceptions(void);
-int  caml_check_pending_actions();
 void caml_handle_incoming_interrupts(void);
- 
+
 void caml_request_major_slice (void);
 
 void caml_request_minor_gc (void);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1079,7 +1079,7 @@ void caml_handle_gc_interrupt()
 {
   handle_gc_interrupt();
 
-  caml_raise_if_exception(caml_process_pending_signals_exn());
+  caml_process_pending_signals();
 }
 
 CAMLexport int caml_bt_is_in_blocking_section(void)

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -149,7 +149,7 @@ CAMLexport value caml_copy_double(double d)
 {
   value res;
 
-  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt(); });
+  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt_no_async_exceptions(); });
   Store_double_val(res, d);
   return res;
 }

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -65,3 +65,7 @@ tests/promotion/bigrecmod.ml
 
 # instrumented runtime test is not very useful (and broken on multicore.) (#9413)
 tests/instrumented-runtime/'main.ml' with 1.1 (native)
+
+# disabled until the follow-up EINTR PR
+tests/lib-systhreads/'eintr.ml' with 1.1.2 (native)
+tests/lib-systhreads/'eintr.ml' with 1.1.1 (bytecode)


### PR DESCRIPTION
This PR avoids polling for pending signals from `caml_alloc_*` calls that originate from C. This prevents asynchronous exceptions that are raised from signal handlers.

This mirrors the work on trunk in https://github.com/ocaml/ocaml/pull/8691 though some of our allocation code has diverged and we don't have statmemprof currently - so we couldn't simply apply those changes.

It would be super useful if in review people could check that I've not missed any calls from C that could trigger a GC which is not done in a way that prevents asynchronous exceptions.

It's worth pointing out that this doesn't handle the asynchronous exceptions that are raised from finalisers.