### PR TITLE
Improving Multicore's issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,13 +9,31 @@ assignees: ''
 <!--
 Welcome to OCaml multicore's Issue tracker!
 
-One thing that can greatly assist in debugging issues is if the
-OCaml multicore build version information is included. You can determine
-the OCaml multicore build version information with `ocamlrun -version`.
+We would like to thank you for reporting your bug to the Multicore OCaml team.
 
-If you have questions about *using* OCaml, please ask at
-https://discuss.ocaml.org (more people read Discuss than this tracker, and
-you'll get confirmation of whether you've really found a bug or need a new
-feature).
+To make sure that we can help you as best as possible, we advise to go through
+the page at https://github.com/ocaml-multicore/ocaml-multicore/wiki/Report-an-issue-to-the-bugtracker
+
+Use the following template to report your issue and fill it with available the informations.
+
+**Describe the issue**
+
+Tell us what problem you observed.
+
+**To reproduce**
+
+Please provide here the build instructions for your issue, and a code sample if available.
+
+**Multicore OCaml build version**
+
+Please provide the output of `ocamlc -version` or `strings your_binary.exe | grep OCAML_RUNTIME_BUILD_GIT_HASH_IS`.
+
+**Did you try running it with the debug runtime and heap verification ON?**
+
+See https://github.com/ocaml-multicore/ocaml-multicore/wiki/Report-an-issue-to-the-bugtracker
+
+**Backtrace**
+
+See link above.
 
 -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,10 +11,10 @@ Welcome to OCaml multicore's Issue tracker!
 
 We would like to thank you for reporting your bug to the Multicore OCaml team.
 
-To make sure that we can help you as best as possible, we advise to go through
+To make sure that we can help you as best as possible, we advise you to go through
 the page at https://github.com/ocaml-multicore/ocaml-multicore/wiki/Report-an-issue-to-the-bugtracker
 
-Use the following template to report your issue and fill it with available the informations.
+Use the following template to report your issue and fill it with the available information.
 
 **Describe the issue**
 


### PR DESCRIPTION
This PR is an attempt at providing a better issue template for the ocaml-multicore repository.

It adds a few useful datapoints that the user may be able to provide us with.

The template itself links to a wiki page where the bulk of the information is, because some steps are a bit hairy and I was afraid that adding everything within the template itself makes it difficult to parse correctly and may be a bit discouraging.

Though is if it feels nicer to anyone else I can inline the relevant information instead.

https://github.com/ocaml-multicore/ocaml-multicore/wiki/Report-an-issue-to-the-bugtracker