### PR TITLE
Better signal handling in systhreads

### DIFF
--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -387,7 +387,8 @@ static value st_encode_sigset(sigset_t * set)
     for (i = 1; i < NSIG; i++)
       if (sigismember(set, i) > 0) {
         value newcons = caml_alloc_small(2, 0);
-        caml_modify(&Field(newcons, 0), Val_int(caml_rev_convert_signal_number(i)));
+        caml_modify(&Field(newcons, 0),
+		    Val_int(caml_rev_convert_signal_number(i)));
         caml_modify(&Field(newcons, 1), res);
         res = newcons;
       }

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -322,6 +322,11 @@ static void * caml_thread_tick(void * arg)
   caml_domain_state *domain;
   uintnat *domain_id = (uintnat *) arg;
   struct timeval timeout;
+  sigset_t mask;
+
+  /* Block all signals so that we don't try to execute an OCaml signal handler*/
+  sigfillset(&mask);
+  pthread_sigmask(SIG_BLOCK, &mask, NULL);
 
   caml_init_domain_self(*domain_id);
   domain = Caml_state;

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -388,7 +388,7 @@ static value st_encode_sigset(sigset_t * set)
       if (sigismember(set, i) > 0) {
         value newcons = caml_alloc_small(2, 0);
         caml_modify(&Field(newcons, 0),
-		    Val_int(caml_rev_convert_signal_number(i)));
+                    Val_int(caml_rev_convert_signal_number(i)));
         caml_modify(&Field(newcons, 1), res);
         res = newcons;
       }

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -713,10 +713,12 @@ CAMLprim value caml_thread_yield(value unit)        /* ML */
 {
   if (atomic_load_acq(&Thread_main_lock.waiters) == 0) return Val_unit;
 
+  caml_raise_if_exception(caml_process_pending_signals_exn());
   caml_thread_save_runtime_state();
   st_thread_yield(&Thread_main_lock);
   Current_thread = st_tls_get(Thread_key);
   caml_thread_restore_runtime_state();
+  caml_raise_if_exception(caml_process_pending_signals_exn());
 
   return Val_unit;
 }


### PR DESCRIPTION
This PR lands improvements in the signal handling in systhreads.

These two are also to be found in trunk, and were responsible for the `threadsigmask` testcase failure on our CI. (see #683)

This made me notice that outside of the various style clashes and rebase cruft, and Multicore specific bits, there are some more bits missing from trunk's systhreads.

Some appears to be fixes, some improvements, and I will take care of importing anything missing in a subsequent PR to our systhreads port. (that will also address diff and typos issues in the process)