### PR TITLE
Integrate all of trunk's EINTR fixes

### DIFF
--- a/ocamltest/run_stubs.c
+++ b/ocamltest/run_stubs.c
@@ -71,10 +71,10 @@ static void logToChannel(void *voidchannel, const char *fmt, va_list ap)
     if (text == NULL) return;
     if (vsnprintf(text, length, fmt, ap) != length) goto end;
   }
-  /* TODO: Lock(channel); */
+  Lock(channel);
   caml_putblock(channel, text, length);
   caml_flush(channel);
-  /* TODO: Unlock(channel); */
+  Unlock(channel);
 end:
   free(text);
 }

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -404,6 +404,8 @@ value caml_thread_sigmask(value cmd, value sigs) /* ML */
   retcode = pthread_sigmask(how, &set, &oldset);
   caml_leave_blocking_section();
   sync_check_error(retcode, "Thread.sigmask");
+  /* Run any handlers for just-unmasked pending signals */
+  caml_raise_if_exception(caml_process_pending_signals_exn());
   return st_encode_sigset(&oldset);
 }
 

--- a/otherlibs/unix/signals.c
+++ b/otherlibs/unix/signals.c
@@ -72,7 +72,7 @@ CAMLprim value unix_sigprocmask(value vaction, value vset)
   retcode = sigprocmask(how, &set, &oldset);
   caml_leave_blocking_section();
   /* Run any handlers for just-unmasked pending signals */
-  /* TODO: caml_process_pending_actions(); */
+  caml_raise_if_exception(caml_process_pending_signals_exn());
   if (retcode != 0) unix_error(retcode, "sigprocmask", Nothing);
   return encode_sigset(&oldset);
 }

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -461,7 +461,7 @@ static void read_main_debug_info(struct debug_info *di)
   if (caml_seek_optional_section(fd, &trail, "DBUG") != -1) {
     chan = caml_open_descriptor_in(fd);
 
-    /* TODO: do we need Lock(chan); */
+    Lock(chan);
     num_events = caml_getword(chan);
     events = caml_alloc(num_events, 0);
 
@@ -479,7 +479,7 @@ static void read_main_debug_info(struct debug_info *di)
       /* Record event list */
       Store_field(events, i, evl);
     }
-    /* TODO: do we need Unlock(chan); */
+    Unlock(chan);
 
     caml_close_channel(chan);
 

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -37,6 +37,7 @@ int caml_reallocate_minor_heap(asize_t);
 
 int caml_incoming_interrupts_queued(void);
 
+int caml_check_pending_actions();
 void caml_handle_gc_interrupt(void);
 void caml_handle_gc_interrupt_no_async_exceptions(void);
 void caml_handle_incoming_interrupts(void);

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -106,9 +106,24 @@ CAMLextern intnat caml_really_getblock (struct channel *, char *, intnat);
 
 #define Channel(v) (*((struct channel **) (Data_custom_val(v))))
 
+/* The locking machinery */
+
+CAMLextern void (*caml_channel_mutex_free) (struct channel *);
+CAMLextern void (*caml_channel_mutex_lock) (struct channel *);
+CAMLextern void (*caml_channel_mutex_unlock) (struct channel *);
+CAMLextern void (*caml_channel_mutex_unlock_exn) (void);
+
 CAMLextern struct channel * caml_all_opened_channels;
 
+#define Lock(channel) \
+  if (caml_channel_mutex_lock != NULL) (*caml_channel_mutex_lock)(channel)
+#define Unlock(channel) \
+  if (caml_channel_mutex_unlock != NULL) (*caml_channel_mutex_unlock)(channel)
+#define Unlock_exn() \
+  if (caml_channel_mutex_unlock_exn != NULL) (*caml_channel_mutex_unlock_exn)()
+
 /* Conversion between file_offset and int64_t */
+
 #define Val_file_offset(fofs) caml_copy_int64(fofs)
 #define File_offset_val(v) ((file_offset) Int64_val(v))
 

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -95,26 +95,6 @@ struct caml__mutex_unwind {
   struct caml__mutex_unwind* next;
 };
 
