### PR TITLE
Make young_start/end/ptr pointers to value

### DIFF
--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -19,13 +19,13 @@ DOMAIN_STATE(volatile uintnat, young_limit)
  * by other domains to signal this domain by causing a spurious allocation
  * failure. */
 
-DOMAIN_STATE(char*, young_ptr)
+DOMAIN_STATE(value*, young_ptr)
 /* Minor heap pointer */
 
-DOMAIN_STATE(char*, young_start)
+DOMAIN_STATE(value*, young_start)
 /* Start of the minor heap */
 
-DOMAIN_STATE(char*, young_end)
+DOMAIN_STATE(value*, young_end)
 /* End of the minor heap. always(young_end <= young_ptr <= young_start) */
 
 DOMAIN_STATE(struct stack_info*, current_stack)

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -213,11 +213,11 @@ extern uintnat caml_use_huge_pages;
                                           CAMLassert ((tag_t) (tag) < 256); \
                                  CAMLassert ((wosize) <= Max_young_wosize); \
   dom_st = Caml_state;                                                      \
-  Move_young_ptr(dom_st, -Bhsize_wosize(wosize));			    \
-  while (Caml_check_gc_interrupt(dom_st)) {				    \
-    Move_young_ptr(dom_st, +Bhsize_wosize(wosize));  			    \
+  Move_young_ptr(dom_st, -Bhsize_wosize(wosize));                           \
+  while (Caml_check_gc_interrupt(dom_st)) {                                 \
+    Move_young_ptr(dom_st, +Bhsize_wosize(wosize));                         \
     { GC }                                                                  \
-    Move_young_ptr(dom_st, -Bhsize_wosize(wosize));  			    \
+    Move_young_ptr(dom_st, -Bhsize_wosize(wosize));                         \
   }                                                                         \
   Hd_hp (dom_st->young_ptr) =                                               \
     Make_header_with_profinfo ((wosize), (tag), 0, profinfo);               \

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -205,17 +205,19 @@ extern uintnat caml_use_huge_pages;
 #define DEBUG_clear(result, wosize)
 #endif
 
+#define Move_young_ptr(d, to) d->young_ptr = (value*)((uintnat)d->young_ptr to);
+
 #define Alloc_small_with_profinfo(result, wosize, tag, GC, profinfo) do{    \
   caml_domain_state* dom_st;                                                \
                                                 CAMLassert ((wosize) >= 1); \
                                           CAMLassert ((tag_t) (tag) < 256); \
                                  CAMLassert ((wosize) <= Max_young_wosize); \
   dom_st = Caml_state;                                                      \
-  dom_st->young_ptr -= Bhsize_wosize (wosize);                              \
-  while (Caml_check_gc_interrupt(dom_st)) {                                 \
-    dom_st->young_ptr += Bhsize_wosize (wosize);                            \
+  Move_young_ptr(dom_st, -Bhsize_wosize(wosize));			    \
+  while (Caml_check_gc_interrupt(dom_st)) {				    \
+    Move_young_ptr(dom_st, +Bhsize_wosize(wosize));  			    \
     { GC }                                                                  \
-    dom_st->young_ptr -= Bhsize_wosize (wosize);                            \
+    Move_young_ptr(dom_st, -Bhsize_wosize(wosize));  			    \
   }                                                                         \
   Hd_hp (dom_st->young_ptr) =                                               \
     Make_header_with_profinfo ((wosize), (tag), 0, profinfo);               \

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -205,19 +205,17 @@ extern uintnat caml_use_huge_pages;
 #define DEBUG_clear(result, wosize)
 #endif
 
-#define Move_young_ptr(d, to) d->young_ptr = (value*)((uintnat)d->young_ptr to);
-
 #define Alloc_small_with_profinfo(result, wosize, tag, GC, profinfo) do{    \
   caml_domain_state* dom_st;                                                \
                                                 CAMLassert ((wosize) >= 1); \
                                           CAMLassert ((tag_t) (tag) < 256); \
                                  CAMLassert ((wosize) <= Max_young_wosize); \
   dom_st = Caml_state;                                                      \
-  Move_young_ptr(dom_st, -Bhsize_wosize(wosize));                           \
+  dom_st->young_ptr -=  Whsize_wosize(wosize);                              \
   while (Caml_check_gc_interrupt(dom_st)) {                                 \
-    Move_young_ptr(dom_st, +Bhsize_wosize(wosize));                         \
+    dom_st->young_ptr += Whsize_wosize(wosize);                             \
     { GC }                                                                  \
-    Move_young_ptr(dom_st, -Bhsize_wosize(wosize));                         \
+    dom_st->young_ptr -= Whsize_wosize(wosize);                             \
   }                                                                         \
   Hd_hp (dom_st->young_ptr) =                                               \
     Make_header_with_profinfo ((wosize), (tag), 0, profinfo);               \

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -310,8 +310,8 @@ int caml_reallocate_minor_heap(asize_t wsize)
 
   domain_state->minor_heap_wsz = wsize;
 
-  domain_state->young_start = (char*)domain_self->minor_heap_area;
-  domain_state->young_end = (char*)(domain_self->minor_heap_area + Bsize_wsize(wsize));
+  domain_state->young_start = (value*)domain_self->minor_heap_area;
+  domain_state->young_end = (value*)(domain_self->minor_heap_area + Bsize_wsize(wsize));
   domain_state->young_limit = (uintnat) domain_state->young_start;
   domain_state->young_ptr = domain_state->young_end;
   return 0;

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -90,7 +90,7 @@ CAMLprim value caml_gc_quick_stat(value v)
 double caml_gc_minor_words_unboxed()
 {
   return (Caml_state->stat_minor_words
-          + ((double) (Caml_state->young_end - Caml_state->young_ptr)) / sizeof(value));
+          + ((double) ((uintnat)Caml_state->young_end - (uintnat)Caml_state->young_ptr)) / sizeof(value));
 }
 
 CAMLprim value caml_gc_minor_words(value v)
@@ -106,8 +106,8 @@ CAMLprim value caml_gc_counters(value v)
 
   /* get a copy of these before allocating anything... */
   double minwords = Caml_state->stat_minor_words
-                    + ((double) Wsize_bsize (Caml_state->young_end -
-                                            Caml_state->young_ptr)) / sizeof(value);
+    + ((double) Wsize_bsize ((uintnat)Caml_state->young_end -
+			     (uintnat) Caml_state->young_ptr)) / sizeof(value);
   double prowords = Caml_state->stat_promoted_words;
   double majwords = Caml_state->stat_major_words + (double) Caml_state->allocated_words;
 
@@ -281,7 +281,7 @@ CAMLprim value caml_gc_stat(value v)
 
 CAMLprim value caml_get_minor_free (value v)
 {
-  return Val_int (Caml_state->young_ptr - Caml_state->young_start);
+  return Val_int ((uintnat)Caml_state->young_ptr - (uintnat)Caml_state->young_start);
 }
 
 void caml_init_gc ()

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -527,7 +527,7 @@ void caml_empty_minor_heap_promote (caml_domain_state* domain, int participating
   struct caml_custom_elt *elt;
   value* young_ptr = domain->young_ptr;
   value* young_end = domain->young_end;
-  uintnat minor_allocated_bytes = young_end - young_ptr;
+  uintnat minor_allocated_bytes = (uintnat)young_end - (uintnat)young_ptr;
   uintnat prev_alloc_words;
   struct oldify_state st = {0};
   value **r;

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -525,8 +525,8 @@ void caml_empty_minor_heap_promote (caml_domain_state* domain, int participating
 {
   struct caml_minor_tables *self_minor_tables = domain->minor_tables;
   struct caml_custom_elt *elt;
-  char* young_ptr = domain->young_ptr;
-  char* young_end = domain->young_end;
+  value* young_ptr = domain->young_ptr;
+  value* young_end = domain->young_end;
   uintnat minor_allocated_bytes = young_end - young_ptr;
   uintnat prev_alloc_words;
   struct oldify_state st = {0};

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -108,7 +108,8 @@ void caml_garbage_collection()
     alloc_bsize = whsize * sizeof(value);
 
     /* Put the young pointer back to what is was before our tiggering allocation */
-    Caml_state->young_ptr += alloc_bsize;
+    Caml_state->young_ptr = (value *)((uintnat)Caml_state->young_ptr
+				      + alloc_bsize);
 
     /* When caml_garbage_collection returns, we assume there is enough space in
       the minor heap for the triggering allocation. Due to finalisers in the
@@ -118,10 +119,12 @@ void caml_garbage_collection()
     do {
       caml_handle_gc_interrupt();
       caml_raise_if_exception(caml_process_pending_signals_exn());
-    } while( Caml_state->young_ptr - alloc_bsize <= (char*)Caml_state->young_limit );
+    } while( (uintnat)Caml_state->young_ptr - alloc_bsize
+	     <= (uintnat)Caml_state->young_limit );
 
     /* Re-do the allocation: we now have enough space in the minor heap. */
-    Caml_state->young_ptr -= alloc_bsize;
+    Caml_state->young_ptr = (value *)((uintnat)Caml_state->young_ptr
+				      - alloc_bsize);
   }
 }
 


### PR DESCRIPTION
This PR attempts to fix #643 

In Multicore, `young_end`, `young_start` and `young_ptr` are `char *`, rather than `value *` as defined in `trunk`.

This can cause issues with external code relying on that fact to do any kind of pointer arithmetic.

This PR aligns OCaml Multicore to trunk.