### PR TITLE
align Bytes.unsafe_of_string / Bytes.unsafe_to_string to ocaml trunk

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -685,8 +685,7 @@ let rec comp_expr env exp sz cont =
         in
         comp_init env sz decl_size
       end
-  | Lprim((Pidentity | Pnop | Popaque |
-           Pbytes_to_string | Pbytes_of_string), [arg], _) ->
+  | Lprim((Pidentity | Pnop | Popaque), [arg], _) ->
       comp_expr env arg sz cont
   | Lprim(Pignore, [arg], _) ->
       comp_expr env arg sz (add_const_unit cont)


### PR DESCRIPTION
This PR aligns the `Pbytes_to_string | Pbytes_of_string` usage in `bytecomp/bytegen.ml` to upstream OCaml.

Fixes #668.