### PR TITLE
AFL: segfault and lock resetting (fixes #497)

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1877,7 +1877,7 @@ let get_mod_field modname field =
 
 let code_force_lazy_block = get_mod_field "CamlinternalLazy" "force_lazy_block"
 
-let code_force_lazy = get_mod_field "CamlinternalLazy" "force"
+let code_force_lazy = get_mod_field "CamlinternalLazy" "force_gen"
 
 (* inline_lazy_force inlines the beginning of the code of Lazy.force. When
    the value argument is tagged as:
@@ -1986,7 +1986,7 @@ let inline_lazy_force arg loc =
       { ap_tailcall = Default_tailcall;
         ap_loc = loc;
         ap_func = Lazy.force code_force_lazy;
-        ap_args = [ arg ];
+        ap_args = [ Lconst (Const_base (Const_int 0)); arg ];
         ap_inlined = Default_inline;
         ap_specialised = Default_specialise
       }

--- a/runtime/afl.c
+++ b/runtime/afl.c
@@ -23,6 +23,7 @@ uintnat caml_afl_prev_loc;
 #if !defined(HAS_SYS_SHM_H) || !defined(HAS_SHMAT)
 
 #include "caml/mlvalues.h"
+#include "caml/domain.h"
 
 CAMLprim value caml_reset_afl_instrumentation(value full)
 {
@@ -117,6 +118,7 @@ CAMLexport value caml_setup_afl(value unit)
     int child_pid = fork();
     if (child_pid < 0) caml_fatal_error("afl-fuzz: could not fork");
     else if (child_pid == 0) {
+      caml_atfork_hook();
       /* Run the program */
       close(FORKSRV_FD_READ);
       close(FORKSRV_FD_WRITE);

--- a/runtime/afl.c
+++ b/runtime/afl.c
@@ -114,6 +114,10 @@ CAMLexport value caml_setup_afl(value unit)
   }
   afl_read();
 
+  /* ensure that another module has not already spawned a domain */
+  if (!caml_domain_alone())
+    caml_fatal_error("afl-fuzz: cannot fork with multiple domains running");
+
   while (1) {
     int child_pid = fork();
     if (child_pid < 0) caml_fatal_error("afl-fuzz: could not fork");

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -515,7 +515,7 @@ void caml_init_domains(uintnat minor_heap_wsz) {
   heaps_base = caml_mem_map(size, size, 1 /* reserve_only */);
   tls_base =
       caml_mem_map(tls_areas_size, tls_areas_size, 1 /* reserve_only */);
-  if (!heaps_base || !tls_base) caml_raise_out_of_memory();
+  if (!heaps_base || !tls_base) caml_fatal_error("Not enough heap memory to start up");
 
   caml_minor_heaps_base = (uintnat) heaps_base;
   caml_minor_heaps_end = (uintnat) heaps_base + size;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -515,7 +515,8 @@ void caml_init_domains(uintnat minor_heap_wsz) {
   heaps_base = caml_mem_map(size, size, 1 /* reserve_only */);
   tls_base =
       caml_mem_map(tls_areas_size, tls_areas_size, 1 /* reserve_only */);
-  if (!heaps_base || !tls_base) caml_fatal_error("Not enough heap memory to start up");
+  if (!heaps_base || !tls_base)
+    caml_fatal_error("Not enough heap memory to start up");
 
   caml_minor_heaps_base = (uintnat) heaps_base;
   caml_minor_heaps_end = (uintnat) heaps_base + size;

--- a/stdlib/camlinternalLazy.ml
+++ b/stdlib/camlinternalLazy.ml
@@ -120,8 +120,8 @@ let try_force_gen_lazy_block ~only_val (blk : 'arg lazy_t) =
 
 (* [force_gen ~only_val:false] is not used, since [Lazy.force] is
    declared as a primitive whose code inlines the tag tests of its
-   argument. This function is here for the sake of completeness, and
-   for debugging purpose. *)
+   argument, except when afl instrumentation is turned on. *)
+
 let force_gen ~only_val (lzv : 'arg lazy_t) =
   let x = Obj.repr lzv in
   (* XXX No safe points start *)


### PR DESCRIPTION
This is a fix to get AFL-instrumentation running on multicore again.

First off, the segfault reported in #497 is caused by a NULL-pointer dereference during error reporting.
The error is triggered because `afl-fuzz` runs the tested program under a memory budget with `setrlimit`:
  https://github.com/google/AFL/blob/61037103ae3722c8060ff7082994836a794f978e/afl-fuzz.c#L2034-L2040
The allocation of the minor heap space in `caml_init_domains` thus fails and calls `caml_raise_out_of_memory`.
It eventually ends up in `caml_raise` where it dereferences `Caml_state` which hasn't been initialized yet:
https://github.com/ocaml-multicore/ocaml-multicore/blob/13a6be2a538434b901404862dc37daadfc862850/runtime/fail_nat.c#L74
The PR changes `caml_init_domains` to use `caml_fatal_error` consistently.



Secondly, the AFL-instrumentation uses `fork` as an optimization to push more tests through.
For a simple setup, `afl-fuzz` can fork and execute a program repeatedly for each mutated input.
This is the behaviour you get with `AFL_NO_FORKSRV=1 afl-fuzz -i input -o output a.out` (also mentioned in #497).
To save time on redundant linking and initialization AFL also offers a "fork server" mode. This mode instead pauses the instrumented program at the point just before "proper execution" begins, and then cheaply forks test programs whenever `afl-fuzz` tells it to:
https://github.com/ocaml-multicore/ocaml-multicore/blob/13a6be2a538434b901404862dc37daadfc862850/runtime/afl.c#L116-L120
This setup is described in more detail in https://lcamtuf.blogspot.com/2014/10/fuzzing-binaries-without-execve.html
Note: Because we are still during initialization this `fork` occurrence will only execute with 1 domain running. 
The child however has problems with unlocking akin to #471. Since `afl-fuzz` silences the tested program
  https://github.com/google/AFL/blob/61037103ae3722c8060ff7082994836a794f978e/afl-fuzz.c#L2067-L2068
an `strace -f` helped reveal the problem:
```
...
[pid 97880] close(198)                  = 0
[pid 97880] close(199)                  = 0
[pid 97880] write(2, "Fatal error during unlock", 25) = 25
[pid 97880] write(2, ": Operation not permitted\n", 26) = 26
[pid 97880] exit_group(2)               = ?
[pid 97880] +++ exited with 2 +++
[pid 97879] <... wait4 resumed>[{WIFEXITED(s) && WEXITSTATUS(s) == 2}], WSTOPPED, NULL) = 97880
[pid 97879] --- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=97880, si_uid=1000, si_status=2, si_utime=0, si_stime=0} ---
[pid 97879] write(199, "\0\2\0\0", 4)   = 4
...
```
Because the child quickly fails silently during `afl-fuzz`s `perform_dry_run` it reports it as
`No instrumentation detected` which is a bit confusing https://github.com/google/AFL/blob/61037103ae3722c8060ff7082994836a794f978e/afl-fuzz.c#L2629-L2632

To fix the unlock issue the PR uses the `caml_atfork_hook` from 1a2c6120a12b414ef63e006806c732f4852f2420
With this fix the test case from #497 runs again using `-m none` (no memory budget).
I'll submit a separate PR regarding heap memory requirements.