### PR TITLE
otherlibs: Unix.kill should check for pending signals

### DIFF
--- a/otherlibs/unix/kill.c
+++ b/otherlibs/unix/kill.c
@@ -27,5 +27,6 @@ CAMLprim value unix_kill(value pid, value signal)
   sig = caml_convert_signal_number(Int_val(signal));
   if (kill(Int_val(pid), sig) == -1)
     uerror("kill", Nothing);
+  caml_raise_if_exception(caml_process_pending_signals_exn());
   return Val_unit;
 }

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -38,10 +38,6 @@ runtime-naked-pointers
 # TODO: not clear compatibility is sensible for multicore
 compatibility
 
-# TODO: signals and kill (#9802)
-tests/lib-unix/kill/'unix_kill.ml' with 1.1 (bytecode)
-tests/lib-unix/kill/'unix_kill.ml' with 1.2 (native)
-
 # TODO: off-by-one error on MacOS+Clang (#408)
 tests/lib-threads/'beat.ml' with 1.2 (native)
 tests/lib-threads/'beat.ml' with 1.1 (bytecode)


### PR DESCRIPTION
This PR re-enable the `unix_kill` testcase, and fix it by making sure `Unix.kill` does check for pending signals on return.

(which is an upstream fix, see ocaml/ocaml#9802)