### PR TITLE
Revert otherlibs/win32unix to ocaml/trunk

### DIFF
--- a/otherlibs/win32unix/accept.c
+++ b/otherlibs/win32unix/accept.c
@@ -42,7 +42,9 @@ CAMLprim value unix_accept(value cloexec, value sock)
   Begin_roots2 (fd, adr)
     fd = win_alloc_socket(snew);
     adr = alloc_sockaddr(&addr, addr_len, snew);
-    res = caml_alloc_2(0, fd, adr);
+    res = caml_alloc_small(2, 0);
+    Field(res, 0) = fd;
+    Field(res, 1) = adr;
   End_roots();
   return res;
 }

--- a/otherlibs/win32unix/mmap.c
+++ b/otherlibs/win32unix/mmap.c
@@ -71,7 +71,7 @@ CAMLprim value caml_unix_map_file(value vfd, value vkind, value vlayout,
   if (num_dims < 1 || num_dims > CAML_BA_MAX_NUM_DIMS)
     caml_invalid_argument("Unix.map_file: bad number of dimensions");
   for (i = 0; i < num_dims; i++) {
-    dim[i] = Long_field(vdim, i);
+    dim[i] = Long_val(Field(vdim, i));
     if (dim[i] == -1 && i == major_dim) continue;
     if (dim[i] < 0)
       caml_invalid_argument("Unix.map_file: negative dimension");

--- a/otherlibs/win32unix/pipe.c
+++ b/otherlibs/win32unix/pipe.c
@@ -38,7 +38,9 @@ CAMLprim value unix_pipe(value cloexec, value unit)
   Begin_roots2(readfd, writefd)
     readfd = win_alloc_handle(readh);
     writefd = win_alloc_handle(writeh);
-    res = caml_alloc_2(0, readfd, writefd);
+    res = caml_alloc_small(2, 0);
+    Field(res, 0) = readfd;
+    Field(res, 1) = writefd;
   End_roots();
   return res;
 }

--- a/otherlibs/win32unix/sendrecv.c
+++ b/otherlibs/win32unix/sendrecv.c
@@ -78,9 +78,9 @@ CAMLprim value unix_recvfrom(value sock, value buff, value ofs, value len,
     }
     memmove (&Byte(buff, Long_val(ofs)), iobuf, ret);
     adr = alloc_sockaddr(&addr, addr_len, -1);
-    res = caml_alloc_2(0,
-      Val_int(ret),
-      adr);
+    res = caml_alloc_small(2, 0);
+    Field(res, 0) = Val_int(ret);
+    Field(res, 1) = adr;
   End_roots();
   return res;
 }

--- a/otherlibs/win32unix/system.c
+++ b/otherlibs/win32unix/system.c
@@ -39,6 +39,7 @@ CAMLprim value win_system(cmd)
   caml_leave_blocking_section();
   caml_stat_free(buf);
   if (ret == -1) uerror("system", Nothing);
-  st = caml_alloc_1(0, Val_int(ret)); /* Tag 0: Exited */
+  st = caml_alloc_small(1, 0); /* Tag 0: Exited */
+  Field(st, 0) = Val_int(ret);
   return st;
 }

--- a/otherlibs/win32unix/unixsupport.c
+++ b/otherlibs/win32unix/unixsupport.c
@@ -271,7 +271,8 @@ value unix_error_of_code (int errcode)
   errconstr =
       cst_to_constr(errcode, error_table, sizeof(error_table)/sizeof(int), -1);
   if (errconstr == Val_int(-1)) {
-    err = caml_alloc_1(0, Val_int(errcode));
+    err = caml_alloc_small(1, 0);
+    Field(err, 0) = Val_int(errcode);
   } else {
     err = errconstr;
   }
@@ -299,15 +300,15 @@ void unix_error(int errcode, const char *cmdname, value cmdarg)
     err = unix_error_of_code (errcode);
     if (unix_error_exn == NULL) {
       unix_error_exn = caml_named_value("Unix.Unix_error");
-      if (!unix_error_exn)
+      if (unix_error_exn == NULL)
         caml_invalid_argument("Exception Unix.Unix_error not initialized,"
-                              " please link unix.cma");
+                         " please link unix.cma");
     }
-    res = caml_alloc_4(0,
-      *unix_error_exn,
-      err,
-      name,
-      arg);
+    res = caml_alloc_small(4, 0);
+    Field(res, 0) = *unix_error_exn;
+    Field(res, 1) = err;
+    Field(res, 2) = name;
+    Field(res, 3) = arg;
   End_roots();
   caml_raise(res);
 }

--- a/otherlibs/win32unix/windir.c
+++ b/otherlibs/win32unix/windir.c
@@ -48,7 +48,9 @@ CAMLprim value win_findfirst(value name)
     }
     valname = caml_copy_string_of_utf16(fileinfo.cFileName);
     valh = win_alloc_handle(h);
-    v = caml_alloc_2(0, valname, valh);
+    v = caml_alloc_small(2, 0);
+    Field(v,0) = valname;
+    Field(v,1) = valh;
   End_roots();
   return v;
 }

--- a/otherlibs/win32unix/winwait.c
+++ b/otherlibs/win32unix/winwait.c
@@ -23,10 +23,16 @@
 
 static value alloc_process_status(HANDLE pid, int status)
 {
-  value st;
+  value res, st;
 
-  st = caml_alloc_1(0, Val_int(status));
-  return caml_alloc_2(0, Val_long((intnat) pid), st);
+  st = caml_alloc(1, 0);
+  Field(st, 0) = Val_int(status);
+  Begin_root (st);
+    res = caml_alloc_small(2, 0);
+    Field(res, 0) = Val_long((intnat) pid);
+    Field(res, 1) = st;
+  End_roots();
+  return res;
 }
 
 enum { CAML_WNOHANG = 1, CAML_WUNTRACED = 2 };


### PR DESCRIPTION
This PR reverts unnecessary changes to `otherlibs/win32unix` vs ocaml/ocaml.