### PR TITLE
testsuite: re-enable signals_alloc testcase

### DIFF
--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -41,6 +41,7 @@ CAMLextern atomic_intnat caml_pending_signals[];
 #define caml_requested_major_slice (Caml_state_field(requested_major_slice))
 #define caml_requested_minor_gc (Caml_state_field(requested_minor_gc))
 
+int caml_check_for_pending_signals(void);
 void caml_update_young_limit(void);
 void caml_request_major_slice (void);
 void caml_request_minor_gc (void);

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -81,7 +81,7 @@ sp is a local copy of the global variable Caml_state->extern_sp. */
   { sp = domain_state->current_stack->sp; accu = sp[0]; env = sp[1]; sp += 3; }
 #define Enter_gc \
   { Setup_for_gc; caml_handle_gc_interrupt(); \
-    caml_raise_if_exception(caml_process_pending_signals_exn()); \
+    caml_process_pending_signals();	      \
     Restore_after_gc; }
 
 /* We store [pc+1] in the stack so that, in case of an exception, the

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -1010,8 +1010,8 @@ value caml_interprete(code_t prog, asize_t prog_size)
 
     Instruct(CHECK_SIGNALS):    /* accu not preserved */
       if (Caml_check_gc_interrupt(domain_state) ||
-	  caml_check_for_pending_signals())
-	goto process_signal;
+          caml_check_for_pending_signals())
+        goto process_signal;
       Next;
 
     process_signal:

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -81,7 +81,7 @@ sp is a local copy of the global variable Caml_state->extern_sp. */
   { sp = domain_state->current_stack->sp; accu = sp[0]; env = sp[1]; sp += 3; }
 #define Enter_gc \
   { Setup_for_gc; caml_handle_gc_interrupt(); \
-    caml_process_pending_signals();           \
+    caml_check_for_pending_signals();         \
     Restore_after_gc; }
 
 /* We store [pc+1] in the stack so that, in case of an exception, the
@@ -931,7 +931,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
            by the current try...with, not the enclosing one. */
         pc--; /* restart the POPTRAP after processing the signal */
         goto process_signal;
-       }
+      }
       domain_state->trap_sp_off = Long_val(Trap_link(sp));
       sp += 4;
       Next;

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -81,7 +81,7 @@ sp is a local copy of the global variable Caml_state->extern_sp. */
   { sp = domain_state->current_stack->sp; accu = sp[0]; env = sp[1]; sp += 3; }
 #define Enter_gc \
   { Setup_for_gc; caml_handle_gc_interrupt(); \
-    caml_process_pending_signals();	      \
+    caml_process_pending_signals();           \
     Restore_after_gc; }
 
 /* We store [pc+1] in the stack so that, in case of an exception, the

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -66,7 +66,7 @@ CAMLexport value caml_process_pending_signals_exn(void)
 
   /* Check that there is indeed a pending signal before issuing the
       syscall in [pthread_sigmask]. */
-  if (!check_for_pending_signals())
+  if (!caml_check_for_pending_signals())
     return Val_unit;
 
 #ifdef POSIX_SIGNALS

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -42,7 +42,7 @@
 CAMLexport atomic_intnat caml_pending_signals[NSIG];
 caml_plat_mutex signal_install_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 
-static int check_for_pending_signals(void)
+int caml_check_for_pending_signals(void)
 {
   int i;
 
@@ -148,7 +148,7 @@ CAMLexport void caml_enter_blocking_section(void)
     caml_enter_blocking_section_hook ();
     /* Check again for pending signals.
        If none, done; otherwise, try again */
-    if (!check_for_pending_signals()) break;
+    if (!caml_check_for_pending_signals()) break;
     caml_leave_blocking_section_hook ();
   }
 }

--- a/testsuite/tests/callback/callbackprim.c
+++ b/testsuite/tests/callback/callbackprim.c
@@ -1,0 +1,76 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                OCaml                                   */
+/*                                                                        */
+/*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 1995 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#include <signal.h>
+#include "caml/mlvalues.h"
+#include "caml/memory.h"
+#include "caml/callback.h"
+
+value mycallback1(value fun, value arg)
+{
+  value res;
+  res = caml_callback(fun, arg);
+  return res;
+}
+
+value mycallback2(value fun, value arg1, value arg2)
+{
+  value res;
+  res = caml_callback2(fun, arg1, arg2);
+  return res;
+}
+
+value mycallback3(value fun, value arg1, value arg2, value arg3)
+{
+  value res;
+  res = caml_callback3(fun, arg1, arg2, arg3);
+  return res;
+}
+
+value mycallback4(value fun, value arg1, value arg2, value arg3, value arg4)
+{
+  value args[4];
+  value res;
+  args[0] = arg1;
+  args[1] = arg2;
+  args[2] = arg3;
+  args[3] = arg4;
+  res = caml_callbackN(fun, 4, args);
+  return res;
+}
+
+value mypushroot(value v, value fun, value arg)
+{
+  Begin_root(v)
+    caml_callback(fun, arg);
+  End_roots();
+  return v;
+}
+
+value mycamlparam (value v, value fun, value arg)
+{
+  CAMLparam3 (v, fun, arg);
+  CAMLlocal2 (x, y);
+  x = v;
+  y = caml_callback (fun, arg);
+  v = x;
+  CAMLreturn (v);
+}
+
+value raise_sigusr1(value unused)
+{
+  raise(SIGUSR1);
+  return Val_unit;
+}


### PR DESCRIPTION
This PR re-enable the `signals_alloc` testcase and attempts at making sure the bytecode interpreter polls for signals when it should.

I'm unsure if the fixes are not an overkill.

I do think that the `check_signals` macros are correct this way. (though I think `caml_check_for_pending_signals` is overkill vs trunk's `caml_something_to_do`, we may make it less expensive at some point.)

The problem lies in the `Enter_gc` macro I modified to explicitly check for signals:
I'm unsure it is fully correct and is the right polling point for signals. On `trunk`, `caml_small_alloc_dispatch` will do this duty just fine (and actually check for signals), versus our `Alloc_small` macro does not proceed in the same way.
Maybe the problem lies in how our `Alloc_small` code works rather than the interpreter. (though the native version of the testcase does not fail for us.).

For the record:
The issue we faced with `signals_alloc` was that, on bytecode, the testcase prints `01243` rather than `01234`.
The problem is that at `signals_alloc.ml:24`, this line triggers an allocation, that should make us poll for signals.
In the bytecode interpreter, it does not actually do that, and does not trigger the signal handler that would set the array in the expected order.

Careful review would be appreciated, and I think this change may be overblown and we could simplify the situation a lot.
