### PR TITLE
introduce caml_process_pending_signals which raises if exceptional

### DIFF
--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -397,7 +397,7 @@ value caml_thread_sigmask(value cmd, value sigs) /* ML */
   caml_leave_blocking_section();
   sync_check_error(retcode, "Thread.sigmask");
   /* Run any handlers for just-unmasked pending signals */
-  caml_raise_if_exception(caml_process_pending_signals_exn());
+  caml_process_pending_signals();
   return st_encode_sigset(&oldset);
 }
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -706,12 +706,12 @@ CAMLprim value caml_thread_yield(value unit)        /* ML */
 {
   if (atomic_load_acq(&Thread_main_lock.waiters) == 0) return Val_unit;
 
-  caml_raise_if_exception(caml_process_pending_signals_exn());
+  caml_process_pending_signals();
   caml_thread_save_runtime_state();
   st_thread_yield(&Thread_main_lock);
   Current_thread = st_tls_get(Thread_key);
   caml_thread_restore_runtime_state();
-  caml_raise_if_exception(caml_process_pending_signals_exn());
+  caml_process_pending_signals();
 
   return Val_unit;
 }

--- a/otherlibs/unix/kill.c
+++ b/otherlibs/unix/kill.c
@@ -27,6 +27,6 @@ CAMLprim value unix_kill(value pid, value signal)
   sig = caml_convert_signal_number(Int_val(signal));
   if (kill(Int_val(pid), sig) == -1)
     uerror("kill", Nothing);
-  caml_raise_if_exception(caml_process_pending_signals_exn());
+  caml_process_pending_signals();
   return Val_unit;
 }

--- a/otherlibs/unix/signals.c
+++ b/otherlibs/unix/signals.c
@@ -72,7 +72,7 @@ CAMLprim value unix_sigprocmask(value vaction, value vset)
   retcode = sigprocmask(how, &set, &oldset);
   caml_leave_blocking_section();
   /* Run any handlers for just-unmasked pending signals */
-  caml_raise_if_exception(caml_process_pending_signals_exn());
+  caml_process_pending_signals();
   if (retcode != 0) unix_error(retcode, "sigprocmask", Nothing);
   return encode_sigset(&oldset);
 }

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -49,6 +49,7 @@ CAMLextern int caml_rev_convert_signal_number (int);
 value caml_execute_signal_exn(int signal_number, int in_signal_handler);
 CAMLextern void caml_record_signal(int signal_number);
 CAMLextern value caml_process_pending_signals_exn(void);
+CAMLextern void caml_process_pending_signals(void);
 void caml_set_action_pending (void);
 int caml_set_signal_action(int signo, int action);
 

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -1012,7 +1012,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
     process_signal:
       Setup_for_event;
       caml_handle_gc_interrupt();
-      caml_raise_if_exception(caml_process_pending_signals_exn());
+      caml_process_pending_signals();
       Restore_after_event;
       Next;
 

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -90,7 +90,7 @@ void caml_garbage_collection()
     if (nallocs == 0) {
       /* This is a poll */
       caml_handle_gc_interrupt(); // process pending actions?
-      caml_raise_if_exception(caml_process_pending_signals_exn());
+      caml_process_pending_signals();
       return;
     }
     else
@@ -98,13 +98,15 @@ void caml_garbage_collection()
       for (i = 0; i < nallocs; i++) {
         allocsz += Whsize_wosize(Wosize_encoded_alloc_len(alloc_len[i]));
       }
-      /* We have computed whsize (including header), but need wosize (without) */
+      /* We have computed whsize (including header)
+         but need wosize (without) */
       allocsz -= 1;
     }
 
     whsize = Whsize_wosize(allocsz);
 
-    /* Put the young pointer back to what is was before our tiggering allocation */
+    /* Put the young pointer back to what is was before our tiggering
+       allocation */
     Caml_state->young_ptr += whsize;
 
     /* When caml_garbage_collection returns, we assume there is enough space in
@@ -114,8 +116,9 @@ void caml_garbage_collection()
       in a loop to ensure it. */
     do {
       caml_handle_gc_interrupt();
-      caml_raise_if_exception(caml_process_pending_signals_exn());
-    } while( (uintnat)(Caml_state->young_ptr - whsize) <= Caml_state->young_limit );
+      caml_process_pending_signals();
+    } while
+       ( (uintnat)(Caml_state->young_ptr - whsize) <= Caml_state->young_limit );
 
     /* Re-do the allocation: we now have enough space in the minor heap. */
     Caml_state->young_ptr -= whsize;


### PR DESCRIPTION
This cleans up about a dozen: `caml_raise_if_exception(caml_process_pending_signals_exn())` calls we have littered around the codebase and also matches `caml_process_pending_actions` / `caml_process_pending_actions_exn` from trunk.