### PR TITLE
Core testsuite workflow

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,0 +1,32 @@
+name: core
+
+on:
+  push:
+  schedule:
+    - cron: '1 0 * * *'
+
+jobs:
+
+  build:
+    name: 'linux'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: 'ocaml-multicore/core'
+          ref: 'monorepo-0.14'
+
+      - name: OCaml
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 'ocaml-variants.4.12.0+domains' 
+          opam-depext: false
+          opam-repositories: |
+            default: https://github.com/ocaml/opam-repository.git
+
+      - run: opam monorepo lock
+
+      - run: opam monorepo pull
+
+      - run: opam exec -- dune runtest

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -24,8 +24,6 @@ jobs:
           opam-repositories: |
             default: https://github.com/ocaml/opam-repository.git
 
-      - run: opam monorepo lock
-
       - run: opam monorepo pull
 
       - run: opam exec -- dune runtest

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,9 +1,8 @@
 name: core
 
 on:
-  push:
   schedule:
-    - cron: '1 0 * * *'
+    - cron: '0 0 * * *'
 
 jobs:
 


### PR DESCRIPTION
This PR aims to implement a workflow to run Core's testsuite once a day.

The long run ideal would be to include in a matrix other pieces of Core's ecosystem (`async_unix`, `core_kernel`, to name a few) and to keep tab on those from within our CI environment, since running their testsuite is rather hard.

This follows @emillon's approach in #624 (thanks!), and the monorepo is a fork of his, hosted at `ocaml-multicore/core`.

This PR and monorepo will need updates once our rebase to 4.13 is done, and I will try to dig further into integrated more libraries in this run, when possible.

As such I will mark it as a draft for now.

Note that in Core's case, I included a fix for the `channel` layout assumption in bigstring, since this will be a required upstream change in the long run.