### PR TITLE
remove noise from diff with upstream on typing/

### DIFF
--- a/typing/cmt2annot.ml
+++ b/typing/cmt2annot.ml
@@ -97,9 +97,8 @@ let rec iterator ~scope rebuild_env =
         bind_bindings body.exp_loc bindings
     | Texp_match (_, f1, _) ->
         bind_cases f1
-    | Texp_try (_, f1) ->
-        bind_cases f1
-    | Texp_function { cases = f; } ->
+    | Texp_function { cases = f; }
+    | Texp_try (_, f) ->
         bind_cases f
     | Texp_letmodule (_, modname, _, _, body ) ->
         Stypes.record (Stypes.An_ident

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -340,14 +340,14 @@ and expression i ppf x =
       line i ppf "Texp_apply\n";
       expression i ppf e;
       list i label_x_expression ppf l;
-  | Texp_match (e, l1, _partial) ->
+  | Texp_match (e, l, _partial) ->
       line i ppf "Texp_match\n";
       expression i ppf e;
-      list i case ppf l1;
-  | Texp_try (e, l1) ->
+      list i case ppf l;
+  | Texp_try (e, l) ->
       line i ppf "Texp_try\n";
       expression i ppf e;
-      list i case ppf l1;
+      list i case ppf l;
   | Texp_tuple (l) ->
       line i ppf "Texp_tuple\n";
       list i expression ppf l;

--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -756,7 +756,7 @@ let rec expression : Typedtree.expression -> term_judg =
       let case_env c m = fst (case c m) in
       join [
         expression e;
-        list case_env cases
+        list case_env cases;
       ]
     | Texp_override (pth, fields) ->
       (*

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -262,10 +262,10 @@ let expr sub x =
           List.map (sub.case sub) cases,
           p
         )
-    | Texp_try (exp, exn_cases) ->
+    | Texp_try (exp, cases) ->
         Texp_try (
           sub.expr sub exp,
-          List.map (sub.case sub) exn_cases
+          List.map (sub.case sub) cases
         )
     | Texp_tuple list ->
         Texp_tuple (List.map (sub.expr sub) list)
@@ -692,7 +692,7 @@ let case
   {
     c_lhs = sub.pat sub c_lhs;
     c_guard = Option.map (sub.expr sub) c_guard;
-    c_rhs = sub.expr sub c_rhs
+    c_rhs = sub.expr sub c_rhs;
   }
 
 let value_binding sub x =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -985,6 +985,7 @@ let transl_type_decl env rec_flag sdecl_list =
   (* Done *)
   (final_decls, final_env)
 
+(* Translating type extensions *)
 
 let transl_extension_constructor ~scope env type_path type_params
                                  typext_params priv sext =
@@ -1220,7 +1221,6 @@ let transl_type_extension extend env loc styext =
   Builtin_attributes.warning_scope styext.ptyext_attributes
     (fun () -> transl_type_extension extend env loc styext)
 
-(* Translate an exception declaration *)
 let transl_exception env sext =
   let scope = Ctype.create_scope () in
   reset_type_variables();
@@ -1256,7 +1256,6 @@ let transl_type_exception env t =
   {tyexn_constructor = contructor;
    tyexn_loc = t.ptyexn_loc;
    tyexn_attributes = t.ptyexn_attributes}, newenv
-
 
 
 type native_repr_attribute =

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -195,7 +195,6 @@ module Variance = struct
   let unknown = 7
   let full = 127
   let covariant = single May_pos lor single Pos lor single Inj
-  let contravariant = single May_neg lor single Neg lor single Inj
   let swap f1 f2 v =
     let v' = set f1 (mem f2 v) v in set f2 (mem f1 v) v'
   let conjugate v = swap May_pos May_neg (swap Pos Neg v)
@@ -395,6 +394,7 @@ and ext_status =
     Text_first                     (* first constructor of an extension *)
   | Text_next                      (* not first constructor of an extension *)
   | Text_exception                 (* an exception *)
+
 
 (* Constructor and record label descriptions inserted held in typing
    environments *)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -387,7 +387,6 @@ module Variance : sig
   val null : t               (* no occurrence *)
   val full : t               (* strictly invariant (all flags) *)
   val covariant : t          (* strictly covariant (May_pos, Pos and Inj) *)
-  val contravariant : t      (* strictly contravariant *)
   val unknown : t            (* allow everything, guarantee nothing *)
   val union  : t -> t -> t
   val inter  : t -> t -> t
@@ -600,6 +599,7 @@ and ext_status =
     Text_first                     (* first constructor in an extension *)
   | Text_next                      (* not first constructor in an extension *)
   | Text_exception
+
 
 (* Constructor and record label descriptions inserted held in typing
    environments *)


### PR DESCRIPTION
This PR squishes unnecessary diffs with upstream ocaml for `typing/`

Before this PR:
```bash
$ git diff --stat 6e053e0d -- typing/
 typing/cmt2annot.ml   |  5 +++--
 typing/predef.ml      |  7 +++++++
 typing/printtyped.ml  |  8 ++++----
 typing/rec_check.ml   |  2 +-
 typing/tast_mapper.ml |  8 ++++----
 typing/typecore.ml    | 65 +++++++++++++++++++++++++++++++++++++++++++++++++----------------
 typing/typecore.mli   |  2 ++
 typing/typedecl.ml    |  3 ++-
 typing/typedtree.ml   |  2 +-
 typing/typedtree.mli  |  2 +-
 typing/types.ml       |  2 +-
 typing/types.mli      |  2 +-
 12 files changed, 76 insertions(+), 32 deletions(-)
```
After this PR:
```bash
$ git diff --stat 6e053e0d -- typing/
 typing/predef.ml      |  7 +++++++
 typing/tast_mapper.ml |  2 +-
 typing/typecore.ml    | 10 +++++++++-
 typing/typecore.mli   |  2 ++
 typing/typedtree.ml   |  2 +-
 typing/typedtree.mli  |  2 +-
 6 files changed, 21 insertions(+), 4 deletions(-)
```
