### PR TITLE
Really flush output when pre-defined formatters are used in parallel.

### DIFF
--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1040,6 +1040,7 @@ let buffered_out_flush oc key () =
   let len = Buffer.length buf in
   let str = Buffer.contents buf in
   output_substring oc str 0 len ;
+  Stdlib.flush oc;
   Buffer.clear buf
 
 let std_buf_key = Domain.DLS.new_key (fun () -> Buffer.create pp_buffer_size)


### PR DESCRIPTION
Without this, even if the channels were requested to be flushed, the flush will only happen at the termination of a domain.

For example, consider the following program:

```ocaml
let print () =
  Format.printf "[%d] Hello, world@." (Domain.self () :> int)

let rec task n =
  if n = 0 then ()
  else begin
    print ();
    let rec loop n =
      if n = 0 then ()
      else (Domain.Sync.cpu_relax (); loop (n-1))
    in
    loop 100_000;
    task n
  end

let main () =
  print ();
  let d = Domain.spawn (fun _ -> task 1) in
  print ();
  Domain.join d

let _ = main ()
```

Note that `@.` requests flushing the pretty-printer and splits a new line. See https://ocaml.org/api/Format.html#VALfprintf. Without this PR, the program just prints one line to screen as it spins. With this, the program keeps printing to the screen as it spins. 