### PR TITLE
Make domain state the same in bytecode and native mode

### DIFF
--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -35,7 +35,8 @@ DOMAIN_STATE(void*, exn_handler)
 /* Pointer into into the current stack */
 
 DOMAIN_STATE(struct c_stack_link*, c_stack)
-/* The C stack associated with this domain. Used by this domain to perform external calls. */
+/* The C stack associated with this domain.
+ * Used by this domain to perform external calls. */
 
 DOMAIN_STATE(struct stack_info**, stack_cache)
 /* This is a list of freelist buckets of stacks */
@@ -152,12 +153,10 @@ DOMAIN_STATE(void*, checking_pointer_pc)
 /* See major_gc.c */
 #endif
 
-#ifndef NATIVE_CODE
 DOMAIN_STATE(intnat, trap_sp_off)
 DOMAIN_STATE(intnat, trap_barrier_off)
 DOMAIN_STATE(struct caml_exception_context*, external_raise)
 /* Bytecode TLS vars, not used for native code */
-#endif
 
 DOMAIN_STATE(extra_params_area, extra_params)
 /* This member must occur last, because it is an array, not a scalar */


### PR DESCRIPTION
This PR makes `struct domain_state` the same in both bytecode and native code. 

In the past, there was a `caml/byte_domain_state.tbl` which separated the additional bytecode domain state variables from those needed in native mode. ocaml/ocaml#10595 introduced an `extra_params` variable that must be at the end of the structure. In the recent multicore rebase to latest trunk, the [merge was done](https://github.com/ocaml-multicore/ocaml-multicore/commit/5245572b9e3a7a44e21cab36d73daa60083992be) by moving the `byte_domain_state.tbl` inside `domain_state.tbl` and using an `#ifndef NATIVE_CODE` guard.

This PR attempts to simplify the situation by making the domain state structure identical in bytecode and native code. There is also a nagging concern that differing state tables could somehow be brittle for not a lot of gain.  