### PR TITLE
GitHub Actions for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,12 @@ jobs:
             os: windows-latest
             config_arg: --host=x86_64-w64-mingw32
     steps:
+      - name: Configure checkout for CRLF compatibility
+        # Most upsetting, but until 10111 is merged...
+        run: |
+          git config --system core.autocrlf false
+          git config --system core.eol lf
+        if: ${{ matrix.os == 'windows-latest' }}
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,26 +39,33 @@ jobs:
             env: OCAMLRUNPARAM=v=0,V=1 USE_RUNTIME=d
           - name: macos
             os: macos-latest
+          - name: windows
+            os: windows-latest
+            config_arg: --host=x86_64-w64-mingw32
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: dra27/setup-ocaml@multicore
+        if: ${{ matrix.os == 'windows-latest' }}
       - name: configure tree
         run: |
-          CONFIG_ARG=${{ matrix.config_arg }} MAKE_ARG=-j XARCH=x64 bash -xe tools/ci/actions/runner.sh configure
+          bash -c 'CONFIG_ARG=${{ matrix.config_arg }} MAKE_ARG=-j XARCH=x64 tools/ci/actions/runner.sh configure'
       - name: Build
         run: |
-          MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build
+          bash -c 'MAKE_ARG=-j tools/ci/actions/runner.sh build'
       - name: Run the testsuite
         if: ${{ matrix.name != 'linux-O0' }}
         run: |
-          bash -xe tools/ci/actions/runner.sh test
+          bash -c 'tools/ci/actions/runner.sh test'
       - name: Run the testsuite (linux-O0, parallel)
         if: ${{ matrix.name == 'linux-O0' }}
         env:
           OCAMLRUNPARAM: v=0,V=1
           USE_RUNTIME: d
         run: |
-          bash -xe tools/ci/actions/runner.sh test_multicore 1 "parallel" "lib-threads" "lib-systhreads"
+          bash -c 'tools/ci/actions/runner.sh test_multicore 1 parallel lib-threads lib-systhreads'
 
   testsuite:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run the testsuite
         if: ${{ matrix.name != 'linux-O0' }}
         run: |
-          bash -c 'tools/ci/actions/runner.sh test'
+          bash -c 'SHOW_TIMINGS=1 tools/ci/actions/runner.sh test'
       - name: Run the testsuite (linux-O0, parallel)
         if: ${{ matrix.name == 'linux-O0' }}
         env:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "flexdll"]
+    path = flexdll
+    url = https://github.com/alainfrisch/flexdll.git

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -48,3 +48,7 @@ BOOTSTRAPPING_FLEXDLL=@bootstrapping_flexdll@
 PACKAGE_TARNAME = @PACKAGE_TARNAME@
 datarootdir = @datarootdir@
 DOCDIR=@docdir@
+
+# Configuration for the C# compiler
+CSC=@csc@
+CSCFLAGS=@csc_flags@

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -538,8 +538,13 @@ let emit_instr env fallthrough i =
       end
   | Lop(Iextcall { func; alloc; stack_ofs }) ->
       add_used_symbol func;
-      if stack_ofs > 0 then begin
-        I.lea (mem64 QWORD 0 RSP) r13;
+      let base_stack_size =
+        if Arch.win64 then
+          32 (* Windows x64 rcx+rdx+r8+r9 shadow stack *)
+        else
+          0 in
+      if stack_ofs > base_stack_size then begin
+        I.lea (mem64 QWORD base_stack_size RSP) r13;
         I.lea (mem64 QWORD stack_ofs RSP) r12;
         load_symbol_addr func rax;
         emit_call "caml_c_call_stack_args";

--- a/configure
+++ b/configure
@@ -16630,6 +16630,7 @@ $as_echo "$as_me: the Win32/POSIX threads library is disabled" >&6;} ;; #(
   *-*-mingw32|*-pc-windows) :
     systhread_support=true
       otherlibraries="$otherlibraries systhreads"
+      PTHREAD_LIBS="-lpthread"
       { $as_echo "$as_me:${as_lineno-$LINENO}: the Win32 threads library is supported" >&5
 $as_echo "$as_me: the Win32 threads library is supported" >&6;} ;; #(
   *) :

--- a/configure
+++ b/configure
@@ -13453,6 +13453,14 @@ fi
 
 
 
+ac_fn_c_check_header_mongrel "$LINENO" "sys/mman.h" "ac_cv_header_sys_mman_h" "$ac_includes_default"
+if test "x$ac_cv_header_sys_mman_h" = xyes; then :
+  $as_echo "#define HAS_SYS_MMAN_H 1" >>confdefs.h
+
+fi
+
+
+
 # Checks for types
 
 ## off_t

--- a/configure
+++ b/configure
@@ -17804,8 +17804,8 @@ fi
 
 case $host in #(
   *-*-mingw32) :
-    bytecclibs="-lws2_32 -lversion -lpthread -lgcc_eh"
-    nativecclibs="-lws2_32 -lversion -lpthread -lgcc_eh" ;; #(
+    bytecclibs="-lws2_32 -lversion -lpthread -lgcc_eh -lDbgHelp"
+    nativecclibs="-lws2_32 -lversion -lpthread -lgcc_eh -lDbgHelp" ;; #(
   *-pc-windows) :
     bytecclibs="advapi32.lib ws2_32.lib version.lib"
     nativecclibs="advapi32.lib ws2_32.lib version.lib" ;; #(

--- a/configure
+++ b/configure
@@ -747,6 +747,8 @@ build_os
 build_vendor
 build_cpu
 build
+csc_flags
+csc
 force_instrumented_runtime
 naked_pointers_checker
 naked_pointers
@@ -2812,6 +2814,8 @@ instrumented_runtime=true
 force_instrumented_runtime=false
 instrumented_runtime_libs=""
 bootstrapping_flexdll=false
+csc=""
+csc_flags=""
 
 # Information about the package
 
@@ -2912,6 +2916,8 @@ VERSION=4.14.0+domains+dev0
 
 
  # TODO: rename this variable
+
+
 
 
 
@@ -14635,6 +14641,58 @@ $as_echo "$as_me: rlwrap doesn't work with native win32 - disabling" >&6;}
   *) :
      ;;
 esac
+
+# C# compiler (for the testsuite)
+# Extract the first word of "csc", so it can be a program name with args.
+set dummy csc; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_csc+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$csc"; then
+  ac_cv_prog_csc="$csc" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_csc="csc"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+csc=$ac_cv_prog_csc
+if test -n "$csc"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $csc" >&5
+$as_echo "$csc" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+if test -n "$csc"; then :
+  case $host in #(
+  *-*-cygwin*|*-*-mingw32|*-pc-windows) :
+    csc_flags='/nologo /nowarn:1668'
+    if ! $arch64; then :
+  csc_flags="$csc_flags /platform:x86"
+fi ;; #(
+  *) :
+    csc=''
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Mono is not yet supported - C sharp tests disabled" >&5
+$as_echo "$as_me: WARNING: Mono is not yet supported - C sharp tests disabled" >&2;} ;;
+esac
+fi
 
 # Checks for library functions
 

--- a/configure
+++ b/configure
@@ -12618,11 +12618,10 @@ case $ocaml_cv_cc_vendor in #(
     CPP="$CC -E -Qn" ;; #(
   # suppress generation of Sun PRO ident string
   msvc-*) :
-    CPP="$CC -nologo -EP";
-#  TODO: why can we not use $CPP in multicore, fix this?
-  CPP="$CC -E -P" ;; #(
+    CPP="$CC -nologo -EP" ;; #(
   *) :
-     ;;
+    #  TODO: why can we not use $CPP in multicore, fix this?
+  CPP="$CC -E -P" ;;
 esac
 
 # Libraries to build depending on the host

--- a/configure
+++ b/configure
@@ -17804,8 +17804,8 @@ fi
 
 case $host in #(
   *-*-mingw32) :
-    bytecclibs="-lws2_32 -lversion"
-    nativecclibs="-lws2_32 -lversion" ;; #(
+    bytecclibs="-lws2_32 -lversion -lpthread -lgcc_eh"
+    nativecclibs="-lws2_32 -lversion -lpthread -lgcc_eh" ;; #(
   *-pc-windows) :
     bytecclibs="advapi32.lib ws2_32.lib version.lib"
     nativecclibs="advapi32.lib ws2_32.lib version.lib" ;; #(

