### PR TITLE
Revert to ocaml/trunk versions of otherlibs/unix

### DIFF
--- a/otherlibs/unix/accept.c
+++ b/otherlibs/unix/accept.c
@@ -27,9 +27,9 @@
 
 CAMLprim value unix_accept(value cloexec, value sock)
 {
-  CAMLparam1(sock);
-  CAMLlocal1(a);
   int retcode;
+  value res;
+  value a;
   union sock_addr_union addr;
   socklen_param_type addr_len;
   int clo = unix_cloexec_p(cloexec);
@@ -48,7 +48,12 @@ CAMLprim value unix_accept(value cloexec, value sock)
   if (clo) unix_set_cloexec(retcode, "accept", Nothing);
 #endif
   a = alloc_sockaddr(&addr, addr_len, retcode);
-  CAMLreturn (caml_alloc_2(0, Val_int(retcode), a));
+  Begin_root (a);
+    res = caml_alloc_small(2, 0);
+    Field(res, 0) = Val_int(retcode);
+    Field(res, 1) = a;
+  End_roots();
+  return res;
 }
 
 #else

--- a/otherlibs/unix/getaddrinfo.c
+++ b/otherlibs/unix/getaddrinfo.c
@@ -46,12 +46,12 @@ static value convert_addrinfo(struct addrinfo * a)
   memcpy(&sa.s_gen, a->ai_addr, len);
   vaddr = alloc_sockaddr(&sa, len, -1);
   vcanonname = caml_copy_string(a->ai_canonname == NULL ? "" : a->ai_canonname);
-  vres = caml_alloc_5(0,
-    cst_to_constr(a->ai_family, socket_domain_table, 3, 0),
-    cst_to_constr(a->ai_socktype, socket_type_table, 4, 0),
-    Val_int(a->ai_protocol),
-    vaddr,
-    vcanonname);
+  vres = caml_alloc_small(5, 0);
+  Field(vres, 0) = cst_to_constr(a->ai_family, socket_domain_table, 3, 0);
+  Field(vres, 1) = cst_to_constr(a->ai_socktype, socket_type_table, 4, 0);
+  Field(vres, 2) = Val_int(a->ai_protocol);
+  Field(vres, 3) = vaddr;
+  Field(vres, 4) = vcanonname;
   CAMLreturn(vres);
 }
 
@@ -117,7 +117,9 @@ CAMLprim value unix_getaddrinfo(value vnode, value vserv, value vopts)
   if (retcode == 0) {
     for (r = res; r != NULL; r = r->ai_next) {
       e = convert_addrinfo(r);
-      v = caml_alloc_2(0, e, vres);
+      v = caml_alloc_small(2, 0);
+      Field(v, 0) = e;
+      Field(v, 1) = vres;
       vres = v;
     }
     freeaddrinfo(res);

--- a/otherlibs/unix/getgr.c
+++ b/otherlibs/unix/getgr.c
@@ -33,8 +33,11 @@ static value alloc_group_entry(struct group *entry)
        hence this workaround */
     pass = caml_copy_string(entry->gr_passwd ? entry->gr_passwd : "");
     mem = caml_copy_string_array((const char**)entry->gr_mem);
-    res = caml_alloc_4(0, name, pass,
-                       Val_int(entry->gr_gid), mem);
+    res = caml_alloc_small(4, 0);
+    Field(res,0) = name;
+    Field(res,1) = pass;
+    Field(res,2) = Val_int(entry->gr_gid);
+    Field(res,3) = mem;
   End_roots();
   return res;
 }

--- a/otherlibs/unix/getgroups.c
+++ b/otherlibs/unix/getgroups.c
@@ -14,7 +14,6 @@
 /**************************************************************************/
 
 #include <caml/mlvalues.h>
-#include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 

--- a/otherlibs/unix/getnameinfo.c
+++ b/otherlibs/unix/getnameinfo.c
@@ -54,7 +54,9 @@ CAMLprim value unix_getnameinfo(value vaddr, value vopts)
   if (retcode != 0) caml_raise_not_found();
   vhost = caml_copy_string(host);
   vserv = caml_copy_string(serv);
-  vres = caml_alloc_2(0, vhost, vserv);
+  vres = caml_alloc_small(2, 0);
+  Field(vres, 0) = vhost;
+  Field(vres, 1) = vserv;
   CAMLreturn(vres);
 }
 

