### PR TITLE
testsuite: re-enable pr9971 test

### DIFF
--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -46,11 +46,6 @@ tests/lib-unix/kill/'unix_kill.ml' with 1.2 (native)
 tests/lib-threads/'beat.ml' with 1.2 (native)
 tests/lib-threads/'beat.ml' with 1.1 (bytecode)
 
-# TODO: pr9971 broken in our systhread implmentation
-# with debug build (#9971/#9973)
-tests/lib-threads/'pr9971.ml' with 1.1 (bytecode)
-tests/lib-threads/'pr9971.ml' with 1.2 (native)
-
 # ocamldebug is broken (#34)
 tool-debugger
 


### PR DESCRIPTION
I don't see any reasons why this would fail with the current state of systhreads, I had it run on my machine with debug runtime and couldn't get it to fail.
Let's just re-enable it.