### PR TITLE
systhreads: initialize thread_next_id to 0

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -106,7 +106,7 @@ static struct caml_thread_table thread_table[Max_domains];
 #define Tick_thread_id thread_table[Caml_state->id].tick_thread_id
 
 /* Identifier for next thread creation */
-static atomic_uintnat thread_next_id;
+static atomic_uintnat thread_next_id = 0;
 
 /* Forward declarations */
 


### PR DESCRIPTION
`thread_next_id` was not initialized properly.
This fixes an issue caught in Core's testsuite.