--- a/otherlibs/unix/getproto.c
+++ b/otherlibs/unix/getproto.c
@@ -33,8 +33,10 @@ static value alloc_proto_entry(struct protoent *entry)
   Begin_roots2 (name, aliases);
     name = caml_copy_string(entry->p_name);
     aliases = caml_copy_string_array((const char**)entry->p_aliases);
-    res = caml_alloc_3(0, name, aliases,
-                       Val_int(entry->p_proto));
+    res = caml_alloc_small(3, 0);
+    Field(res,0) = name;
+    Field(res,1) = aliases;
+    Field(res,2) = Val_int(entry->p_proto);
   End_roots();
   return res;
 }

--- a/otherlibs/unix/getpw.c
+++ b/otherlibs/unix/getpw.c
@@ -37,14 +37,14 @@ static value alloc_passwd_entry(struct passwd *entry)
 #endif
     dir = caml_copy_string(entry->pw_dir);
     shell = caml_copy_string(entry->pw_shell);
-    res = caml_alloc_7(0,
-      name,
-      passwd,
-      Val_int(entry->pw_uid),
-      Val_int(entry->pw_gid),
-      gecos,
-      dir,
-      shell);
+    res = caml_alloc_small(7, 0);
+    Field(res,0) = name;
+    Field(res,1) = passwd;
+    Field(res,2) = Val_int(entry->pw_uid);
+    Field(res,3) = Val_int(entry->pw_gid);
+    Field(res,4) = gecos;
+    Field(res,5) = dir;
+    Field(res,6) = shell;
   End_roots();
   return res;
 }

--- a/otherlibs/unix/getserv.c
+++ b/otherlibs/unix/getserv.c
@@ -38,11 +38,11 @@ static value alloc_service_entry(struct servent *entry)
     name = caml_copy_string(entry->s_name);
     aliases = caml_copy_string_array((const char**)entry->s_aliases);
     proto = caml_copy_string(entry->s_proto);
-    res = caml_alloc_4(0,
-      name,
-      aliases,
-      Val_int(ntohs(entry->s_port)),
-      proto);
+    res = caml_alloc_small(4, 0);
+    Field(res,0) = name;
+    Field(res,1) = aliases;
+    Field(res,2) = Val_int(ntohs(entry->s_port));
+    Field(res,3) = proto;
   End_roots();
   return res;
 }

--- a/otherlibs/unix/gmtime.c
+++ b/otherlibs/unix/gmtime.c
@@ -24,16 +24,16 @@
 static value alloc_tm(struct tm *tm)
 {
   value res;
-  res = caml_alloc_9(0,
-    Val_int(tm->tm_sec),
-    Val_int(tm->tm_min),
-    Val_int(tm->tm_hour),
-    Val_int(tm->tm_mday),
-    Val_int(tm->tm_mon),
-    Val_int(tm->tm_year),
-    Val_int(tm->tm_wday),
-    Val_int(tm->tm_yday),
-    tm->tm_isdst ? Val_true : Val_false);
+  res = caml_alloc_small(9, 0);
+  Field(res,0) = Val_int(tm->tm_sec);
+  Field(res,1) = Val_int(tm->tm_min);
+  Field(res,2) = Val_int(tm->tm_hour);
+  Field(res,3) = Val_int(tm->tm_mday);
+  Field(res,4) = Val_int(tm->tm_mon);
+  Field(res,5) = Val_int(tm->tm_year);
+  Field(res,6) = Val_int(tm->tm_wday);
+  Field(res,7) = Val_int(tm->tm_yday);
+  Field(res,8) = tm->tm_isdst ? Val_true : Val_false;
   return res;
 }
 
@@ -67,20 +67,22 @@ CAMLprim value unix_mktime(value t)
   value tmval = Val_unit, clkval = Val_unit;
 
   Begin_roots2(tmval, clkval);
-    tm.tm_sec = Int_field(t, 0);
-    tm.tm_min = Int_field(t, 1);
-    tm.tm_hour = Int_field(t, 2);
-    tm.tm_mday = Int_field(t, 3);
-    tm.tm_mon = Int_field(t, 4);
-    tm.tm_year = Int_field(t, 5);
-    tm.tm_wday = Int_field(t, 6);
-    tm.tm_yday = Int_field(t, 7);
+    tm.tm_sec = Int_val(Field(t, 0));
+    tm.tm_min = Int_val(Field(t, 1));
+    tm.tm_hour = Int_val(Field(t, 2));
+    tm.tm_mday = Int_val(Field(t, 3));
+    tm.tm_mon = Int_val(Field(t, 4));
+    tm.tm_year = Int_val(Field(t, 5));
+    tm.tm_wday = Int_val(Field(t, 6));
+    tm.tm_yday = Int_val(Field(t, 7));
     tm.tm_isdst = -1; /* tm.tm_isdst = Bool_val(Field(t, 8)); */
     clock = mktime(&tm);
     if (clock == (time_t) -1) unix_error(ERANGE, "mktime", Nothing);
     tmval = alloc_tm(&tm);
     clkval = caml_copy_double((double) clock);
