### PR TITLE
otherlibs: remove caml_channel_mutex_io hooks from systhreads

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -94,7 +94,6 @@ struct caml_thread_table {
   caml_thread_t all_threads;
   caml_thread_t current_thread;
   st_tlskey thread_key;
-  st_tlskey last_locked_key;
   st_masterlock thread_lock;
   int tick_thread_running;
   st_thread_id tick_thread_id;


### PR DESCRIPTION
This PR removes the `caml_channel_mutex_io` hooks in systhreads.
The rationale is that this behavior is now the default behavior in Multicore-OCaml as of #649, and the relevant thread local values are kept thread local in our implementation (rather than domain-local), which means it behaves the same as systhreads.
