### PR TITLE
runtime: remove unused fields from io.h

### DIFF
--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -44,8 +44,6 @@ struct channel {
   char * max;                   /* Logical end of the buffer (for input) */
   caml_plat_mutex mutex;        /* Mutex protecting buffer */
   struct channel * next, * prev;/* Double chaining of channels (flush_all) */
-  int revealed;                 /* For Cash only */
-  int old_revealed;             /* For Cash only */
   atomic_uintnat refcount;      /* For flush_all and for Cash */
   int flags;                    /* Bitfield */
   char buff[IO_BUFFER_SIZE];    /* The buffer itself */

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -90,13 +90,18 @@ static void channel_mutex_unlock_default(struct channel *chan)
 static void channel_mutex_unlock_exn_default(void)
 {
   struct channel * chan = last_channel_locked;
-  if (chan != NULL && caml_channel_mutex_unlock != NULL) caml_channel_mutex_unlock(chan);
+  if (chan != NULL && caml_channel_mutex_unlock != NULL)
+    caml_channel_mutex_unlock(chan);
 }
 
-CAMLexport void (*caml_channel_mutex_free) (struct channel *) = channel_mutex_free_default;
-CAMLexport void (*caml_channel_mutex_lock) (struct channel *) = channel_mutex_lock_default;
-CAMLexport void (*caml_channel_mutex_unlock) (struct channel *) = channel_mutex_unlock_default;
-CAMLexport void (*caml_channel_mutex_unlock_exn) (void) = channel_mutex_unlock_exn_default;
+CAMLexport void (*caml_channel_mutex_free) (struct channel *)
+  = channel_mutex_free_default;
+CAMLexport void (*caml_channel_mutex_lock) (struct channel *)
+  = channel_mutex_lock_default;
+CAMLexport void (*caml_channel_mutex_unlock) (struct channel *)
+  = channel_mutex_unlock_default;
+CAMLexport void (*caml_channel_mutex_unlock_exn) (void)
+  = channel_mutex_unlock_exn_default;
 
 /* List of opened channels */
 CAMLexport struct channel * caml_all_opened_channels = NULL;
@@ -525,7 +530,7 @@ void caml_finalize_channel(value vchan)
               "[ocaml] (moreover, it has unflushed data)\n"
               );
   }
-  else 
+  else
   {
     caml_stat_free(chan->name);
     caml_stat_free(chan);

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -169,8 +169,6 @@ CAMLexport struct channel * caml_open_descriptor_in(int fd)
   channel->curr = channel->max = channel->buff;
   channel->end = channel->buff + IO_BUFFER_SIZE;
   caml_plat_mutex_init(&channel->mutex);
-  channel->revealed = 0;
-  channel->old_revealed = 0;
   atomic_store_rel(&channel->refcount, 0);
   channel->prev = NULL;
   channel->name = NULL;


### PR DESCRIPTION
`revealed` and `old_revealed` were removed from trunk a while ago.

See: https://github.com/ocaml/ocaml/pull/10136