### PR TITLE
Set thread names for domains

### DIFF
--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -318,6 +318,7 @@ static void * caml_thread_tick(void * arg)
   caml_init_domain_self(*domain_id);
   domain = Caml_state;
 
+  caml_domain_set_name(T("Tick"));
   while(! atomic_load_acq(&Tick_thread_stop)) {
     /* select() seems to be the most efficient way to suspend the
        thread for sub-second intervals */

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -498,6 +498,8 @@ static void * caml_thread_start(void * v)
 
   st_tls_set(Thread_key, th);
 
+  caml_domain_set_name(T("Domain"));
+
   st_masterlock_acquire(&Thread_main_lock);
   Current_thread = st_tls_get(Thread_key);
   caml_thread_restore_runtime_state();

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -95,6 +95,8 @@ int caml_global_barrier_num_domains();
 
 int caml_domain_is_terminating(void);
 
+void caml_domain_set_name(char_os*);
+
 #endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -498,6 +498,16 @@ extern int caml_snwprintf(wchar_t * buf,
 #define snprintf_os snprintf
 #endif
 
+/* platform dependent thread naming */
+#ifdef _WIN32
+extern int caml_thread_setname(const what_t* name);
+#else
+extern int caml_thread_setname(const char* name);
+#define caml_thread_setname_os caml_thread_setname
+#endif
+
+#define caml_thread_setname_os caml_thread_setname
+
 /* Macro used to deactivate thread and address sanitizers on some
    functions. */
 #define CAMLno_tsan

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -281,7 +281,8 @@ static void caml_wait_interrupt_serviced(struct interruptor* target)
 void caml_domain_set_name(char_os *name)
 {
   char thread_name[MAX_DOMAIN_NAME_LENGTH];
-  snprintf_os(thread_name, MAX_DOMAIN_NAME_LENGTH, T("%s%d"), name, Caml_state->id);
+  snprintf_os(thread_name, MAX_DOMAIN_NAME_LENGTH,
+              T("%s%d"), name, Caml_state->id);
   caml_thread_setname_os(thread_name);
 }
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -277,6 +277,14 @@ static void caml_wait_interrupt_serviced(struct interruptor* target)
   }
 }
 
+#define MAX_DOMAIN_NAME_LENGTH 16
+void caml_domain_set_name(char_os *name)
+{
+  char thread_name[MAX_DOMAIN_NAME_LENGTH];
+  snprintf_os(thread_name, MAX_DOMAIN_NAME_LENGTH, T("%s%d"), name, Caml_state->id);
+  caml_thread_setname_os(thread_name);
+}
+
 asize_t caml_norm_minor_heap_size (intnat wsize)
 {
   asize_t bs, max;
@@ -547,6 +555,7 @@ void caml_init_domains(uintnat minor_heap_wsz) {
   caml_init_signal_handling();
 
   CAML_EVENTLOG_INIT();
+  caml_domain_set_name(T("Domain"));
 }
 
 void caml_init_domain_self(int domain_id) {
@@ -595,6 +604,8 @@ static void* backup_thread_func(void* v)
 
   domain_self = di;
   SET_Caml_state((void*)(di->tls_area));
+
+  caml_domain_set_name(T("BackupThread"));
 
   CAML_EVENTLOG_IS_BACKUP_THREAD();
 
@@ -728,6 +739,7 @@ static void* domain_thread_func(void* v)
     install_backup_thread(domain_self);
     caml_gc_log("Domain starting (unique_id = %"ARCH_INTNAT_PRINTF_FORMAT"u)",
                 domain_self->interruptor.unique_id);
+    caml_domain_set_name(T("Domain"));
     caml_domain_start_hook();
     caml_callback(ml_values->callback, Val_unit);
     domain_terminate();
@@ -1304,4 +1316,17 @@ CAMLprim value caml_domain_dls_get(value unused)
 {
   CAMLnoalloc;
   return Caml_state->dls_root;
+}
+
+CAMLprim value caml_ml_domain_set_name(value name)
+{
+  CAMLparam1(name);
+  char_os* name_os;
+
+  if (caml_string_length(name) >= MAX_DOMAIN_NAME_LENGTH)
+    caml_invalid_argument("caml_ml_domain_set_name");
+  name_os = caml_stat_strdup_to_os(String_val(name));
+  caml_thread_setname_os(name_os);
+  caml_stat_free(name_os);
+  CAMLreturn(Val_unit);
 }

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -49,6 +49,7 @@
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #endif
+#include <pthread.h>
 #include "caml/fail.h"
 #include "caml/memory.h"
 #include "caml/misc.h"
@@ -432,5 +433,25 @@ int caml_num_rows_fd(int fd)
     return -1;
 #else
   return -1;
+#endif
+}
+
+int caml_thread_setname(const char* name)
+{
+#ifdef __APPLE__
+  pthread_setname_np(name);
+  return 0;
+#else
+#ifdef _GNU_SOURCE
+  int ret;
+  pthread_t self = pthread_self();
+
+  ret = pthread_setname_np(self, name);
+  if (ret == ERANGE)
+    return -1;
+  return 0;
+#else /* not glibc, not apple */
+  return 0;
+#endif
 #endif
 }

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1041,4 +1041,8 @@ CAMLexport clock_t caml_win32_clock(void)
   /* total in 100-nanosecond intervals (1e7 / CLOCKS_PER_SEC) */
   clocks_per_sec = INT64_LITERAL(10000000U) / (ULONGLONG)CLOCKS_PER_SEC;
   return (clock_t)(total / clocks_per_sec);
+
+int caml_thread_setname(wchar_t *name)
+{
+  return -1;
 }

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1041,6 +1041,7 @@ CAMLexport clock_t caml_win32_clock(void)
   /* total in 100-nanosecond intervals (1e7 / CLOCKS_PER_SEC) */
   clocks_per_sec = INT64_LITERAL(10000000U) / (ULONGLONG)CLOCKS_PER_SEC;
   return (clock_t)(total / clocks_per_sec);
+}
 
 int caml_thread_setname(wchar_t *name)
 {

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -203,3 +203,5 @@ let join { termination_mutex; state; _ } =
 let get_id { domain; _ } = domain
 
 let self () = Raw.self ()
+
+external set_name : string -> unit = "caml_ml_domain_set_name"

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -55,6 +55,11 @@ val cpu_relax : unit -> unit
 (** If busy-waiting, calling cpu_relax () between iterations
     will improve performance on some CPU architectures *)
 
+val set_name : string -> unit
+(** [set_name s] set the domain's thread name to [s]. [s] should not be longer
+    than 15 characters. If [s] is longer than 15 characters,
+    raise Invalid_argument. *)
+
 module DLS : sig
 (** Domain-local Storage *)
 


### PR DESCRIPTION
This PR implements thread naming for Multicore OCaml various units.

It exposes as well an interface to allow one user to name Domains and Threads differently.

While this is working, I am unsure the macros logic is robust enough to work on anything beyond common Unixes and such. I tested it successfully on Linux and MacOS. The Windows implementation is left undone.

There's also a specific bit I solved by setting a 16 char restriction on the size of the name of a thread.
(following [glibc's](https://man7.org/linux/man-pages/man3/pthread_setname_np.3.html) restrictions.)
This may be a bit too restrictive on other platforms where such a restriction may not exist?

One last thing, maybe this function should not sit in `Domain` (since it can be used for both systhreads and domains), but I think having a dedicated module for this does not sound great.
(or maybe it could fit into the future `ThreadLocal` module)

(extra check-typo pass on unix.c and win32.c)