### PR TITLE
Add ability to discontinue with backtrace

### DIFF
--- a/stdlib/effectHandlers.mli
+++ b/stdlib/effectHandlers.mli
@@ -40,6 +40,15 @@ module Deep : sig
       @raise Invalid_argument if the continuation has already been
       resumed. *)
 
+  val discontinue_with_backtrace:
+    ('a, 'b) continuation -> exn -> Printexc.raw_backtrace -> 'b
+  (** [discontinue_with_backtrace k e bt] resumes the continuation [k] by
+      raising the exception [e] in [k] using [bt] as the origin for the
+      exception.
+
+      @raise Invalid_argument if the continuation has already been
+      resumed. *)
+
   type ('a,'b) handler =
     { retc: 'a -> 'b;
       exnc: exn -> 'b;
@@ -98,6 +107,17 @@ module Shallow : sig
 
       @raise Invalid_argument if the continuation has already been resumed.
    *)
+
+  val discontinue_with_backtrace :
+    ('a,'b) continuation -> exn -> Printexc.raw_backtrace ->
+    ('b,'c) handler -> 'c
+  (** [discontinue_with k e bt h] resumes the continuation [k] by raising the
+      exception [e] with the handler [h] using the raw backtrace [bt] as the
+      origin of the exception.
+
+      @raise Invalid_argument if the continuation has already been resumed.
+   *)
+
 
   external get_callstack :
     ('a,'b) continuation -> int -> Printexc.raw_backtrace =

--- a/stdlib/effectHandlers.mli
+++ b/stdlib/effectHandlers.mli
@@ -30,14 +30,14 @@ module Deep : sig
   val continue: ('a, 'b) continuation -> 'a -> 'b
   (** [continue k x] resumes the continuation [k] by passing [x] to [k].
 
-      @raise Invalid_argument if the continuation has already been
+      @raise Continuation_alread_taken if the continuation has already been
       resumed. *)
 
   val discontinue: ('a, 'b) continuation -> exn -> 'b
   (** [discontinue k e] resumes the continuation [k] by raising the
       exception [e] in [k].
 
-      @raise Invalid_argument if the continuation has already been
+      @raise Continuation_already_taken if the continuation has already been
       resumed. *)
 
   val discontinue_with_backtrace:
@@ -46,7 +46,7 @@ module Deep : sig
       raising the exception [e] in [k] using [bt] as the origin for the
       exception.
 
-      @raise Invalid_argument if the continuation has already been
+      @raise Continuation_already_taken if the continuation has already been
       resumed. *)
 
   type ('a,'b) handler =
@@ -98,14 +98,16 @@ module Shallow : sig
   (** [continue_with k v h] resumes the continuation [k] with value [v] with
       the handler [h].
 
-      @raise Invalid_argument if the continuation has already been resumed.
+      @raise Continuation_already_taken if the continuation has already been
+      resumed.
    *)
 
   val discontinue_with : ('a,'b) continuation -> exn -> ('b,'c) handler -> 'c
   (** [discontinue_with k e h] resumes the continuation [k] by raising the
       exception [e] with the handler [h].
 
-      @raise Invalid_argument if the continuation has already been resumed.
+      @raise Continuation_already_taken if the continuation has already been
+      resumed.
    *)
 
   val discontinue_with_backtrace :
@@ -115,7 +117,8 @@ module Shallow : sig
       exception [e] with the handler [h] using the raw backtrace [bt] as the
       origin of the exception.
 
-      @raise Invalid_argument if the continuation has already been resumed.
+      @raise Continuation_already_taken if the continuation has already been
+      resumed.
    *)
 
 

--- a/testsuite/tests/effects/backtrace.ml
+++ b/testsuite/tests/effects/backtrace.ml
@@ -1,0 +1,54 @@
+(* TEST
+   flags = "-g"
+   ocamlrunparam += ",b=1"
+*)
+
+open EffectHandlers
+open EffectHandlers.Deep
+
+let rec foo i =
+  if i = 0 then ()
+  else begin
+    ignore (failwith "exn");
+    foo i
+  end
+  [@@inline never]
+
+let rec bar i =
+  if i = 0 then ()
+  else begin
+    foo i;
+    bar i
+  end
+  [@@inline never]
+
+type _ eff += Wait : unit eff
+
+let task1 () =
+  try
+    bar 42; None
+  with e ->
+    Some (e, Printexc.get_raw_backtrace ())
+
+let rec task2 i =
+  if i = 0 then ()
+  else begin
+    perform Wait;
+    task2 i
+  end
+  [@@inline never]
+
+let main () =
+  let (x, bt) = Option.get (task1 ()) in
+  match_with task2 42
+  { retc = Fun.id;
+    exnc = (fun e ->
+      let open Printexc in
+      print_raw_backtrace stdout (get_raw_backtrace ()));
+    effc = fun (type a) (e : a eff) ->
+      match e with
+      | Wait -> Some (fun (k : (a, _) continuation) ->
+          discontinue_with_backtrace k x bt)
+      | _ -> None }
+
+let _ = main ()

--- a/testsuite/tests/effects/backtrace.reference
+++ b/testsuite/tests/effects/backtrace.reference
@@ -1,0 +1,6 @@
+Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+Called from Backtrace.foo in file "backtrace.ml", line 12, characters 11-27
+Called from Backtrace.bar in file "backtrace.ml", line 20, characters 4-9
+Called from Backtrace.task1 in file "backtrace.ml", line 29, characters 4-10
+Re-raised at Stdlib__EffectHandlers.Deep.discontinue_with_backtrace.(fun) in file "effectHandlers.ml", line 41, characters 4-38
+Called from Backtrace.task2 in file "backtrace.ml", line 36, characters 4-16


### PR DESCRIPTION
This feature will come in handy for getting the backtrace when modelling async/await. In the case where the awaited task raises an exception, we can get a backtrace that includes frames from both the awaited and awaiting task. 