### PR TITLE
Remove caml_read_field

### DIFF
--- a/otherlibs/unix/cstringv.c
+++ b/otherlibs/unix/cstringv.c
@@ -23,8 +23,6 @@
 
 char_os ** cstringvect(value arg, char * cmdname)
 {
-  CAMLparam1 (arg);
-  CAMLlocal1 (x);
   char_os ** res;
   mlsize_t size, i;
 
@@ -33,12 +31,10 @@ char_os ** cstringvect(value arg, char * cmdname)
     if (! caml_string_is_c_safe(Field(arg, i)))
       unix_error(EINVAL, cmdname, Field(arg, i));
   res = (char_os **) caml_stat_alloc((size + 1) * sizeof(char_os *));
-  for (i = 0; i < size; i++) {
-    caml_read_field(arg, i, &x);
-    res[i] = caml_stat_strdup_to_os(String_val(x));
-  }
+  for (i = 0; i < size; i++)
+    res[i] = caml_stat_strdup_to_os(String_val(Field(arg, i)));
   res[size] = NULL;
-  CAMLreturnT (char**, res);
+  return res;
 }
 
 void cstringvect_free(char_os ** v)

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -68,7 +68,8 @@ CAMLprim value caml_floatarray_get(value array, value index)
   if (idx < 0 || idx >= Wosize_val(array) / Double_wosize)
     caml_array_bound_error();
   d = Double_flat_field(array, idx);
-  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt_no_async_exceptions(); });
+  Alloc_small(res, Double_wosize, Double_tag,
+    { caml_handle_gc_interrupt_no_async_exceptions(); });
   Store_double_val(res, d);
   return res;
 }
@@ -121,13 +122,14 @@ CAMLprim value caml_array_set(value array, value index, value newval)
 /* [ floatarray -> int -> float ] */
 CAMLprim value caml_floatarray_unsafe_get(value array, value index)
 {
-  intnat idx = Long_val (index);
+  intnat idx = Long_val(index);
   double d;
   value res;
 
   CAMLassert (Tag_val(array) == Double_array_tag);
   d = Double_flat_field(array, idx);
-  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt_no_async_exceptions(); });
+  Alloc_small(res, Double_wosize, Double_tag,
+    { caml_handle_gc_interrupt_no_async_exceptions(); });
   Store_double_val(res, d);
   return res;
 }
@@ -183,7 +185,8 @@ CAMLprim value caml_floatarray_create(value len)
     if (wosize == 0)
       return Atom(0);
     else
-      Alloc_small (result, wosize, Double_array_tag, { caml_handle_gc_interrupt_no_async_exceptions(); });
+      Alloc_small (result, wosize, Double_array_tag,
+        { caml_handle_gc_interrupt_no_async_exceptions(); });
   }else if (wosize > Max_wosize)
     caml_invalid_argument("Float.Array.create");
   else {
@@ -266,13 +269,13 @@ CAMLprim value caml_make_array(value init)
 #ifdef FLAT_FLOAT_ARRAY
   CAMLparam1 (init);
   mlsize_t wsize, size, i;
-  CAMLlocal3 (v, res, x);
+  CAMLlocal2 (v, res);
 
   size = Wosize_val(init);
   if (size == 0) {
     CAMLreturn (init);
   } else {
-    caml_read_field(init, 0, &v);
+    v = Field(init, 0);
     if (Is_long(v)
         || Tag_val(v) != Double_tag) {
       CAMLreturn (init);
@@ -280,8 +283,8 @@ CAMLprim value caml_make_array(value init)
       wsize = size * Double_wosize;
       res = caml_alloc(wsize, Double_array_tag);
       for (i = 0; i < size; i++) {
-        caml_read_field(init, i, &x);
-        Store_double_flat_field(res, i, Double_val(x));
+        double d = Double_val(Field(init, i));
+        Store_double_flat_field(res, i, d);
       }
       CAMLreturn (res);
     }

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -215,7 +215,7 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
 /* Is_young(val) is true iff val is in the reserved area for minor heaps */
 
 #define Is_young(val) \
-  (CAMLassert (Is_block (val)),		   \
+  (CAMLassert (Is_block (val)), \
    (char *)(val) < (char *)caml_minor_heaps_end && \
    (char *)(val) > (char *)caml_minor_heaps_base)
 
@@ -231,7 +231,8 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
 /* Forward_tag: forwarding pointer that the GC may silently shortcut.
    See stdlib/lazy.ml. */
 #define Forward_tag 250
-#define Forward_val(v) Field(v, 0) /* FIXME: not immutable once shortcutting is implemented */
+#define Forward_val(v) Field(v, 0)
+/* FIXME: not immutable once shortcutting is implemented */
 
 /* If tag == Infix_tag : an infix header inside a closure */
 /* Infix_tag must be odd so that the infix header is scanned as an integer */
@@ -438,14 +439,6 @@ CAMLextern value caml_atom(tag_t);
 #define Is_some(v) Is_block(v)
 
 CAMLextern value caml_set_oo_id(value obj);
-
-Caml_inline void caml_read_field(value x, intnat i, value* ret) {
-  value v;
-  Assert (Hd_val(x));
-  /* See Note [MM] in memory.c */
-  v = atomic_load_explicit(&Op_atomic_val(x)[i], memory_order_relaxed);
-  *ret = v;
-}
 
 #define Int_field(x, i) Int_val(Field(x, i))
 #define Long_field(x, i) Long_val(Field(x, i))

--- a/runtime/hash.c
+++ b/runtime/hash.c
@@ -241,7 +241,8 @@ CAMLprim value caml_hash(value count, value limit, value seed, value obj)
         h = 42;
         break;
       case Cont_tag:
-        /* All continuations hash to the same value, since we have no idea how to distinguish them. */
+        /* All continuations hash to the same value,
+           since we have no idea how to distinguish them. */
         h = 42;
         break;
       case Forward_tag:
@@ -273,7 +274,7 @@ CAMLprim value caml_hash(value count, value limit, value seed, value obj)
         /* Copy fields into queue, not exceeding the total size [sz] */
         for (i = 0, len = Wosize_val(v); i < len; i++) {
           if (wr >= sz) break;
-          caml_read_field(v, i, &queue[wr++]);
+          queue[wr++] = Field(v, i);
         }
         break;
       }

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -116,8 +116,7 @@ static char * token_name(char * names, int number)
 
 static void print_token(struct parser_tables *tables, int state, value tok)
 {
-  CAMLparam1 (tok);
-  CAMLlocal1 (v);
+  value v;
 
   if (Is_long(tok)) {
     fprintf(stderr, "State %d: read token %s\n",
@@ -125,7 +124,7 @@ static void print_token(struct parser_tables *tables, int state, value tok)
   } else {
     fprintf(stderr, "State %d: read token %s(",
             state, token_name(tables->names_block, Tag_val(tok)));
-    caml_read_field(tok, 0, &v);
+    v = Field(tok, 0);
     if (Is_long(v))
       fprintf(stderr, "%" ARCH_INTNAT_PRINTF_FORMAT "d", Long_val(v));
     else if (Tag_val(v) == String_tag)
@@ -136,7 +135,6 @@ static void print_token(struct parser_tables *tables, int state, value tok)
       fprintf(stderr, "_");
     fprintf(stderr, ")\n");
   }
-  CAMLreturn0;
 }
 
 static int trace()


### PR DESCRIPTION
This PR removes `caml_read_field` as the existing `Field` does everything you will need. It also allows us to revert to the upstream implementation in many places where previously we used `caml_read_field`. 

(there are some line length check-typo cleanups embedded in here)