### PR TITLE
First pass to improve the diff to startup code

### DIFF
--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -39,6 +39,8 @@ struct caml_params {
   uintnat eventlog_enabled;
   uintnat verify_heap;
   uintnat print_stats;
+  uintnat print_magic;
+  uintnat print_config;
 
   uintnat init_percent_free;
   uintnat init_max_percent_free;
@@ -61,6 +63,7 @@ extern const struct caml_params* const caml_params;
 
 extern void caml_parse_ocamlrunparam (void);
 extern int caml_parse_command_line (char_os **argv);
+extern void caml_command_error(char *msg, ...);
 
 /* Common entry point to caml_startup.
    Returns 0 if the runtime is already initialized.

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -23,6 +23,7 @@
 #include <pthread.h>
 #include <string.h>
 #include "caml/alloc.h"
+#include "caml/backtrace.h"
 #include "caml/callback.h"
 #include "caml/domain.h"
 #include "caml/domain_state.h"
@@ -441,6 +442,11 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
     domain_state->backtrace_buffer = NULL;
     domain_state->backtrace_last_exn = Val_unit;
     caml_register_generational_global_root(&domain_state->backtrace_last_exn);
+
+    if (caml_params->backtrace_enabled) {
+      caml_record_backtraces(1);
+    }
+
 #ifndef NATIVE_CODE
     domain_state->external_raise = NULL;
     domain_state->trap_sp_off = 1;

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -354,7 +354,6 @@ CAMLexport void caml_main(char_os **argv)
   /* Initialize the abstract machine */
   caml_init_gc ();
   Caml_state->external_raise = NULL;
-  if (caml_params->backtrace_enabled) caml_record_backtraces(1);
   /* Initialize the interpreter */
   caml_interprete(NULL, 0);
   /* Initialize the debugger, if needed */

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -51,13 +51,13 @@
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
 #include "caml/osdeps.h"
-#include "caml/startup_aux.h"
 #include "caml/prims.h"
 #include "caml/printexc.h"
 #include "caml/reverse.h"
 #include "caml/signals.h"
 #include "caml/sys.h"
 #include "caml/startup.h"
+#include "caml/startup_aux.h"
 
 #include "build_config.h"
 
@@ -70,18 +70,6 @@
 #endif
 
 static char magicstr[EXEC_MAGIC_LENGTH+1];
-static int print_magic = 0;
-
-/* Print the specified error message followed by an end-of-line and exit */
-static void error(char *msg, ...)
-{
-  va_list ap;
-  va_start(ap, msg);
-  vfprintf (stderr, msg, ap);
-  va_end(ap);
-  fprintf(stderr, "\n");
-  exit(127);
-}
 
 /* Read the trailer of a bytecode file */
 
@@ -102,7 +90,7 @@ static int read_trailer(int fd, struct exec_trailer *trail)
   memcpy(magicstr, trail->magic, EXEC_MAGIC_LENGTH);
   magicstr[EXEC_MAGIC_LENGTH] = 0;
 
-  if (print_magic) {
+  if (caml_params->print_magic) {
     printf("%s\n", magicstr);
     exit(0);
   }
@@ -248,6 +236,31 @@ static char_os * read_section_to_os(int fd, struct exec_trailer *trail,
 
 #endif
 
+/* Invocation of ocamlrun: 4 cases.
+
+   1.  runtime + bytecode
+       user types:  ocamlrun [options] bytecode args...
+       arguments:  ocamlrun [options] bytecode args...
+
+   2.  bytecode script
+       user types:  bytecode args...
+   2a  (kernel 1) arguments:  ocamlrun ./bytecode args...
+   2b  (kernel 2) arguments:  bytecode bytecode args...
+
+   3.  concatenated runtime and bytecode
+       user types:  composite args...
+       arguments:  composite args...
+
+Algorithm:
+  1-  If argument 0 is a valid byte-code file that does not start with #!,
+      then we are in case 3 and we pass the same command line to the
+      OCaml program.
+  2-  In all other cases, we parse the command line as:
+        (whatever) [options] bytecode args...
+      and we strip "(whatever) [options]" from the command line.
+
+*/
+
 #ifdef _WIN32
 extern void caml_signal_thread(void * lpParam);
 #endif
@@ -271,6 +284,7 @@ CAMLexport void caml_main(char_os **argv)
   char_os * shared_lib_path, * shared_libs;
   char_os * exe_name, * proc_self_exe;
 
+  /* Initialize the domain */
   CAML_INIT_DOMAIN_STATE;
 
   /* Determine options */
@@ -310,22 +324,22 @@ CAMLexport void caml_main(char_os **argv)
   if (fd < 0) {
     pos = caml_parse_command_line(argv);
     if (argv[pos] == 0) {
-      error("no bytecode file specified");
+      caml_command_error("no bytecode file specified");
     }
     exe_name = argv[pos];
     fd = caml_attempt_open(&exe_name, &trail, 1);
     switch(fd) {
     case FILE_NOT_FOUND:
-      error("cannot find file '%s'",
+      caml_command_error("cannot find file '%s'",
                        caml_stat_strdup_of_os(argv[pos]));
       break;
     case BAD_BYTECODE:
-      error(
+      caml_command_error(
         "the file '%s' is not a bytecode executable file",
         caml_stat_strdup_of_os(exe_name));
       break;
     case WRONG_MAGIC:
-      error(
+      caml_command_error(
         "the file '%s' has not the right magic number: "\
         "expected %s, got %s",
         caml_stat_strdup_of_os(exe_name),
@@ -403,6 +417,7 @@ CAMLexport value caml_startup_code_exn(
 {
   char_os * exe_name;
 
+  /* Initialize the domain */
   CAML_INIT_DOMAIN_STATE;
 
   /* Determine options */
@@ -446,7 +461,8 @@ CAMLexport value caml_startup_code_exn(
   /* Use the builtin table of primitives */
   caml_build_primitive_table_builtin();
   /* Load the globals */
-  caml_modify_generational_global_root(&caml_global_data, caml_input_value_from_block(data, data_size));
+  caml_modify_generational_global_root
+    (&caml_global_data, caml_input_value_from_block(data, data_size));
   caml_minor_collection(); /* ensure all globals are in major heap */
   /* Record the sections (for caml_get_section_table in meta.c) */
   caml_init_section_table(section_table, section_table_size);

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -79,6 +79,9 @@ void (*caml_termination_hook)(void *) = NULL;
 
 extern value caml_start_program (caml_domain_state*);
 extern void caml_init_signals (void);
+#ifdef _WIN32
+extern void caml_win32_overflow_detection (void);
+#endif
 
 #if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
 
@@ -91,6 +94,7 @@ value caml_startup_common(char_os **argv, int pooling)
 {
   char_os * exe_name, * proc_self_exe;
 
+  /* Initialize the domain */
   CAML_INIT_DOMAIN_STATE;
 
   /* Determine options */
@@ -115,6 +119,9 @@ value caml_startup_common(char_os **argv, int pooling)
 
   init_segments();
   caml_init_signals();
+#ifdef _WIN32
+  caml_win32_overflow_detection();
+#endif
   caml_debugger_init (); /* force debugger.o stub to be linked */
   exe_name = argv[0];
   if (exe_name == NULL) exe_name = T("");
@@ -137,7 +144,7 @@ value caml_startup_exn(char_os **argv)
   return caml_startup_common(argv, /* pooling */ 0);
 }
 
-void caml_main(char_os **argv)
+void caml_startup(char_os **argv)
 {
   value res = caml_startup_exn(argv);
   caml_maybe_print_stats(Val_unit);
@@ -145,9 +152,9 @@ void caml_main(char_os **argv)
     caml_fatal_uncaught_exception(Extract_exception(res));
 }
 
-void caml_startup(char_os **argv)
+void caml_main(char_os **argv)
 {
-  caml_main(argv);
+  caml_startup(argv);
 }
 
 value caml_startup_pooled_exn(char_os **argv)

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -19,7 +19,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "caml/backtrace.h"
 #include "caml/callback.h"
 #include "caml/custom.h"
 #include "caml/codefrag.h"
@@ -113,9 +112,6 @@ value caml_startup_common(char_os **argv, int pooling)
 #endif
   caml_init_custom_operations();
   caml_init_gc ();
-
-  if (caml_params->backtrace_enabled)
-    caml_record_backtraces(1);
 
   init_segments();
   caml_init_signals();


### PR DESCRIPTION
This PR attempts to improve the diff in the startup code on trunk and Multicore.

This actually does not quite improve the diff heavily, but it make sure to be more consistent with the changes introduced by Multicore when it comes to `runparams` and command line arguments (given to `ocamlrun`).

I also made sure to check that we did not drop any newer options from the list.

Side notes:
- As mentioned, Multicore handles such parameters within a dedicated struct (`caml_params`) that is read-only outside of `startup_aux`. This means that after startup, these parameters cannot be tempered with. In the Multicore setting, no other runtime code ever modify these fields after startup. This implies some amount of code motion versus trunk.
- In Multicore, there is still a few `runparams` disabled:
  - `a` (setting the allocation policy, ie `best_fit`, `first_fit` or `next_fit`.).
  - `H` (allocating pages using mmap/mmunmap)
  - `w` (the initial size of the major heap window)
- In Multicore, the atom table is handled differently, so the diffing here cannot really be worked around.

The last commit included in this PR also fixes what seems like an omission to me: if backtraced are enabled, it seems like we do not currently enable it for any other domains than the main one.
I moved the backtrace enabling behavior to `create_domain`, relying on `caml_params` to check if it needs to be enabled.