-    res = caml_alloc_2(0, clkval, tmval);
+    res = caml_alloc_small(2, 0);
+    Field(res, 0) = clkval;
+    Field(res, 1) = tmval;
   End_roots ();
   return res;
 }

--- a/otherlibs/unix/mmap.c
+++ b/otherlibs/unix/mmap.c
@@ -114,7 +114,7 @@ CAMLprim value caml_unix_map_file(value vfd, value vkind, value vlayout,
   if (num_dims < 1 || num_dims > CAML_BA_MAX_NUM_DIMS)
     caml_invalid_argument("Unix.map_file: bad number of dimensions");
   for (i = 0; i < num_dims; i++) {
-    dim[i] = Long_field(vdim, i);
+    dim[i] = Long_val(Field(vdim, i));
     if (dim[i] == -1 && i == major_dim) continue;
     if (dim[i] < 0)
       caml_invalid_argument("Unix.map_file: negative dimension");

--- a/otherlibs/unix/nanosecond_stat.h
+++ b/otherlibs/unix/nanosecond_stat.h
@@ -1,15 +1,17 @@
-/***********************************************************************/
-/*                                                                     */
-/*                                OCaml                                */
-/*                                                                     */
-/*                 Jeremie Dimino, Jane Street Group, LLC              */
-/*                                                                     */
-/*  Copyright 2015 Institut National de Recherche en Informatique et   */
-/*  en Automatique.  All rights reserved.  This file is distributed    */
-/*  under the terms of the GNU Library General Public License, with    */
-/*  the special exception on linking described in file ../../LICENSE.  */
-/*                                                                     */
-/***********************************************************************/
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*                  Jeremie Dimino, Jane Street Group, LLC                */
+/*                                                                        */
+/*   Copyright 2015 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
 
 /* This file is used by the configure test program nanosecond_stat.c
    and stat.c in this directory */

--- a/otherlibs/unix/pipe.c
+++ b/otherlibs/unix/pipe.c
@@ -33,8 +33,8 @@ CAMLprim value unix_pipe(value cloexec, value vunit)
     unix_set_cloexec(fd[1], "pipe", Nothing);
   }
 #endif
-  res = caml_alloc_2(0,
-    Val_int(fd[0]),
-    Val_int(fd[1]));
+  res = caml_alloc_small(2, 0);
+  Field(res, 0) = Val_int(fd[0]);
+  Field(res, 1) = Val_int(fd[1]);
   return res;
 }

