### PR TITLE
Improve systhreads's diff with trunk

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -30,11 +30,6 @@
 #include "caml/printexc.h"
 #include "caml/roots.h"
 #include "caml/signals.h"
-#ifdef NATIVE_CODE
-#include "caml/stack.h"
-#else
-#include "caml/stacks.h"
-#endif
 #include "caml/sys.h"
 #include "caml/memprof.h"
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -797,7 +797,8 @@ static struct custom_operations caml_threadstatus_ops = {
 static value caml_threadstatus_new (void)
 {
   st_event ts = NULL;           /* suppress warning */
-  st_check_error(st_event_create(&ts), "Thread.create");
+  value wrapper;
+  sync_check_error(st_event_create(&ts), "Thread.create");
   wrapper = caml_alloc_custom(&caml_threadstatus_ops,
                               sizeof(st_event *),
                               0, 1);


### PR DESCRIPTION
This PR aims to improve Systhread's diff with trunk.

There is also at least one problematic behavior that was fixed in `caml_thread_stop` by making sure `Current_thread` indeed points to the correct data. (has it may not be the case once the thread reaches `caml_thread_stop`).