--- a/configure.ac
+++ b/configure.ac
@@ -515,7 +515,7 @@ AS_CASE([$ocaml_cv_cc_vendor],
   [sunc-*],
     [CPP="$CC -E -Qn"], # suppress generation of Sun PRO ident string
   [msvc-*],
-    [CPP="$CC -nologo -EP"];
+    [CPP="$CC -nologo -EP"],
 #  TODO: why can we not use $CPP in multicore, fix this?
   [CPP="$CC -E -P"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1959,8 +1959,8 @@ AC_CHECK_LIB(execinfo, backtrace, cclibs="$cclibs -lexecinfo",[])
 
 AS_CASE([$host],
   [*-*-mingw32],
-    [bytecclibs="-lws2_32 -lversion"
-    nativecclibs="-lws2_32 -lversion"],
+    [bytecclibs="-lws2_32 -lversion -lpthread -lgcc_eh"
+    nativecclibs="-lws2_32 -lversion -lpthread -lgcc_eh"],
   [*-pc-windows],
     [bytecclibs="advapi32.lib ws2_32.lib version.lib"
     nativecclibs="advapi32.lib ws2_32.lib version.lib"],

--- a/configure.ac
+++ b/configure.ac
@@ -1792,6 +1792,7 @@ AS_CASE([$enable_systhreads,$enable_unix_lib],
     [*-*-mingw32|*-pc-windows],
       [systhread_support=true
       otherlibraries="$otherlibraries systhreads"
+      PTHREAD_LIBS="-lpthread"
       AC_MSG_NOTICE([the Win32 threads library is supported])],
     [AX_PTHREAD(
       [systhread_support=true

--- a/configure.ac
+++ b/configure.ac
@@ -1959,8 +1959,8 @@ AC_CHECK_LIB(execinfo, backtrace, cclibs="$cclibs -lexecinfo",[])
 
 AS_CASE([$host],
   [*-*-mingw32],
-    [bytecclibs="-lws2_32 -lversion -lpthread -lgcc_eh"
-    nativecclibs="-lws2_32 -lversion -lpthread -lgcc_eh"],
+    [bytecclibs="-lws2_32 -lversion -lpthread -lgcc_eh -lDbgHelp"
+    nativecclibs="-lws2_32 -lversion -lpthread -lgcc_eh -lDbgHelp"],
   [*-pc-windows],
     [bytecclibs="advapi32.lib ws2_32.lib version.lib"
     nativecclibs="advapi32.lib ws2_32.lib version.lib"],

--- a/configure.ac
+++ b/configure.ac
@@ -865,6 +865,8 @@ AC_CHECK_HEADER([sys/select.h], [AC_DEFINE([HAS_SYS_SELECT_H])], [],
 
 AC_CHECK_HEADER([stdatomic.h], [AC_DEFINE([HAS_STDATOMIC_H])])
 
+AC_CHECK_HEADER([sys/mman.h], [AC_DEFINE([HAS_SYS_MMAN_H])])
+
 # Checks for types
 
 ## off_t

--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,8 @@ instrumented_runtime=true
 force_instrumented_runtime=false
 instrumented_runtime_libs=""
 bootstrapping_flexdll=false
+csc=""
+csc_flags=""
 
 # Information about the package
 
@@ -172,6 +174,8 @@ AC_SUBST([compute_deps])
 AC_SUBST([naked_pointers])
 AC_SUBST([naked_pointers_checker])
 AC_SUBST([force_instrumented_runtime])
+AC_SUBST([csc])
+AC_SUBST([csc_flags])
 
 ## Generated files
 
@@ -1243,6 +1247,15 @@ AS_CASE([$rlwrap,$system],
   [rlwrap,win*|rlwrap,mingw*],
     [AC_MSG_NOTICE([rlwrap doesn't work with native win32 - disabling])
      rlwrap=''])
+
+# C# compiler (for the testsuite)
+AC_CHECK_PROG([csc],[csc],[csc])
+AS_IF([test -n "$csc"],
+  [AS_CASE([$host],[*-*-cygwin*|*-*-mingw32|*-pc-windows],
+    [csc_flags='/nologo /nowarn:1668'
+    AS_IF([! $arch64],[csc_flags="$csc_flags /platform:x86"])],
+    [csc=''
+    AC_MSG_WARN([Mono is not yet supported - C sharp tests disabled])])])
 
 # Checks for library functions
 

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -52,17 +52,8 @@ endif
 
 ifeq "$(UNIX_OR_WIN32)" "win32"
   ocamlsrcdir := $(shell echo "$(abspath $(shell pwd)/..)" | cygpath -w -f -)
-  CSC := csc
-  ifeq "$(HOST:i686-%=i686)" "i686"
-    CSCFLAGS := /platform:x86
-  else
-    CSCFLAGS :=
-  endif
-  CSCFLAGS += /nologo /nowarn:1668
 else
   ocamlsrcdir := $(abspath $(shell pwd)/..)
-  CSC :=
-  CSCFLAGS :=
 endif
 mkexe := $(MKEXE)
 

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -67,24 +67,27 @@ let tsl_block_of_file_safe test_filename =
 let print_usage () =
   Printf.printf "%s\n%!" Options.usage
 
-type result_summary = No_failure | Some_failure
+type result_summary = No_failure | Some_failure | All_skipped
+let join_result summary result =
+  let open Result in
+  match result.status, summary with
+  | Fail, _
+  | _, Some_failure -> Some_failure
+  | Skip, All_skipped -> All_skipped
+  | _ -> No_failure
+
 let join_summaries sa sb =
   match sa, sb with
-  | Some_failure, _ | _, Some_failure -> Some_failure
-  | No_failure, No_failure -> No_failure
-
-let summary_of_result res =
-  let open Result in
-  match res.status with
-  | Pass -> No_failure
-  | Skip -> No_failure
-  | Fail -> Some_failure
+  | Some_failure, _
+  | _, Some_failure -> Some_failure
+  | All_skipped, All_skipped -> All_skipped
+  | _ -> No_failure
 
 let rec run_test log common_prefix path behavior = function
   Node (testenvspec, test, env_modifiers, subtrees) ->
   Printf.printf "%s %s (%s) => %!" common_prefix path test.Tests.test_name;
-  let (msg, children_behavior, summary) = match behavior with
-    | Skip_all_tests -> "n/a", Skip_all_tests, No_failure
+  let (msg, children_behavior, result) = match behavior with
+    | Skip_all_tests -> "n/a", Skip_all_tests, Result.skip
     | Run env ->
       let testenv0 = interpret_environment_statements env testenvspec in
       let testenv = List.fold_left apply_modifiers testenv0 env_modifiers in
@@ -92,14 +95,13 @@ let rec run_test log common_prefix path behavior = function
       let msg = Result.string_of_result result in
       let children_behavior =
         if Result.is_pass result then Run newenv else Skip_all_tests in
-      let summary = summary_of_result result in
-      (msg, children_behavior, summary) in
+      (msg, children_behavior, result) in
   Printf.printf "%s\n%!" msg;
-  join_summaries summary
-    (run_test_trees log common_prefix path children_behavior subtrees)
+  join_result
+    (run_test_trees log common_prefix path children_behavior subtrees) result
 
 and run_test_trees log common_prefix path behavior trees =
-  List.fold_left join_summaries No_failure
+  List.fold_left join_summaries All_skipped
     (List.mapi (run_test_i log common_prefix path behavior) trees)
 
 and run_test_i log common_prefix path behavior i test_tree =
@@ -127,6 +129,7 @@ let init_tests_to_skip () =
   tests_to_skip := String.words (Sys.safe_getenv "OCAMLTEST_SKIP_TESTS")
 
 let test_file test_filename =
+  let start = Unix.gettimeofday () in
   let skip_test = List.mem test_filename !tests_to_skip in
   let tsl_block = tsl_block_of_file_safe test_filename in
   let (rootenv_statements, test_trees) = test_trees_of_tsl_block tsl_block in
@@ -209,10 +212,14 @@ let test_file test_filename =
   | Some_failure ->
       if not Options.log_to_stderr then
         Sys.dump_file stderr ~prefix:"> " log_filename
-  | No_failure ->
+  | No_failure | All_skipped ->
       if not Options.keep_test_dir_on_success then
         clean_test_build_directory ()
-  end
+  end;
+  if Options.show_timings && summary = No_failure then
+    let wall_clock_duration = Unix.gettimeofday () -. start in
+    Printf.eprintf "Wall clock: %s took %.02fs\n%!"
+                   test_filename wall_clock_duration
 
 let is_test s =
   match tsl_block_of_file s with

--- a/ocamltest/ocaml_compilers.ml
+++ b/ocamltest/ocaml_compilers.ml
@@ -40,12 +40,12 @@ class compiler
   method target = target
 
   method program_variable =
-    if Ocaml_backends.is_native host
+    if Ocaml_backends.is_native host && not Sys.win32
     then Builtin_variables.program2
     else Builtin_variables.program
 
   method program_output_variable =
-    if Ocaml_backends.is_native host
+    if Ocaml_backends.is_native host && not Sys.win32
     then None
     else Some Builtin_variables.output
 

--- a/ocamltest/ocamltest_unix.mli
+++ b/ocamltest/ocamltest_unix.mli
@@ -18,3 +18,4 @@
 val has_symlink : unit -> bool
 val symlink : ?to_dir:bool -> string -> string -> unit
 val chmod : string -> int -> unit
+val gettimeofday : unit -> float

--- a/ocamltest/ocamltest_unix_dummy.ml
+++ b/ocamltest/ocamltest_unix_dummy.ml
@@ -16,3 +16,4 @@
 let has_symlink () = false
 let symlink ?to_dir:_ _ _ = invalid_arg "symlink not available"
 let chmod _ _ = invalid_arg "chmod not available"
+let gettimeofday () = invalid_arg "gettimeofday not available"

--- a/ocamltest/ocamltest_unix_real.ml
+++ b/ocamltest/ocamltest_unix_real.ml
@@ -12,8 +12,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Unix.has_symlink never raises *)
+(* Unix.gettimeofday and Unix.has_symlink never raise *)
 let has_symlink = Unix.has_symlink
+let gettimeofday = Unix.gettimeofday
 
 (* Convert Unix_error to Sys_error *)
 let wrap f x =

--- a/ocamltest/options.ml
+++ b/ocamltest/options.ml
@@ -57,6 +57,8 @@ let find_test_dirs = ref []
 
 let list_tests = ref []
 
+let show_timings = ref false
+
 let add_to_list r x =
   r := !r @ [x]
 
@@ -68,6 +70,8 @@ let commandline_options =
   ("-show-actions", Arg.Unit show_actions, " Show available actions.");
   ("-show-tests", Arg.Unit show_tests, " Show available tests.");
   ("-show-variables", Arg.Unit show_variables, " Show available variables.");
+  ("-show-timings", Arg.Set show_timings,
+   " Show the wall clock time taken for each test file.");
   ("-timeout",
      Arg.Int (fun t -> if t >= 0
                        then default_timeout := t
@@ -95,3 +99,4 @@ let default_timeout = !default_timeout
 let find_test_dirs = !find_test_dirs
 let list_tests = !list_tests
 let keep_test_dir_on_success = !keep_test_dir_on_success
+let show_timings = !show_timings

--- a/ocamltest/options.mli
+++ b/ocamltest/options.mli
@@ -30,3 +30,5 @@ val find_test_dirs : string list
 val list_tests : string list
 
 val keep_test_dir_on_success : bool
+
+val show_timings : bool

--- a/otherlibs/str/Makefile
+++ b/otherlibs/str/Makefile
@@ -24,6 +24,8 @@ include ../Makefile.otherlibs.common
 str.cmo: str.cmi
 str.cmx: str.cmi
 
+LDOPTS = $(PTHREAD_LINK)
+
 .PHONY: depend
 depend:
 	$(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml > .depend

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -79,7 +79,11 @@ CAMLnoreturn_end;
 
 static void st_thread_exit(void)
 {
+#ifdef _WIN32
+  ExitThread(0);
+#else
   pthread_exit(NULL);
+#endif
 }
 
 static void st_thread_join(st_thread_id thr)
@@ -309,11 +313,13 @@ static void * caml_thread_tick(void * arg)
   caml_domain_state *domain;
   uintnat *domain_id = (uintnat *) arg;
   struct timeval timeout;
+#ifndef _WIN32
   sigset_t mask;
 
   /* Block all signals so that we don't try to execute an OCaml signal handler*/
   sigfillset(&mask);
   pthread_sigmask(SIG_BLOCK, &mask, NULL);
+#endif
 
   caml_init_domain_self(*domain_id);
   domain = Caml_state;
@@ -351,6 +357,7 @@ static int st_atfork(void (*fn)(void))
 
 /* Signal handling */
 
+#ifndef _WIN32
 static void st_decode_sigset(value vset, sigset_t * set)
 {
   sigemptyset(set);
@@ -383,9 +390,11 @@ static value st_encode_sigset(sigset_t * set)
 }
 
 static int sigmask_cmd[3] = { SIG_SETMASK, SIG_BLOCK, SIG_UNBLOCK };
+#endif
 
 value caml_thread_sigmask(value cmd, value sigs) /* ML */
 {
+#ifndef _WIN32
   int how;
   sigset_t set, oldset;
   int retcode;
@@ -399,6 +408,10 @@ value caml_thread_sigmask(value cmd, value sigs) /* ML */
   /* Run any handlers for just-unmasked pending signals */
   caml_raise_if_exception(caml_process_pending_signals_exn());
   return st_encode_sigset(&oldset);
+#else
+  caml_invalid_argument("Thread.sigmask not implemented");
+  return Val_int(0);            /* not reached */
+#endif
 }
 
 value caml_wait_signal(value sigs) /* ML */

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -4,7 +4,7 @@
 /*                                                                        */
 /*          Xavier Leroy and Damien Doligez, INRIA Rocquencourt           */
 /*                                                                        */
-/*   Copyright 1996 Institut National de Recherche en Informatique et     */
+/*   Copyright 2009 Institut National de Recherche en Informatique et     */
 /*     en Automatique.                                                    */
 /*                                                                        */
 /*   All rights reserved.  This file is distributed under the terms of    */
@@ -13,24 +13,11 @@
 /*                                                                        */
 /**************************************************************************/
 
-#ifndef CAML_ROOTS_H
-#define CAML_ROOTS_H
+/* Win32 implementation of the "st" interface */
 
-#ifdef CAML_INTERNALS
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0400
+#include <windows.h>
 
-#include "misc.h"
-#include "memory.h"
-
-typedef void (*scanning_action) (void*, value, value *);
-CAMLextern void (*caml_scan_roots_hook)(scanning_action, void*, caml_domain_state*);
-
-CAMLextern void caml_do_roots (scanning_action f, void* data, caml_domain_state* d,
-                               int do_final_val);
-CAMLextern void caml_do_local_roots(scanning_action f, void* data,
-                                    struct caml__roots_block* local_roots,
-                                    struct stack_info *current_stack,
-                                    value * v_gc_regs);
-
-#endif /* CAML_INTERNALS */
-
-#endif /* CAML_ROOTS_H */
+/* FIXME Replace winpthreads implementation with native */
+#include "st_posix.h"

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -98,9 +98,9 @@ libcamlrunpic_OBJECTS := $(BYTECODE_C_SOURCES:.c=.bpic.$(O))
 
 libasmrun_OBJECTS := $(NATIVE_C_SOURCES:.c=.n.$(O)) $(ASM_OBJECTS)
 
-libasmrund_OBJECTS := $(NATIVE_C_SOURCES:.c=.nd.$(O)) $(ASM_OBJECTS)
+libasmrund_OBJECTS := $(NATIVE_C_SOURCES:.c=.nd.$(O)) $(ASM_OBJECTS:.$(O)=.d.$(O))
 
-libasmruni_OBJECTS := $(NATIVE_C_SOURCES:.c=.ni.$(O)) $(ASM_OBJECTS)
+libasmruni_OBJECTS := $(NATIVE_C_SOURCES:.c=.ni.$(O)) $(ASM_OBJECTS:.$(O)=.i.$(O))
 
 libasmrunpic_OBJECTS := $(NATIVE_C_SOURCES:.c=.npic.$(O)) \
   $(ASM_OBJECTS:.$(O)=_libasmrunpic.$(O))
@@ -392,12 +392,19 @@ $(foreach object_type,$(subst %,,$(object_types)), \
 
 # Compilation of assembly files
 
-%.o: %.S
-	$(ASPP) $(ASPPFLAGS) -o $@ $< || \
+ASPP_ERROR = \
 	{ echo "If your assembler produced syntax errors, it is probably";\
           echo "unhappy with the preprocessor. Check your assembler, or";\
           echo "try producing $*.o by hand.";\
           exit 2; }
+%.o: %.S
+	$(ASPP) $(ASPPFLAGS) -o $@ $< || $(ASPP_ERROR)
+
+%.d.o: %.S
+	$(ASPP) $(ASPPFLAGS) $(OC_DEBUG_CPPFLAGS) -o $@ $< || $(ASPP_ERROR)
+
+%.i.o: %.S
+	$(ASPP) $(ASPPFLAGS) $(OC_INSTR_CPPFLAGS) -o $@ $< || $(ASPP_ERROR)
 
 %_libasmrunpic.o: %.S
 	$(ASPP) $(ASPPFLAGS) $(SHAREDLIB_CFLAGS) -o $@ $<
@@ -413,6 +420,18 @@ amd64nt.obj: amd64nt.asm domain_state64.inc
 
 i386nt.obj: i386nt.asm domain_state32.inc
 	$(ASM)$@ $(ASMFLAGS) $<
+
+amd64nt.d.obj: amd64nt.asm domain_state64.inc
+	$(ASM)$@ $(ASMFLAGS) $(OC_DEBUG_CPPFLAGS) $<
+
+i386nt.d.obj: i386nt.asm domain_state32.inc
+	$(ASM)$@ $(ASMFLAGS) $(OC_DEBUG_CPPFLAGS) $<
+
+amd64nt.i.obj: amd64nt.asm domain_state64.inc
+	$(ASM)$@ $(ASMFLAGS) $(OC_INSTR_CPPFLAGS) $<
+
+i386nt.i.obj: i386nt.asm domain_state32.inc
+	$(ASM)$@ $(ASMFLAGS) $(OC_INSTR_CPPFLAGS) $<
 
 %_libasmrunpic.obj: %.asm
 	$(ASM)$@ $(ASMFLAGS) $<

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -230,7 +230,7 @@
         pushq   %r13; CFI_ADJUST (8); CFI_OFFSET(r13, -56); \
         pushq   %r14; CFI_ADJUST (8); CFI_OFFSET(r14, -64); \
         pushq   %r15; CFI_ADJUST (8); CFI_OFFSET(r15, -72); \
-        subq    $(8+10*16), %rsp; CFI_ADJUST (8+10*16);     \
+        subq    $(10*16), %rsp; CFI_ADJUST (10*16);         \
         movupd  %xmm6, 0*16(%rsp);                          \
         movupd  %xmm7, 1*16(%rsp);                          \
         movupd  %xmm8, 2*16(%rsp);                          \
@@ -253,7 +253,7 @@
         movupd  7*16(%rsp), %xmm13;                         \
         movupd  8*16(%rsp), %xmm14;                         \
         movupd  9*16(%rsp), %xmm15;                         \
-        addq    $(8+10*16), %rsp; CFI_ADJUST (-8-10*16);    \
+        addq    $(10*16), %rsp; CFI_ADJUST (-10*16);        \
         popq    %r15; CFI_ADJUST(-8); CFI_SAME_VALUE(r15);  \
         popq    %r14; CFI_ADJUST(-8); CFI_SAME_VALUE(r14);  \
         popq    %r13; CFI_ADJUST(-8); CFI_SAME_VALUE(r13);  \

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -924,7 +924,7 @@ CFI_STARTPROC
 LBL(frame_runstack):
         leaq    32(%rsp), %r11 /* SP with exn handler popped */
         movq    Handler_value(%r11), %rbx
-1:      movq    Caml_state(current_stack), %rdi /* arg to caml_free_stack */
+1:      movq    Caml_state(current_stack), C_ARG_1 /* arg to caml_free_stack */
     /* restore parent stack and exn_handler into Caml_state */
         movq    Handler_parent(%r11), %r10
         movq    Stack_exception(%r10), %r11
@@ -937,7 +937,7 @@ LBL(frame_runstack):
         CFI_DEF_CFA_REGISTER(DW_REG_r13)
         movq    %rax, %r12 /* save %rax across C call */
         movq    Caml_state(c_stack), %rsp
-        call    GCALL(caml_free_stack)
+        C_call  (GCALL(caml_free_stack))
     /* switch directly to parent stack with correct return */
         movq    %r13, %rsp
         CFI_RESTORE_STATE

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -42,15 +42,15 @@ void caml_handle_gc_interrupt(void);
 void caml_handle_gc_interrupt_no_async_exceptions(void);
 void caml_handle_incoming_interrupts(void);
 
-void caml_interrupt_self(void);
+CAMLextern void caml_interrupt_self(void);
 
-CAMLexport void caml_reset_domain_lock(void);
-CAMLexport int caml_bt_is_in_blocking_section(void);
-CAMLexport intnat caml_domain_is_multicore (void);
-CAMLexport void caml_bt_enter_ocaml(void);
-CAMLexport void caml_bt_exit_ocaml(void);
-CAMLexport void caml_acquire_domain_lock(void);
-CAMLexport void caml_release_domain_lock(void);
+CAMLextern void caml_reset_domain_lock(void);
+CAMLextern int caml_bt_is_in_blocking_section(void);
+CAMLextern intnat caml_domain_is_multicore (void);
+CAMLextern void caml_bt_enter_ocaml(void);
+CAMLextern void caml_bt_exit_ocaml(void);
+CAMLextern void caml_acquire_domain_lock(void);
+CAMLextern void caml_release_domain_lock(void);
 
 CAMLextern void (*caml_atfork_hook)(void);
 
@@ -58,8 +58,8 @@ CAMLextern void (*caml_domain_start_hook)(void);
 CAMLextern void (*caml_domain_stop_hook)(void);
 CAMLextern void (*caml_domain_external_interrupt_hook)(void);
 
-void caml_init_domains(uintnat minor_heap_size);
-void caml_init_domain_self(int);
+CAMLextern void caml_init_domains(uintnat minor_heap_size);
+CAMLextern void caml_init_domain_self(int);
 
 CAMLextern atomic_uintnat caml_num_domains_running;
 CAMLextern uintnat caml_minor_heaps_base;

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -108,7 +108,7 @@ extern value caml_global_data;
 #define Trap_link(tp) ((tp)[1])
 
 struct stack_info** caml_alloc_stack_cache (void);
-struct stack_info* caml_alloc_main_stack (uintnat init_size);
+CAMLextern struct stack_info* caml_alloc_main_stack (uintnat init_size);
 void caml_scan_stack(scanning_action f, void* fdata,
                      struct stack_info* stack, value* v_gc_regs);
 /* try to grow the stack until at least required_size words are available.
@@ -116,7 +116,7 @@ void caml_scan_stack(scanning_action f, void* fdata,
 int caml_try_realloc_stack (asize_t required_size);
 void caml_change_max_stack_size (uintnat new_max_size);
 void caml_maybe_expand_stack();
-void caml_free_stack(struct stack_info* stk);
+CAMLextern void caml_free_stack(struct stack_info* stk);
 
 #ifdef NATIVE_CODE
 void caml_get_stack_sp_pc (struct stack_info* stack,

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -446,7 +446,7 @@ int caml_runtime_warnings_active(void);
                       | ((uintnat) (x) << 16) \
                       | ((uintnat) (x) << 48))
 #define Is_debug_tag(x) \
-  (((x) & 0xff00ffffff00fffful) == 0xD700D7D7D700D6D7ul)
+  (((x) & INT64_LITERAL(0xff00ffffff00ffffu)) == INT64_LITERAL(0xD700D7D7D700D6D7u))
 #else
 #define Debug_tag(x) (0xD700D6D7ul | ((uintnat) (x) << 16))
 #define Is_debug_tag(x) \

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -148,6 +148,10 @@ extern int64_t caml_time_counter(void);
 
 extern void caml_init_os_params(void);
 
+#if defined(DEBUG) || defined(NATIVE_CODE)
+extern void caml_print_trace(void);
+#endif
+
 #endif /* CAML_INTERNALS */
 
 #ifdef _WIN32

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -146,6 +146,8 @@ CAMLextern clock_t caml_win32_clock(void);
    resolution may be less. The starting point is unspecified. */
 extern int64_t caml_time_counter(void);
 
+extern void caml_init_os_params(void);
+
 #endif /* CAML_INTERNALS */
 
 #ifdef _WIN32

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -161,5 +161,8 @@ Caml_inline void caml_plat_unlock(caml_plat_mutex* m)
   check_err("unlock", pthread_mutex_unlock(m));
 }
 
+/* On Windows, the SYSTEM_INFO.dwPageSize is a DWORD (32-bit), but conveniently
+   long is also 32-bit */
+extern long caml_sys_pagesize;
 
 #endif /* CAML_PLATFORM_H */

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -72,6 +72,8 @@
 
 #undef HAS_STDATOMIC_H
 
+#undef HAS_SYS_MMAN_H
+
 /* 2. For the Unix library. */
 
 #undef HAS_SOCKETS

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -25,13 +25,13 @@ extern void caml_free_locale(void);
 
 /* readonly after startup */
 struct caml_params {
-  const char* exe_name;
+  const char_os* exe_name;
 
   /* for meta.c */
   const char* section_table;
   asize_t section_table_size;
 
-  const char* cds_file;
+  const char_os* cds_file;
 
   uintnat verb_gc;
   uintnat parser_trace;
@@ -69,7 +69,7 @@ extern void caml_command_error(char *msg, ...);
    If [pooling] is 0, [caml_stat_*] functions will not be backed by a pool. */
 extern int caml_startup_aux (int pooling);
 
-void caml_init_exe_name(const char* exe_name);
+void caml_init_exe_name(const char_os* exe_name);
 void caml_init_section_table(const char* section_table,
                              asize_t section_table_size);
 

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -50,7 +50,8 @@ void caml_change_max_stack_size (uintnat new_max_size)
 
   if (new_max_size < size) new_max_size = size;
   if (new_max_size != caml_max_stack_size){
-    caml_gc_log ("Changing stack limit to %luk bytes",
+    caml_gc_log ("Changing stack limit to %"
+                 ARCH_INTNAT_PRINTF_FORMAT "uk bytes",
                      new_max_size * sizeof (value) / 1024);
   }
   caml_max_stack_size = new_max_size;
@@ -156,7 +157,8 @@ value caml_alloc_stack (value hval, value hexn, value heff) {
 
   if (!stack) caml_raise_out_of_memory();
 
-  fiber_debug_log ("Allocate stack=%p of %lu words", stack, caml_fiber_wsz);
+  fiber_debug_log ("Allocate stack=%p of %" ARCH_INTNAT_PRINTF_FORMAT
+                     "u words", stack, caml_fiber_wsz);
 
   return Val_ptr(stack);
 }

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -289,7 +289,8 @@ void caml_init_gc ()
   caml_max_stack_size = caml_params->init_max_stack_wsz;
   caml_fiber_wsz = caml_params->init_fiber_wsz;
   caml_percent_free = norm_pfree (caml_params->init_percent_free);
-  caml_gc_log ("Initial stack limit: %luk bytes",
+  caml_gc_log ("Initial stack limit: %"
+               ARCH_INTNAT_PRINTF_FORMAT "uk bytes",
                caml_max_stack_size / 1024 * sizeof (value));
 
   caml_custom_major_ratio =

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -330,7 +330,8 @@ value caml_interprete(code_t prog, asize_t prog_size)
 #ifdef DEBUG
     caml_bcodcount++;
     if (caml_icount-- == 0) caml_stop_here ();
-    if (caml_params->trace_level>1) printf("\n##%ld\n", caml_bcodcount);
+    if (caml_params->trace_level>1)
+      printf("\n##%" ARCH_INTNAT_PRINTF_FORMAT "d\n", caml_bcodcount);
     if (caml_params->trace_level) caml_disasm_instr(pc);
     if (caml_params->trace_level>1) {
       printf("env=");

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -593,7 +593,8 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
   oldify_mopup (&st, 1); /* ephemerons promoted here */
   CAML_EV_END(EV_MINOR_REMEMBERED_SET_PROMOTE);
   CAML_EV_END(EV_MINOR_REMEMBERED_SET);
-  caml_gc_log("promoted %d roots, %lu bytes", remembered_roots, st.live_bytes);
+  caml_gc_log("promoted %d roots, %" ARCH_INTNAT_PRINTF_FORMAT "u bytes",
+              remembered_roots, st.live_bytes);
 
   CAML_EV_BEGIN(EV_MINOR_FINALIZERS_ADMIN);
   caml_gc_log("running finalizer data structure book-keeping");

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -29,9 +29,6 @@ __declspec(noreturn) void __cdecl abort(void);
 #include <string.h>
 #include <stdarg.h>
 #include <stdlib.h>
-#if defined(DEBUG) || defined(NATIVE_CODE)
-#include <execinfo.h>
-#endif
 #include "caml/config.h"
 #include "caml/misc.h"
 #include "caml/memory.h"
@@ -48,32 +45,13 @@ caml_timing_hook caml_finalise_begin_hook = NULL;
 caml_timing_hook caml_finalise_end_hook = NULL;
 
 #if defined(DEBUG) || defined(NATIVE_CODE)
-
-void print_trace (void)
-{
-  void *array[10];
-  size_t size;
-  char **strings;
-  size_t i;
-
-  size = backtrace (array, 10);
-  strings = backtrace_symbols (array, size);
-
-  caml_gc_log ("Obtained %zd stack frames.", size);
-
-  for (i = 0; i < size; i++)
-    caml_gc_log ("%s", strings[i]);
-
-  free (strings);
-}
-
-void caml_failed_assert (char * expr, char_os * file_os, int line)
+void caml_failed_assert(char * expr, char_os * file_os, int line)
 {
   char* file = caml_stat_strdup_of_os(file_os);
-  fprintf (stderr, "[%02d] file %s; line %d ### Assertion failed: %s\n",
-           Caml_state ? Caml_state->id : -1, file, line, expr);
-  print_trace ();
-  fflush (stderr);
+  fprintf(stderr, "[%02d] file %s; line %d ### Assertion failed: %s\n",
+          Caml_state ? Caml_state->id : -1, file, line, expr);
+  caml_print_trace();
+  fflush(stderr);
   caml_stat_free(file);
   abort();
 }

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -1,12 +1,17 @@
 #define CAML_INTERNALS
 
-#include <sys/mman.h>
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
 #include <sys/time.h>
 #include "caml/platform.h"
 #include "caml/fail.h"
+#ifdef HAS_SYS_MMAN_H
+#include <sys/mman.h>
+#endif
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 /* Mutexes */
 
@@ -132,6 +137,10 @@ uintnat caml_mem_round_up_pages(uintnat size)
   return round_up(size, caml_sys_pagesize);
 }
 
+#ifdef _WIN32
+#define MAP_FAILED 0
+#endif
+
 void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only)
 {
   uintnat alloc_sz = caml_mem_round_up_pages(size + alignment);
@@ -142,8 +151,14 @@ void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only)
   alignment = caml_mem_round_up_pages(alignment);
 
   Assert (alloc_sz > size);
+#ifdef _WIN32
+  /* Memory is only reserved at this point. It'll be committed after the
+     trim. */
+  mem = VirtualAlloc(NULL, alloc_sz, MEM_RESERVE, PAGE_NOACCESS);
+#else
   mem = mmap(0, alloc_sz, reserve_only ? PROT_NONE : (PROT_READ | PROT_WRITE),
              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+#endif
   if (mem == MAP_FAILED) {
     return 0;
   }
@@ -152,10 +167,28 @@ void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only)
   base = (uintnat)mem;
   aligned_start = round_up(base, alignment);
   aligned_end = aligned_start + caml_mem_round_up_pages(size);
+#ifdef _WIN32
+  /* VirtualFree can be used to decommit portions of memory, but it can only
+     release the entire block of memory. For Windows, repeat the call but this
+     time specify the address. */
+  if (!VirtualFree(mem, 0, MEM_RELEASE))
+    printf("The world seems to be upside down\n");
+  mem = VirtualAlloc((void*)aligned_start,
+                     aligned_end - aligned_start + 1,
+                     MEM_RESERVE | (reserve_only ? 0 : MEM_COMMIT),
+                     reserve_only ? PAGE_NOACCESS : PAGE_READWRITE);
+  if (!mem)
+    printf("Trimming failed\n");
+  else if (mem != (void*)aligned_start)
+    printf("Hang on a sec - it's allocated a different block?!\n");
+#else
   caml_mem_unmap((void*)base, aligned_start - base);
   caml_mem_unmap((void*)aligned_end, (base + alloc_sz) - aligned_end);
+#endif
   return (void*)aligned_start;
 }
+
+#ifndef _WIN32
 static void* map_fixed(void* mem, uintnat size, int prot)
 {
   if (mmap((void*)mem, size, prot,
@@ -166,9 +199,13 @@ static void* map_fixed(void* mem, uintnat size, int prot)
     return mem;
   }
 }
+#endif
 
 void* caml_mem_commit(void* mem, uintnat size)
 {
+#ifdef _WIN32
+  return VirtualAlloc(mem, size, MEM_COMMIT, PAGE_READWRITE);
+#else
   void* p = map_fixed(mem, size, PROT_READ | PROT_WRITE);
   /*
     FIXME: On Linux, with overcommit, you stand a better
@@ -179,16 +216,27 @@ void* caml_mem_commit(void* mem, uintnat size)
       if (p) memset(p, 0, size);
   */
   return p;
+#endif
 }
 
 void caml_mem_decommit(void* mem, uintnat size)
 {
+#ifdef _WIN32
+  if (!VirtualFree(mem, size, MEM_DECOMMIT))
+    printf("VirtualFree failed to decommit\n");
+#else
   map_fixed(mem, size, PROT_NONE);
+#endif
 }
 
 void caml_mem_unmap(void* mem, uintnat size)
 {
+#ifdef _WIN32
+  if (!VirtualFree(mem, size, MEM_RELEASE))
+    printf("VirtualFree failed\n");
+#else
   munmap(mem, size);
+#endif
 }
 
 #define Min_sleep_ns       10000 // 10 us

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -125,10 +125,11 @@ static uintnat round_up(uintnat size, uintnat align) {
   return (size + align - 1) & ~(align - 1);
 }
 
+long caml_sys_pagesize = 0;
 
 uintnat caml_mem_round_up_pages(uintnat size)
 {
-  return round_up(size, sysconf(_SC_PAGESIZE));
+  return round_up(size, caml_sys_pagesize);
 }
 
 void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only)

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -795,12 +795,18 @@ static void verify_swept (struct caml_heap_state* local) {
       verify_pool(p, i, &pool_stats);
     }
   }
-  caml_gc_log("Pooled memory: %lu alloced, %lu free, %lu fragmentation",
+  caml_gc_log("Pooled memory: %" ARCH_INTNAT_PRINTF_FORMAT
+                "u alloced, %" ARCH_INTNAT_PRINTF_FORMAT
+                "u free, %" ARCH_INTNAT_PRINTF_FORMAT
+                "u fragmentation",
               pool_stats.alloced, pool_stats.free, pool_stats.overhead);
 
   verify_large(local->swept_large, &large_stats);
   Assert(local->unswept_large == 0);
-  caml_gc_log("Large memory: %lu alloced, %lu free, %lu fragmentation",
+  caml_gc_log("Large memory: %" ARCH_INTNAT_PRINTF_FORMAT
+                "u alloced, %" ARCH_INTNAT_PRINTF_FORMAT
+                "u free, %" ARCH_INTNAT_PRINTF_FORMAT
+                "u fragmentation",
               large_stats.alloced, large_stats.free, large_stats.overhead);
 
   /* Check stats are being computed correctly */

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -196,7 +196,7 @@ CAMLexport void caml_shutdown(void)
   shutdown_happened = 1;
 }
 
-void caml_init_exe_name(const char* exe_name)
+void caml_init_exe_name(const char_os* exe_name)
 {
   params.exe_name = exe_name;
 }

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -301,6 +301,7 @@ CAMLexport void caml_main(char_os **argv)
   caml_install_invalid_parameter_handler();
 #endif
   caml_init_custom_operations();
+  caml_init_os_params();
   caml_ext_table_init(&caml_shared_libs_path, 8);
 
   /* Determine position of bytecode file */
@@ -434,6 +435,7 @@ CAMLexport value caml_startup_code_exn(
   caml_install_invalid_parameter_handler();
 #endif
   caml_init_custom_operations();
+  caml_init_os_params();
 
   /* Initialize the abstract machine */
   caml_init_gc ();

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -111,6 +111,7 @@ value caml_startup_common(char_os **argv, int pooling)
   caml_install_invalid_parameter_handler();
 #endif
   caml_init_custom_operations();
+  caml_init_os_params();
   caml_init_gc ();
 
   init_segments();

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -49,6 +49,9 @@
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #endif
+#if defined(DEBUG) || defined(NATIVE_CODE)
+#include <execinfo.h>
+#endif
 #include "caml/fail.h"
 #include "caml/memory.h"
 #include "caml/misc.h"
@@ -441,3 +444,23 @@ void caml_init_os_params(void)
   caml_sys_pagesize = sysconf(_SC_PAGESIZE);
   return;
 }
+
+#if defined(DEBUG) || defined(NATIVE_CODE)
+void caml_print_trace(void)
+{
+  void *array[10];
+  size_t size;
+  char **strings;
+  size_t i;
+
+  size = backtrace(array, 10);
+  strings = backtrace_symbols(array, size);
+
+  caml_gc_log("Obtained %ld stack frames.\n", size);
+
+  for (i = 0; i < size; i++)
+    caml_gc_log("[%02zd] %s\n", i, strings[i]);
+
+  free(strings);
+}
+#endif

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -57,6 +57,7 @@
 #include "caml/sys.h"
 #include "caml/io.h"
 #include "caml/alloc.h"
+#include "caml/platform.h"
 
 #ifndef S_ISREG
 #define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
@@ -433,4 +434,10 @@ int caml_num_rows_fd(int fd)
 #else
   return -1;
 #endif
+}
+
+void caml_init_os_params(void)
+{
+  caml_sys_pagesize = sysconf(_SC_PAGESIZE);
+  return;
 }

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1043,3 +1043,8 @@ CAMLexport clock_t caml_win32_clock(void)
   clocks_per_sec = INT64_LITERAL(10000000U) / (ULONGLONG)CLOCKS_PER_SEC;
   return (clock_t)(total / clocks_per_sec);
 }
+
+void caml_init_os_params(void)
+{
+  return;
+}

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -37,6 +37,9 @@
 #include <errno.h>
 #include <string.h>
 #include <signal.h>
+#if defined(DEBUG) || defined(NATIVE_CODE)
+#include <dbghelp.h>
+#endif
 #include "caml/alloc.h"
 #include "caml/codefrag.h"
 #include "caml/fail.h"
@@ -1108,3 +1111,60 @@ int64_t caml_time_counter(void)
   QueryPerformanceCounter(&now);
   return (now.QuadPart * frequency.QuadPart + clock_offset.QuadPart);
 }
+
+#if defined(DEBUG) || defined(NATIVE_CODE)
+void caml_print_trace(void)
+{
+  CONTEXT context;
+  STACKFRAME64 frame;
+  HANDLE hProcess = GetCurrentProcess();
+  HANDLE hThread = GetCurrentThread();
+  static int symbols_loaded = 0;
+  int i = 0;
+
+  memset(&context, 0, sizeof(CONTEXT));
+  memset(&frame, 0, sizeof(STACKFRAME64));
+
+  /* SymCleanup at present is never called */
+  if (!symbols_loaded && SymInitialize(hProcess, NULL, TRUE)) {
+    fprintf(stderr, "Loaded symbols\n");
+    symbols_loaded = 1;
+  }
+
+  context.ContextFlags = CONTEXT_FULL;
+  RtlCaptureContext(&context);
+
+#ifdef _M_X64
+  frame.AddrPC.Mode = frame.AddrFrame.Mode = frame.AddrStack.Mode = AddrModeFlat;
+  frame.AddrPC.Offset = context.Rip;
+  frame.AddrFrame.Offset = context.Rsp;
+  frame.AddrStack.Offset = context.Rsp;
+#else
+#error Unsupported Windows architecture
+#endif
+
+  /* For the symbols to be populated, compile with ocamlopt -g and run
+     `cv2pdb prog.exe` to generate prog.pdb. The output of this stack trace is
+     limited, probably because we make no effort to emit correct DWARF
+     information on Windows.
+
+     cv2pdb can be downloaded from https://github.com/rainers/cv2pdb */
+  while (i++ < 10 && StackWalk64(IMAGE_FILE_MACHINE_AMD64,
+                                 hProcess, hThread,
+                                 &frame, &context, NULL,
+                                 SymFunctionTableAccess64, SymGetModuleBase64,
+                                 NULL)) {
+    char buffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(wchar_t)];
+    PSYMBOL_INFO symbol = (PSYMBOL_INFO)buffer;
+    DWORD64 offset = 0;
+    char *name;
+    symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+    symbol->MaxNameLen = MAX_SYM_NAME;
+    if (SymFromAddr(hProcess, frame.AddrPC.Offset, &offset, symbol))
+      name = symbol->Name;
+    else
+      name = "???";
+    caml_gc_log("[%02d] %s\n", i, name);
+  }
+}
+#endif

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1046,13 +1046,65 @@ CAMLexport clock_t caml_win32_clock(void)
   return (clock_t)(total / clocks_per_sec);
 }
 
+static LARGE_INTEGER frequency;
+static LARGE_INTEGER clock_offset;
+typedef void (WINAPI *LPFN_GETSYSTEMTIME) (LPFILETIME);
+
 void caml_init_os_params(void)
 {
   SYSTEM_INFO si;
+  LPFN_GETSYSTEMTIME pGetSystemTime;
+  FILETIME stamp;
+  ULARGE_INTEGER now;
+  LARGE_INTEGER counter;
 
   /* Get the system page size */
   GetSystemInfo(&si);
   caml_sys_pagesize = si.dwPageSize;
 
-  return;
+  /* Get the number of nanoseconds for each tick in QueryPerformanceCounter */
+  QueryPerformanceFrequency(&frequency);
+  /* Convert the frequency to the duration of 1 tick in ns */
+  frequency.QuadPart = 1000000000LL / frequency.QuadPart;
+
+  /* Get the current time as accurately as we can.
+     GetSystemTimePreciseAsFileTime is available on Windows 8 / Server 2012+ and
+     gives <1us precision. For Windows 7 and earlier, which is only accurate to
+     10-100ms. */
+  pGetSystemTime =
+    (LPFN_GETSYSTEMTIME)GetProcAddress(GetModuleHandle(L"kernel32"),
+                                       "GetSystemTimePreciseAsFileTime");
+  if (!pGetSystemTime)
+    pGetSystemTime = GetSystemTimeAsFileTime;
+
+  /* Get the time and the performance counter. Get the performance counter first
+     to ensure no quantum effects */
+  QueryPerformanceCounter(&counter);
+  pGetSystemTime(&stamp);
+
+  now.LowPart = stamp.dwLowDateTime;
+  now.HighPart = stamp.dwHighDateTime;
+
+  /* Convert a FILETIME in 100ns ticks since 1 January 1601 to
+     ns since 1 Jan 1970. */
+  clock_offset.QuadPart =
+    ((now.QuadPart - INT64_LITERAL(0x19DB1DED53E8000U)) * 100);
+
+  /* Get the offset between QueryPerformanceCounter and
+     GetSystemTimePreciseAsFileTime in order to return a true timestamp, rather
+     than just a monotonic time source */
+  clock_offset.QuadPart -= (counter.QuadPart * frequency.QuadPart);
+
+  GetSystemTimePreciseAsFileTime(&stamp);
+  now.LowPart = stamp.dwLowDateTime;
+  now.HighPart = stamp.dwHighDateTime;
+  now.QuadPart *= 100;
+}
+
+int64_t caml_time_counter(void)
+{
+  LARGE_INTEGER now;
+  /* Windows 2000 is no longer supported, so this function always succeeds */
+  QueryPerformanceCounter(&now);
+  return (now.QuadPart * frequency.QuadPart + clock_offset.QuadPart);
 }

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -47,6 +47,7 @@
 #include "caml/signals.h"
 #include "caml/sys.h"
 #include "caml/startup_aux.h"
+#include "caml/platform.h"
 
 #include "caml/config.h"
 
@@ -1047,5 +1048,11 @@ CAMLexport clock_t caml_win32_clock(void)
 
 void caml_init_os_params(void)
 {
+  SYSTEM_INFO si;
+
+  /* Get the system page size */
+  GetSystemInfo(&si);
+  caml_sys_pagesize = si.dwPageSize;
+
   return;
 }

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -46,6 +46,7 @@
 #include "caml/osdeps.h"
 #include "caml/signals.h"
 #include "caml/sys.h"
+#include "caml/startup_aux.h"
 
 #include "caml/config.h"
 

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -111,10 +111,20 @@ endif
 
 TIMEOUT ?= 600 # 10 minutes
 
+# SHOW_TIMINGS should be set by the user (to a non-empty value) if they want
+# the timings for each test file to be included in the log
+SHOW_TIMINGS ?=
+ifeq "$(SHOW_TIMINGS)" ""
+  OCAMLTEST_SHOW_TIMINGS_FLAG :=
+else
+  OCAMLTEST_SHOW_TIMINGS_FLAG := -show-timings
+endif
+
 OCAMLTESTFLAGS := \
   -timeout $(TIMEOUT) \
   $(OCAMLTEST_PROMOTE_FLAG) \
-  $(OCAMLTEST_KEEP_TEST_DIR_ON_SUCCESS_FLAG)
+  $(OCAMLTEST_KEEP_TEST_DIR_ON_SUCCESS_FLAG) \
+  $(OCAMLTEST_SHOW_TIMINGS_FLAG)
 
 # Make sure USE_RUNTIME is defined
 USE_RUNTIME ?=

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -183,7 +183,7 @@ all-quick: lib tools
 	@cat disabled | tr -d '\r' | sed -n 's/#.*//; /\//d; /./p' > disabled-dirs
 	@cat multicore-tests | tr -d '\r' | sed -e '/#/d' | fgrep -vf disabled-dirs | \
 	  while read LINE; do \
-	    $(MAKE) $(NO_PRINT) exec-one DIR=tests/$$LINE; \
+	    $(MAKE) --no-print-directory exec-one DIR=tests/$$LINE; \
 	  done 2>&1 | tee _log
 	@rm disabled-dirs
 	@$(MAKE) report
@@ -193,7 +193,7 @@ all-enabled: lib tools
 	@cat disabled | tr -d '\r' | sed -n 's/#.*//; /\//d; /./p' > disabled-dirs
 	@ls tests | fgrep -v -f disabled-dirs | \
 	  while read LINE; do \
-	    $(MAKE) $(NO_PRINT) exec-one DIR=tests/$$LINE; \
+	    $(MAKE) --no-print-directory exec-one DIR=tests/$$LINE; \
 	  done 2>&1 | tee _log
 	@rm disabled-dirs
 	@$(MAKE) report

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -178,6 +178,16 @@ check-failstamp:
 	  exit 1; \
 	fi
 
+.PHONY: all-quick
+all-quick: lib tools
+	@cat disabled | tr -d '\r' | sed -n 's/#.*//; /\//d; /./p' > disabled-dirs
+	@cat multicore-tests | tr -d '\r' | sed -e '/#/d' | fgrep -vf disabled-dirs | \
+	  while read LINE; do \
+	    $(MAKE) $(NO_PRINT) exec-one DIR=tests/$$LINE; \
+	  done 2>&1 | tee _log
+	@rm disabled-dirs
+	@$(MAKE) report
+
 .PHONY: all-enabled
 all-enabled: lib tools
 	@cat disabled | tr -d '\r' | sed -n 's/#.*//; /\//d; /./p' > disabled-dirs

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -179,7 +179,7 @@ check-failstamp:
 
 .PHONY: all-enabled
 all-enabled: lib tools
-	@sed -n 's/#.*//; /\//d; /./p' disabled > disabled-dirs
+	@cat disabled | tr -d '\r' | sed -n 's/#.*//; /\//d; /./p' > disabled-dirs
 	@ls tests | fgrep -v -f disabled-dirs | \
 	  while read LINE; do \
 	    $(MAKE) $(NO_PRINT) exec-one DIR=tests/$$LINE; \

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -133,20 +133,21 @@ endif
 .PHONY: default
 default:
 	@echo "Available targets:"
-	@echo "  all             launch all tests"
-	@echo "  all-foo         launch all tests beginning with foo"
-	@echo "  all-enabled     launch all enabled tests"
-	@echo "  parallel        launch all tests using GNU parallel"
-	@echo "  parallel-foo    launch all tests beginning with foo using \
+	@echo "  all              launch all tests"
+	@echo "  all-foo          launch all tests beginning with foo"
+	@echo "  all-enabled      launch all enabled tests"
+	@echo "  parallel         launch all tests using GNU parallel"
+	@echo "  parallel-enabled launch all enabled tests using GNU parallel"
+	@echo "  parallel-foo     launch all tests beginning with foo using \
 	GNU parallel"
-	@echo "  one TEST=f      launch just this single test"
-	@echo "  one DIR=p       launch the tests located in path p"
-	@echo "  one LIST=f      launch the tests listed in f (one per line)"
-	@echo "  promote DIR=p   promote the reference files for the tests in p"
-	@echo "  lib             build library modules"
-	@echo "  tools           build test tools"
-	@echo "  clean           delete generated files"
-	@echo "  report          print the report for the last execution"
+	@echo "  one TEST=f       launch just this single test"
+	@echo "  one DIR=p        launch the tests located in path p"
+	@echo "  one LIST=f       launch the tests listed in f (one per line)"
+	@echo "  promote DIR=p    promote the reference files for the tests in p"
+	@echo "  lib              build library modules"
+	@echo "  tools            build test tools"
+	@echo "  clean            delete generated files"
+	@echo "  report           print the report for the last execution"
 	@echo
 	@echo "all*, parallel* and list can automatically re-run failed test"
 	@echo "directories if MAX_TESTSUITE_DIR_RETRIES permits"
@@ -236,6 +237,27 @@ parallel-%: lib tools
 
 .PHONY: parallel
 parallel: parallel-*
+
+.PHONY: parallel-enabled
+parallel-enabled: parallel-enabled-*
+
+.PHONY: parallel-enabled-%
+parallel-enabled-%: lib tools
+	@echo | parallel >/dev/null 2>/dev/null \
+	 || (echo "Unable to run the GNU parallel tool;";\
+	     echo "You should install it before using the parallel* targets.";\
+	     exit 1)
+	@echo | parallel --gnu --no-notice >/dev/null 2>/dev/null \
+	 || (echo "Your 'parallel' tool seems incompatible with GNU parallel.";\
+	     echo "This target requires GNU parallel.";\
+	     exit 1)
+	@cat disabled | tr -d '\r' | sed -n 's/#.*//; /\//d; /./p' > disabled-dirs
+	@(cd tests ; ls -d $**) | fgrep -v -f disabled-dirs | while read -r dir; do echo $$dir; done \
+	 | parallel --gnu --no-notice --keep-order \
+	     "$(MAKE) --no-print-directory exec-one DIR=tests/{} 2>&1" \
+	 | tee $(TESTLOG)
+	@rm disabled-dirs
+	@$(MAKE) report
 
 .PHONY: list
 list: lib tools

--- a/testsuite/multicore-tests
+++ b/testsuite/multicore-tests
@@ -1,0 +1,12 @@
+# This file lists test directories which should be run for a "quick" multicore test
+backtrace
+basic
+callback
+effects
+gc-roots
+lazy
+lib-unix
+parallel
+promotion
+unwind
+weak-ephe-final

--- a/testsuite/summarize.awk
+++ b/testsuite/summarize.awk
@@ -16,6 +16,7 @@
 BEGIN {
     while ((getline line < "disabled") > 0) {
         gsub(/#.*/, "", line);
+        gsub(/\r$/, "", line);
         if (line) {
             is_disabled[line] = 1;
         }

--- a/testsuite/summarize.awk
+++ b/testsuite/summarize.awk
@@ -65,13 +65,13 @@ function record_fail() {
     check();
     if (!(key in RESULTS) || RESULTS[key] == "s"){
         if (!(key in RESULTS)) ++nresults;
-    		testcase = sprintf ("%s/%s", curdir, curfile);
-			gsub(/[ \t]+$/, "", testcase);
-			if (is_disabled[testcase]) {
-				RESULTS[key] = "d";
-			} else {
-				RESULTS[key] = "f";
-			}
+        testcase = sprintf ("%s/%s", curdir, curfile);
+      gsub(/[ \t]+$/, "", testcase);
+      if (is_disabled[testcase]) {
+        RESULTS[key] = "d";
+      } else {
+        RESULTS[key] = "f";
+      }
     }
     delete SKIPPED[curdir];
     clear();
@@ -131,6 +131,15 @@ function record_unexp() {
     in_test = 1;
 }
 
+/^Wall clock:/ {
+  match($0, /: .* took /);
+  curfile = substr($0, RSTART+2, RLENGTH-8);
+  match($0, / took .*s/);
+  duration = substr($0, RSTART+6, RLENGTH-7);
+  if (duration + 0.0 > 10.0)
+    slow[slowcount++] = sprintf("%s: %s", curfile, duration);
+}
+
 /=> passed/ {
     record_pass();
 }
@@ -183,8 +192,8 @@ END {
             }else if (r == "e"){
                 ++ unexped;
                 unexp[unexpidx++] = key;
-							}else if (r == "d"){
-									++ ndisabled;
+              }else if (r == "d"){
+                  ++ ndisabled;
             }else if (r == "s"){
                 ++ skipped;
                 curdir = DIRS[key];
@@ -230,6 +239,10 @@ END {
         printf("  %3d tests considered", nresults);
         if (nresults != passed + skipped + ignored + failed + ndisabled + unexped){
             printf (" (totals don't add up??)");
+        }
+        if (slowcount != 0){
+            printf("\n\nTests taking longer than 10s:\n");
+            for (i=0; i < slowcount; i++) printf("    %s\n", slow[i]);
         }
         printf ("\n");
         if (reran != 0){

--- a/testsuite/tests/lib-systhreads/test_c_thread_register.ml
+++ b/testsuite/tests/lib-systhreads/test_c_thread_register.ml
@@ -3,9 +3,8 @@
    * hassysthreads
    include systhreads
    ** not-bsd
-   *** libunix
-   **** bytecode
-   **** native
+   *** bytecode
+   *** native
 *)
 
 (* spins a external thread from C and register it to the OCaml runtime *)

--- a/testsuite/tests/lib-unix/common/fork_cleanup.ml
+++ b/testsuite/tests/lib-unix/common/fork_cleanup.ml
@@ -1,8 +1,9 @@
 (* TEST
 * hasunix
 include unix
-** bytecode
-** native
+** not-windows
+*** bytecode
+*** native
 *)
 
 (* this test checks that the domain lock is properly reinitialized

--- a/testsuite/tests/lib-unix/common/fork_cleanup_systhreads.ml
+++ b/testsuite/tests/lib-unix/common/fork_cleanup_systhreads.ml
@@ -1,8 +1,9 @@
 (* TEST
 * hassysthreads
 include systhreads
-** bytecode
-** native
+** not-windows
+*** bytecode
+*** native
 *)
 
 (* this test checks that the domain lock is properly reinitialized

--- a/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
+++ b/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
@@ -1,8 +1,9 @@
 (* TEST
 include unix
 * hasunix
-** bytecode
-** native
+** not-windows
+*** bytecode
+*** native
 *)
 
 (* on Multicore, fork is not allowed is another domain is, and was running. *)

--- a/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
+++ b/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
@@ -1,8 +1,9 @@
 (* TEST
 include unix
 * hasunix
-** bytecode
-** native
+** not-windows
+*** bytecode
+*** native
 *)
 
 (* on Multicore, fork is not allowed is another domain is, and was running. *)

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -164,6 +164,10 @@ BasicCompiler () {
   ReportBuildStatus 0
 }
 
+if [ "$(uname -o)" = "Cygwin"] ; then
+  export PATH="/usr/x86_64-w64-mingw32/sys-root/mingw/bin:$PATH"
+fi
+
 case $1 in
 configure) Configure;;
 build) Build;;


### PR DESCRIPTION
This includes all the commits from #351 and there are 2 tests which always fail and 1 which occasionally fails but are fixed by #573.

There are 8 new commits here for consideration:

- "Add all-quick target for testsuite" - this is not at present used, but is taken from older work I did last year on this (when Travis was still in use). It might be useful, as it's slightly more structured than what's done for, say, Linux-O0 at the moment. The idea was to have a smaller set of tests which could be run on PRs (for Windows) and only run the full testsuite on Windows for merges.
- "GitHub Actions workflow to test Windows" - mangles the existing workflow to test mingw-w64 in the build-misc job
- "Fix --no-print-directory in testsuite" - could be extracted, but the multicore-specific test targets had a couple of `$(NO_PRINT)` in them which got removed in https://github.com/ocaml/ocaml/pull/9805. This gets rid of all `make[n]` cruft here:
```
make[2]: Leaving directory '/cygdrive/d/a/ocaml-multicore/ocaml-multicore/testsuite'
make[1]: Leaving directory '/cygdrive/d/a/ocaml-multicore/ocaml-multicore/testsuite'
make[1]: Entering directory '/cygdrive/d/a/ocaml-multicore/ocaml-multicore/testsuite'
Running tests from 'tests/tool-ocaml' ...
make[2]: Entering directory '/cygdrive/d/a/ocaml-multicore/ocaml-multicore/testsuite'
```
- "Configure for sadness" - unfortunately, the OCaml testsuite at present cannot be run on a default CRLF checkout of OCaml. Fixing that requires a change to the encoding of exception backtraces (to have a start and end line number) which is implemented in https://github.com/ocaml/ocaml/pull/10111 but which is not yet merged. For now, enable LF checkouts, but with the fullest intention of reverting it when possible (it's yet another little stumbling block for anyone trying to contribute on Windows...)
- "Add -show-timings option to ocamltest" - the testsuite is stupendously slow on Windows (open to further investigation by anyone...!). As a very perfunctory start at looking into this, I've added a `-show-timings` flag to `ocamltest` (which is activated using `make -C testsuite SHOW_TIMINGS=1 ...` by the testsuite) which shows the wall-clock time for each test _file_. This might be worth upstreaming, although my implementation of it is a bit ugly.
- "Only build the programs once on Windows" - ocamltest actually compiles everything four times - with `ocamlc.byte`, `ocamlc.opt`, `ocamlopt.byte` and `ocamlopt.opt`. This is too expensive on Windows, so I've hacked the built-in actions to disable it. This is also worth upstreaming as a proper option, but not using the code I've written here.
- "Report tests taking longer than 10s" - I hacked `testsuite/summarize.awk` to list the test files which took longer than 10s in the end report.
- "Ensure Cygwin's mingw-w64 runtime DLLs are used" - is a technical fix to ensure the correct mingw-w64 runtime is picked up. Docker bundles some as well (bundling them is unfortunately much more commonplace than the more correct manifesting, as done in opam, and causes DLL hell in `PATH`...)

The workflow is quite preliminary because upstream ocaml/ocaml is still using AppVeyor. I've done some work on switching it to GitHub Actions, but I'm waiting on 10111 before moving further with it. As a result, some of the changes to `runner.sh` and so forth here are ~a little bit~ really quite a lot hackier than might be nice, but the aim is that we'd pull in upstream's improved GitHub Actions workflow when I, um, merge it!