### PR TITLE
Add some injectivity annotations to the standard library.

### DIFF
--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -27,7 +27,7 @@
     import additional compatibility layers. *)
 
 (** An atomic (mutable) reference to a value of type ['a]. *)
-type 'a t
+type !'a t
 
 (** Create an atomic reference. *)
 val make : 'a -> 'a t

--- a/stdlib/camlinternalAtomic.ml
+++ b/stdlib/camlinternalAtomic.ml
@@ -1,6 +1,6 @@
 (* CamlinternalAtomic is a dependency of Stdlib, so it is compiled with
    -nopervasives. *)
-type 'a t
+type !'a t
 
 (* Atomic is a dependency of Stdlib, so it is compiled with
    -nopervasives. *)

--- a/stdlib/camlinternalAtomic.mli
+++ b/stdlib/camlinternalAtomic.mli
@@ -19,7 +19,7 @@
    modules_before_stdlib used in stdlib/dune does not support the
    Stdlib__ prefix trick. *)
 
-type 'a t
+type !'a t
 val make : 'a -> 'a t
 val get : 'a t -> 'a
 val set : 'a t -> 'a -> unit


### PR DESCRIPTION
This backports https://github.com/ocaml/ocaml/commit/0aa72dd0340fb51dbd412a39440281e4cdde97fd from 4.12.0
This is required to compile stdcompat without any changes:
```
#=== ERROR while compiling stdcompat.16 =======================================#
# context              2.1.0 | linux/x86_64 | ocaml-variants.4.12.0+domains+channel_mutex | file:///home/opam/opam-repository
# path                 ~/.opam/4.12.0+domains+channel_mutex/.opam-switch/build/stdcompat.16
# command              ~/.opam/opam-init/hooks/sandbox.sh build make all
# exit-code            2
# env-file             ~/.opam/log/stdcompat-20-5b27e5.env
# output-file          ~/.opam/log/stdcompat-20-5b27e5.out
### output ###
# ocamlopt.opt -c  -bin-annot -no-alias-deps -nolabels -I . -alert -deprecated stdcompat__atomic_s.mli -o stdcompat__atomic_s.cmi
# File "stdcompat__atomic_s.mli", line 4, characters 0-24:
# 4 | type !'a t = 'a Atomic.t
#     ^^^^^^^^^^^^^^^^^^^^^^^^
# Error: In this definition, expected parameter variances are not satisfied.
#        The 1st type parameter was expected to be injective invariant,
#        but it is invariant.
# make[1]: *** [Makefile:1651: stdcompat__atomic_s.cmi] Error 2
# make[1]: Leaving directory '/home/opam/.opam/4.12.0+domains+channel_mutex/.opam-switch/build/stdcompat.16'
# make: *** [Makefile:836: all] Error 2
```