### PR TITLE
Deprecate Sync and timer_ticks from Domain

### DIFF
--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -72,8 +72,10 @@ type nanoseconds = int64
 external timer_ticks : unit -> (int64 [@unboxed]) =
   "caml_ml_domain_ticks" "caml_ml_domain_ticks_unboxed" [@@noalloc]
 
+let cpu_relax () = Raw.cpu_relax ()
+
 module Sync = struct
-  let cpu_relax () = Raw.cpu_relax ()
+  let cpu_relax = cpu_relax
   let poll () = ()
 end
 

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -17,6 +17,7 @@ type id = private int
 (** Domains have unique integer identifiers *)
 
 val get_id : 'a t -> id
+(** [get_id d] returns the identifier of the domain [d] *)
 
 val self : unit -> id
 (** [self ()] is the identifier of the currently running domain *)
@@ -33,14 +34,18 @@ val at_exit : (unit -> unit) -> unit
     function raises an exception, the exceptions are ignored. *)
 
 type nanoseconds = int64
+
 val timer_ticks : unit -> nanoseconds
+[@@ocaml.deprecated "timer_ticks() will be removed from the multicore runtime; please use another timing function, such as Unix.gettimeofday()"]
 (** Returns the number of nanoseconds elapsed since the OCaml
     runtime started. *)
 
 module Sync : sig
-  (** Low-level Domain related primitives. **)
+  (** @deprecated Sync will be removed in 5.0.0
+      Low-level Domain related primitives. **)
 
   val cpu_relax : unit -> unit
+  [@@ocaml.deprecated "Use Domain.cpu_relax()"]
   (** If busy-waiting, calling cpu_relax () between iterations
       will improve performance on some CPU architectures *)
 

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -40,6 +40,10 @@ val timer_ticks : unit -> nanoseconds
 (** Returns the number of nanoseconds elapsed since the OCaml
     runtime started. *)
 
+val cpu_relax : unit -> unit
+(** If busy-waiting, calling cpu_relax () between iterations
+    will improve performance on some CPU architectures *)
+
 module Sync : sig
   (** @deprecated Sync will be removed in 5.0.0
       Low-level Domain related primitives. **)

--- a/testsuite/tests/lazy/lazy5.ml
+++ b/testsuite/tests/lazy/lazy5.ml
@@ -5,7 +5,7 @@ let rec safe_force l =
   match Lazy.try_force l with
   | Some x -> x
   | None -> (
-      Domain.Sync.cpu_relax () ;
+      Domain.cpu_relax () ;
       safe_force l
     )
 

--- a/testsuite/tests/lazy/lazy6.ml
+++ b/testsuite/tests/lazy/lazy6.ml
@@ -7,7 +7,7 @@ let flag2 = Atomic.make false
 
 let rec wait_for_flag f =
   if Atomic.get f then ()
-  else (Domain.Sync.cpu_relax (); wait_for_flag f)
+  else (Domain.cpu_relax (); wait_for_flag f)
 
 let l1 = Lazy.from_fun (fun () ->
   Atomic.set flag1 true;
@@ -23,7 +23,7 @@ let second_domain () =
     try Lazy.force l2 with
     | Lazy.RacyLazy ->
         (Atomic.set flag2 true;
-         Domain.Sync.cpu_relax ();
+         Domain.cpu_relax ();
          loop ())
   in
   loop ()

--- a/testsuite/tests/lazy/lazy7.ml
+++ b/testsuite/tests/lazy/lazy7.ml
@@ -8,7 +8,7 @@ let rec safe_force l =
   match Lazy.try_force l with
   | Some x -> x
   | None -> (
-      Domain.Sync.cpu_relax () ;
+      Domain.cpu_relax () ;
       safe_force l
     )
 


### PR DESCRIPTION
Syncs 4.12.0+domains+effects with the mainline 5.00 branch, specifically the change from PR #704 