-#define With_mutex(mutex0, BODY) do {                   \
-  struct caml__mutex_unwind caml__locked_mutex;         \
-  caml_plat_mutex* caml__mutex = (mutex0);              \
-  int caml__mutex_go = 1;                               \
-  Assert(CAML_LOCAL_ROOTS);                             \
-  caml__locked_mutex.mutex = caml__mutex;               \
-  caml__locked_mutex.next = CAML_LOCAL_ROOTS->mutexes;  \
-  CAML_LOCAL_ROOTS->mutexes = &caml__locked_mutex;      \
-  for (caml_plat_try_lock(caml__mutex) ||               \
-         ((caml_enter_blocking_section(),               \
-           caml_plat_lock(caml__mutex),                 \
-           caml_leave_blocking_section()), 0);          \
-       caml__mutex_go;                                  \
-       caml_plat_unlock(caml__mutex),                   \
-         caml__mutex_go = 0,                            \
-         CAML_LOCAL_ROOTS->mutexes =                    \
-         CAML_LOCAL_ROOTS->mutexes->next)               \
-    { BODY }                                            \
-  } while(0)
-
 /* Memory management primitives (mmap) */
 
 uintnat caml_mem_round_up_pages(uintnat size);

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -954,9 +954,9 @@ CAMLprim value caml_output_value(value vchan, value v, value flags)
   CAMLparam3 (vchan, v, flags);
   struct channel * channel = Channel(vchan);
 
-  With_mutex(&channel->mutex, {
-    caml_output_val(channel, v, flags);
-  } );
+  Lock(channel);
+  caml_output_val(channel, v, flags);
+  Unlock(channel);
   CAMLreturn (Val_unit);
 }
 

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -788,9 +788,9 @@ CAMLprim value caml_input_value(value vchan)
   struct channel * chan = Channel(vchan);
   CAMLlocal1 (res);
 
-  With_mutex(&chan->mutex, {
-    res = caml_input_val(chan);
-  } );
+  Lock(chan);
+  res = caml_input_val(chan);
+  Unlock(chan);
   CAMLreturn (res);
 }
 

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -77,12 +77,13 @@
 int caml_read_fd(int fd, int flags, void * buf, int n)
 {
   int retcode;
-  do {
-    caml_enter_blocking_section();
-    retcode = read(fd, buf, n);
-    caml_leave_blocking_section();
-  } while (retcode == -1 && errno == EINTR);
-  if (retcode == -1) caml_sys_io_error(NO_ARG);
+  caml_enter_blocking_section_no_pending();
+  retcode = read(fd, buf, n);
+  caml_leave_blocking_section();
+  if (retcode == -1) {
+    if (errno == EINTR) return Io_interrupted;
+    else caml_sys_io_error(NO_ARG);
+  }
   return retcode;
 }
 
@@ -90,11 +91,11 @@ int caml_write_fd(int fd, int flags, void * buf, int n)
 {
   int retcode;
  again:
-  caml_enter_blocking_section();
+  caml_enter_blocking_section_no_pending();
   retcode = write(fd, buf, n);
   caml_leave_blocking_section();
   if (retcode == -1) {
-    if (errno == EINTR) goto again;
+    if (errno == EINTR) return Io_interrupted;
     if ((errno == EAGAIN || errno == EWOULDBLOCK) && n > 1) {
       /* We couldn't do a partial write here, probably because
          n <= PIPE_BUF and POSIX says that writes of less than

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -65,7 +65,3 @@ tests/promotion/bigrecmod.ml
 
 # instrumented runtime test is not very useful (and broken on multicore.) (#9413)
 tests/instrumented-runtime/'main.ml' with 1.1 (native)
-
-# disabled until the follow-up EINTR PR
-tests/lib-systhreads/'eintr.ml' with 1.1.2 (native)
-tests/lib-systhreads/'eintr.ml' with 1.1.1 (bytecode)


### PR DESCRIPTION
This PR incorporates nearly all of the changes from @stedolan 's https://github.com/ocaml/ocaml/pull/9722 . It should significantly reduce our diff with trunk on files such as `io.c`. It also restores the mutex lock/unlock hooks that have caused some compatibility issues (https://github.com/ocaml-multicore/ocaml-multicore/pull/623). 

After https://github.com/ocaml-multicore/ocaml-multicore/pull/630 and https://github.com/ocaml-multicore/ocaml-multicore/pull/631 this should be the last signals PR (though we still need to deal with asynchronous exceptions from finalisers).

One design question for @Engil to consider (for potentially a follow-up PR) - do we still need the systhreads implementations of the hooks given how similar they are to the default ones in `io.c` now?