### PR TITLE
Fixups and housekeeping for testsuite/disabled file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -49,6 +49,7 @@ README*                  typo.missing-header
 api_docgen/*.mld                typo.missing-header
 api_docgen/alldoc.tex           typo.missing-header
 tools/mantis2gh_stripped.csv typo.missing-header
+testsuite/disabled       typo.missing-header
 
 *.adoc                   typo.long-line=may
 

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -46,15 +46,14 @@ tests/lib-unix/kill/'unix_kill.ml' with 1.2 (native)
 tests/lib-threads/'beat.ml' with 1.2 (native)
 tests/lib-threads/'beat.ml' with 1.1 (bytecode)
 
-# TODO: pr9971 broken in our systhread implmentation with debug build (#9971/#9973)
+# TODO: pr9971 broken in our systhread implmentation
+# with debug build (#9971/#9973)
 tests/lib-threads/'pr9971.ml' with 1.1 (bytecode)
 tests/lib-threads/'pr9971.ml' with 1.2 (native)
 
 # ocamldebug is broken (#34)
 tool-debugger
 
-# since promotion is based on minor heap size now, this test can no longer be correct
-tests/promotion/bigrecmod.ml
-
-# instrumented runtime test is not very useful (and broken on multicore.) (#9413)
+# instrumented runtime test is not very useful
+# (and broken on multicore.) (#9413)
 tests/instrumented-runtime/'main.ml' with 1.1 (native)


### PR DESCRIPTION
Some housekeeping for the testsuite/disabled file:
- remove unnecessary test/promotion in the testsuite/disabled file; 
- allow testsuite/disabled to pass check-typo without a license header; 
- fix up the 80char line check-typo problems with testsuite/disabled