### PR TITLE
Improve ephemerons compatibility with testsuite

### DIFF
--- a/runtime/caml/weak.h
+++ b/runtime/caml/weak.h
@@ -1,15 +1,17 @@
-/***********************************************************************/
-/*                                                                     */
-/*                                OCaml                                */
-/*                                                                     */
-/*            Damien Doligez, projet Para, INRIA Rocquencourt          */
-/*                                                                     */
-/*  Copyright 1997 Institut National de Recherche en Informatique et   */
-/*  en Automatique.  All rights reserved.  This file is distributed    */
-/*  under the terms of the GNU Library General Public License, with    */
-/*  the special exception on linking described in file ../LICENSE.     */
-/*                                                                     */
-/***********************************************************************/
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*              Damien Doligez, projet Para, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 1996 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
 
 /* Operations on weak arrays */
 
@@ -29,11 +31,11 @@ extern value caml_ephe_none;
 struct caml_ephe_info {
   value todo; /* These are ephemerons which need to be marked and swept in the
                  current cycle. If the ephemeron is alive, after marking, they
-                 go into the live list. */
-  value live; /* These are ephemerons which are alive in the current cycle.
-                 They still need to be swept to get rid of dead keys and
-                 values. Invariant: No keys are unreachable for these
-                 ephemerons. */
+                 go into the live list after cleaning them off the unreachable
+                 keys and releasing values if any of the keys are unreachable.
+                 */
+  value live; /* These are ephemerons which are alive in the current cycle,
+                 whose keys and data are live (or not set). */
   uintnat cycle;
   struct {
     value* todop;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -842,14 +842,17 @@ intnat ephe_mark (intnat budget, uintnat for_cycle,
             }
           }
         }
-        else if (is_unmarked (key))
-          alive_data = 0;
+        else {
+          if (Tag_val (key) == Infix_tag) key -= Infix_offset_val (key);
+          if (is_unmarked (key))
+            alive_data = 0;
+        }
       }
     }
     budget -= Whsize_wosize(i);
 
     if (force_alive || alive_data) {
-      if (data != caml_ephe_none && Is_block(data) && is_unmarked(data)) {
+      if (data != caml_ephe_none && Is_block(data)) {
         caml_darken (0, data, 0);
       }
       Ephe_link(v) = domain_state->ephe_info->live;

--- a/testsuite/disabled
+++ b/testsuite/disabled
@@ -5,18 +5,9 @@
 # Either an entire directory or a specific file can be disabled here.
 # If an entire directory is listed, those tests won't even be run.
 
-# Obj.truncate is incompatible with multicore (ocaml/ocaml#1725)
-tests/weak-ephe-final/'weaktest.ml' with 1 (native)
-tests/weak-ephe-final/'weaktest.ml' with 2 (bytecode)
-
 # TODO: port the new Ephemeron C-api to multicore
 #  https://github.com/ocaml/ocaml/pull/676
 ephe-c-api
-
-# TODO: port https://github.com/ocaml/ocaml/pull/9742
-# Make Ephemeron compatible with infix pointers
-tests/misc/'ephe_infix.ml' with 1 (native)
-tests/misc/'ephe_infix.ml' with 2 (bytecode)
 
 # TODO: port stat-mem-prof
 #  https://github.com/ocaml/ocaml/pull/8634

--- a/testsuite/tests/weak-ephe-final/weaktest.ml
+++ b/testsuite/tests/weak-ephe-final/weaktest.ml
@@ -60,6 +60,17 @@ for j = 0 to 99 do
   r := [];
   incr added;
 
+  (* Ephemeron / Weak array implementation in multicore OCaml differs
+     significantly from stock OCaml. In particular, ephemerons keys and data in
+     the minor heap are considered roots for the minor collection. Moreover,
+     When blit'ing ephemerons, the source keys and data are marked as live to
+     play nicely with the concurrent major GC. As a result, this test keeps the
+     previous bunches of strings alive longer than on stock. Hence, the test as
+     is fails on multicore. We add a [full_major] call that forces old bunches
+     to be collected and to confirm that ephemeron implementation on multicore
+     does work as intended. *)
+  Gc.full_major ();
+
   for i = 1 to bunch do
     let c = random_string 7 in
     r := c :: !r;


### PR DESCRIPTION
There are two improvements in this PR

1. Imports the upstream fixes for making ephemerons work with infix objects: https://github.com/ocaml/ocaml/pull/9742.
2. Clarifies why `weaktest.ml` fails on multicore and fixes the test by adding `Gc.full_major()` in the test. Here is the newly added comment copied from the `weaktest.ml` file: 

> Ephemeron / Weak array implementation in multicore OCaml differs significantly from stock OCaml. In particular, ephemerons keys and data in the minor heap are considered roots for the minor collection. Moreover, When blit'ing ephemerons, the source keys and data are marked as live to play nicely with the concurrent major GC. As a result, this test keeps the previous bunches of strings alive longer than on stock. Hence, the test fails. We add a [full_major] call that forces old bunches to be collected and to confirm that ephemeron implementation on multicore does work as intended. 