### PR TITLE
Fix 5.00 install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,7 @@ FLEXDLL_MANIFEST = default$(filter-out _i386,_$(ARCH)).manifest
 
 DOC_FILES=\
   Changes \
-  README.adoc \
+  README.stock.adoc \
   README.win32.adoc \
   LICENSE
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -164,7 +164,7 @@ ifneq "$(BYTECODE_SHARED_LIBRARIES)" ""
 	$(INSTALL_PROG) $(BYTECODE_SHARED_LIBRARIES) "$(INSTALL_LIBDIR)"
 endif
 	mkdir -p "$(INSTALL_INCDIR)"
-	$(INSTALL_DATA) caml/domain_state.tbl caml/byte_domain_state.tbl caml/*.h "$(INSTALL_INCDIR)"
+	$(INSTALL_DATA) caml/domain_state.tbl caml/*.h "$(INSTALL_INCDIR)"
 
 .PHONY: installopt
 installopt:

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -244,15 +244,21 @@ caml/jumptbl.h : caml/instruct.h
 	       -e '/^}/q' > $@
 
 # Avoid building due to GIT_HASH when it hasn't changed
-GIT_HASH: $(shell (git rev-parse --short HEAD || echo "<hash unavailable>") > GIT_HASH.new; \
-        cmp -s GIT_HASH GIT_HASH.new || echo GIT_HASH.new)
+GIT_HASH: $(shell (git rev-parse --short HEAD || \
+                   echo "<hash unavailable>") > GIT_HASH.new; \
+                  cmp -s GIT_HASH GIT_HASH.new || echo GIT_HASH.new)
 	cp $^ $@
 
-caml/version.h : $(ROOTDIR)/tools/make-version-header.sh $(ROOTDIR)/VERSION GIT_HASH
+caml/version.h : $(ROOTDIR)/tools/make-version-header.sh \
+    $(ROOTDIR)/VERSION GIT_HASH
 	$(ROOTDIR)/tools/make-version-header.sh $(ROOTDIR)/VERSION > $@
 	echo "#define OCAML_RUNTIME_BUILD_GIT_HASH \"`cat GIT_HASH`\"" >> $@
-	echo "#define OCAML_RUNTIME_BUILD_GIT_BRANCH \"`(git symbolic-ref -q --short HEAD || echo "<branch unavailable>")`\"" >> $@
-	echo "#define OCAML_RUNTIME_BUILD_GIT_TAG \"`(git describe --tags --exact-match || echo "<tag unavailable>")`\"" >> $@
+	echo "#define OCAML_RUNTIME_BUILD_GIT_BRANCH \"\
+	   `(git symbolic-ref -q --short HEAD || echo "<branch unavailable>")`\
+	   \"" >> $@
+	echo "#define OCAML_RUNTIME_BUILD_GIT_TAG \"\
+	   `(git describe --tags --exact-match || echo "<tag unavailable>")`\
+	   \"" >> $@
 
 # These are provided as a temporary shim to allow cross-compilation systems
 # to supply a host C compiler and different flags and a linking macro.


### PR DESCRIPTION
This PR fixes the embarrassment of `make install` failing to run clean with `5.00`.

Two problems have been fixed up:
- we no longer have `caml/byte_domain_state.tbl` so can't install it
- we have renamed `README.adoc` to `README.stock.adoc`

Fixes #674