### PR TITLE
fix `make install`

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -164,7 +164,7 @@ ifneq "$(BYTECODE_SHARED_LIBRARIES)" ""
 	$(INSTALL_PROG) $(BYTECODE_SHARED_LIBRARIES) "$(INSTALL_LIBDIR)"
 endif
 	mkdir -p "$(INSTALL_INCDIR)"
-	$(INSTALL_DATA) caml/domain_state.tbl caml/byte_domain_state.tbl caml/*.h \
+	$(INSTALL_DATA) caml/domain_state.tbl caml/*.h \
 	"$(INSTALL_INCDIR)"
 
 .PHONY: installopt


### PR DESCRIPTION
This PR fixes an install bug which manifests as `/usr/bin/install: cannot stat 'caml/byte_domain_state.tbl': No such file or directory` when issuing `make install`. 