--- a/otherlibs/unix/select.c
+++ b/otherlibs/unix/select.c
@@ -36,7 +36,7 @@ static int fdlist_to_fdset(value fdlist, fd_set *fdset, int *maxfd)
   value l;
   FD_ZERO(fdset);
   for (l = fdlist; l != Val_int(0); l = Field(l, 1)) {
-    long fd = Long_field(l, 0);
+    long fd = Long_val(Field(l, 0));
     /* PR#5563: harden against bad fds */
     if (fd < 0 || fd >= FD_SETSIZE) return -1;
     FD_SET((int) fd, fdset);
@@ -54,9 +54,9 @@ static value fdset_to_fdlist(value fdlist, fd_set *fdset)
     for (l = fdlist; l != Val_int(0); l = Field(l, 1)) {
       int fd = Int_val(Field(l, 0));
       if (FD_ISSET(fd, fdset)) {
-        value newres = caml_alloc_2(0,
-          Val_int(fd),
-          res);
+        value newres = caml_alloc_small(2, 0);
+        Field(newres, 0) = Val_int(fd);
+        Field(newres, 1) = res;
         res = newres;
       }
     }
@@ -97,10 +97,10 @@ CAMLprim value unix_select(value readfds, value writefds, value exceptfds,
     readfds = fdset_to_fdlist(readfds, &read);
     writefds = fdset_to_fdlist(writefds, &write);
     exceptfds = fdset_to_fdlist(exceptfds, &except);
-    res = caml_alloc_3(0,
-      readfds,
-      writefds,
-      exceptfds);
+    res = caml_alloc_small(3, 0);
+    Field(res, 0) = readfds;
+    Field(res, 1) = writefds;
+    Field(res, 2) = exceptfds;
   End_roots();
   return res;
 }

--- a/otherlibs/unix/sendrecv.c
+++ b/otherlibs/unix/sendrecv.c
@@ -71,9 +71,9 @@ CAMLprim value unix_recvfrom(value sock, value buff, value ofs, value len,
     if (ret == -1) uerror("recvfrom", Nothing);
     memmove (&Byte(buff, Long_val(ofs)), iobuf, ret);
     adr = alloc_sockaddr(&addr, addr_len, -1);
-    res = caml_alloc_2(0,
-      Val_int(ret),
-      adr);
+    res = caml_alloc_small(2, 0);
+    Field(res, 0) = Val_int(ret);
+    Field(res, 1) = adr;
   End_roots();
   return res;
 }

--- a/otherlibs/unix/setgroups.c
+++ b/otherlibs/unix/setgroups.c
@@ -36,7 +36,7 @@ CAMLprim value unix_setgroups(value groups)
 
   size = Wosize_val(groups);
   gidset = (gid_t *) caml_stat_alloc(size * sizeof(gid_t));
-  for (i = 0; i < size; i++) gidset[i] = Int_field(groups, i);
+  for (i = 0; i < size; i++) gidset[i] = Int_val(Field(groups, i));
 
   n = setgroups(size, gidset);
 

--- a/otherlibs/unix/socketaddr.c
+++ b/otherlibs/unix/socketaddr.c
@@ -145,9 +145,9 @@ value alloc_sockaddr(union sock_addr_union * adr /*in*/,
   case AF_INET:
     { value a = alloc_inet_addr(&adr->s_inet.sin_addr);
       Begin_root (a);
-        res = caml_alloc_2(1,
-          a,
-          Val_int(ntohs(adr->s_inet.sin_port)));
+        res = caml_alloc_small(2, 1);
+        Field(res,0) = a;
+        Field(res,1) = Val_int(ntohs(adr->s_inet.sin_port));
       End_roots();
       break;
     }
@@ -155,9 +155,9 @@ value alloc_sockaddr(union sock_addr_union * adr /*in*/,
   case AF_INET6:
     { value a = alloc_inet6_addr(&adr->s_inet6.sin6_addr);
       Begin_root (a);
-        res = caml_alloc_2(1,
-          a,
-          Val_int(ntohs(adr->s_inet6.sin6_port)));
+        res = caml_alloc_small(2, 1);
+        Field(res,0) = a;
+        Field(res,1) = Val_int(ntohs(adr->s_inet6.sin6_port));
       End_roots();
       break;
     }

--- a/otherlibs/unix/socketpair.c
+++ b/otherlibs/unix/socketpair.c
@@ -42,9 +42,9 @@ CAMLprim value unix_socketpair(value cloexec, value domain,
     unix_set_cloexec(sv[1], "socketpair", Nothing);
   }
 #endif
-  res = caml_alloc_2(0,
-    Val_int(sv[0]),
-    Val_int(sv[1]));
+  res = caml_alloc_small(2, 0);
+  Field(res,0) = Val_int(sv[0]);
+  Field(res,1) = Val_int(sv[1]);
   return res;
 }
 

--- a/otherlibs/unix/stat.c
+++ b/otherlibs/unix/stat.c
@@ -80,7 +80,7 @@ static value stat_aux(int use_64, struct stat *buf)
   ctime = caml_copy_double(stat_timestamp(buf->st_ctime, NSEC(buf, c)));
   #undef NSEC
   offset = use_64 ? Val_file_offset(buf->st_size) : Val_int (buf->st_size);
-  v = caml_alloc(12, 0);
+  v = caml_alloc_small(12, 0);
   Field (v, 0) = Val_int (buf->st_dev);
   Field (v, 1) = Val_int (buf->st_ino);
   Field (v, 2) = cst_to_constr(buf->st_mode & S_IFMT, file_kind_table,

--- a/otherlibs/unix/unixsupport.c
+++ b/otherlibs/unix/unixsupport.c
@@ -266,7 +266,8 @@ value unix_error_of_code (int errcode)
   errconstr =
       cst_to_constr(errcode, error_table, sizeof(error_table)/sizeof(int), -1);
   if (errconstr == Val_int(-1)) {
-    err = caml_alloc_1(0, Val_int(errcode));
+    err = caml_alloc_small(1, 0);
+    Field(err, 0) = Val_int(errcode);
   } else {
     err = errconstr;
   }
@@ -276,7 +277,7 @@ value unix_error_of_code (int errcode)
 int code_of_unix_error (value error)
 {
   if (Is_block(error)) {
-    return Int_field(error, 0);
+    return Int_val(Field(error, 0));
   } else {
     return error_table[Int_val(error)];
   }
@@ -285,22 +286,22 @@ int code_of_unix_error (value error)
 void unix_error(int errcode, const char *cmdname, value cmdarg)
 {
   value res;
+  const value * unix_error_exn;
   value name = Val_unit, err = Val_unit, arg = Val_unit;
-  const value* unix_error_exn;
 
   Begin_roots3 (name, err, arg);
     arg = cmdarg == Nothing ? caml_copy_string("") : cmdarg;
     name = caml_copy_string(cmdname);
     err = unix_error_of_code (errcode);
     unix_error_exn = caml_named_value("Unix.Unix_error");
-    if (!unix_error_exn)
+    if (unix_error_exn == NULL)
       caml_invalid_argument("Exception Unix.Unix_error not initialized,"
-                            " please link unix.cma");
-    res = caml_alloc_4(0,
-      *unix_error_exn,
-      err,
-      name,
-      arg);
+                       " please link unix.cma");
+    res = caml_alloc_small(4, 0);
+    Field(res, 0) = *unix_error_exn;
+    Field(res, 1) = err;
+    Field(res, 2) = name;
+    Field(res, 3) = arg;
   End_roots();
   caml_raise(res);
 }

--- a/otherlibs/unix/unixsupport.h
+++ b/otherlibs/unix/unixsupport.h
@@ -41,7 +41,7 @@ extern void caml_unix_check_path(value path, const char * cmdname);
 
 #define UNIX_BUFFER_SIZE 65536
 
-#define DIR_Val(v) *((DIR **) Data_abstract_val(v))
+#define DIR_Val(v) *((DIR **) &Field(v, 0))
 
 extern char ** cstringvect(value arg, char * cmdname);
 extern void cstringvect_free(char **);

--- a/otherlibs/unix/wait.c
+++ b/otherlibs/unix/wait.c
@@ -41,24 +41,29 @@
 
 static value alloc_process_status(int pid, int status)
 {
-  value st;
+  value st, res;
 
   // status is undefined when pid is zero so we set a default value.
   if (pid == 0) status = 0;
 
   if (WIFEXITED(status)) {
-    st = caml_alloc_1(TAG_WEXITED,
-                      Val_int(WEXITSTATUS(status)));
+    st = caml_alloc_small(1, TAG_WEXITED);
+    Field(st, 0) = Val_int(WEXITSTATUS(status));
   }
   else if (WIFSTOPPED(status)) {
-    st = caml_alloc_1(TAG_WSTOPPED,
-                      Val_int(caml_rev_convert_signal_number(WSTOPSIG(status))));
+    st = caml_alloc_small(1, TAG_WSTOPPED);
+    Field(st, 0) = Val_int(caml_rev_convert_signal_number(WSTOPSIG(status)));
   }
   else {
-    st = caml_alloc_1(TAG_WSIGNALED,
-                      Val_int(caml_rev_convert_signal_number(WTERMSIG(status))));
+    st = caml_alloc_small(1, TAG_WSIGNALED);
+    Field(st, 0) = Val_int(caml_rev_convert_signal_number(WTERMSIG(status)));
   }
-  return caml_alloc_2(0, Val_int(pid), st);
+  Begin_root (st);
+    res = caml_alloc_small(2, 0);
+    Field(res, 0) = Val_int(pid);
+    Field(res, 1) = st;
+  End_roots();
+  return res;
 }
 
 CAMLprim value unix_wait(value unit)


### PR DESCRIPTION
This PR reverts to ocaml/trunk versions of files in `otherlibs/unix` where possible.

There are two places to note:
- `unixsupport.c` we move the `unix_error_exn` to the stack from a global
- `cstringv.c` is handled in #679 where `caml_read_field` is removed

Otherwise all the other changes are a straight take of the file from upstream. 