### PR TITLE
Fix C++ namespace pollution reported in #671

### DIFF
--- a/runtime/caml/camlatomic.h
+++ b/runtime/caml/camlatomic.h
@@ -35,6 +35,11 @@ extern "C++" {
 #define ATOMIC_UINTNAT_INIT(x) (x)
 typedef std::atomic<uintnat> atomic_uintnat;
 typedef std::atomic<intnat> atomic_intnat;
+using std::memory_order_relaxed;
+using std::memory_order_acquire;
+using std::memory_order_release;
+using std::memory_order_acq_rel;
+using std::memory_order_seq_cst;
 }
 
 #elif defined(HAS_STDATOMIC_H)

--- a/runtime/caml/camlatomic.h
+++ b/runtime/caml/camlatomic.h
@@ -17,10 +17,9 @@
 
 extern "C++" {
 #include <atomic>
-using namespace std;
 #define ATOMIC_UINTNAT_INIT(x) (x)
-typedef atomic<uintnat> atomic_uintnat;
-typedef atomic<intnat> atomic_intnat;
+typedef std::atomic<uintnat> atomic_uintnat;
+typedef std::atomic<intnat> atomic_intnat;
 }
 
 #elif defined(HAS_STDATOMIC_H)

--- a/runtime/caml/camlatomic.h
+++ b/runtime/caml/camlatomic.h
@@ -1,3 +1,18 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*      KC Sivaramakrishnan, Indian Institute of Technology, Madras       */
+/*                Stephen Dolan, University of Cambridge                  */
+/*                                                                        */
+/*   Copyright 2018 Indian Institute of Technology, Madras                */
+/*   Copyright 2018 University of Cambridge                               */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
 #ifndef CAML_ATOMIC_H
 #define CAML_ATOMIC_H
 
@@ -50,7 +65,10 @@ typedef struct { intnat repr; } atomic_intnat;
 #define atomic_store_explicit(x, v, m) __atomic_store_n(&(x)->repr, (v), (m))
 #define atomic_store(x, v) atomic_store_explicit((x), (v), memory_order_seq_cst)
 #define atomic_compare_exchange_strong(x, oldv, newv) \
-  __atomic_compare_exchange_n(&(x)->repr, (oldv), (newv), 0, memory_order_seq_cst, memory_order_seq_cst)
+  __atomic_compare_exchange_n( \
+    &(x)->repr, \
+    (oldv), (newv), 0, \
+    memory_order_seq_cst, memory_order_seq_cst)
 #define atomic_exchange(x, newv) \
   __atomic_exchange_n(&(x)->repr, (newv), memory_order_seq_cst)
 #define atomic_fetch_add(x, n) \


### PR DESCRIPTION
I think this will fix the C++ namespace pollution (and some check-typo issues). 

Apologies, I didn't have a good way to test this one. @ygrek are you able to try this patch against what was originally giving you trouble?

Fixes #671.