### PR TITLE
Reduce minor heap reservation

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -223,7 +223,7 @@ typedef uint64_t uintnat;
 /* Maximum size of the minor zone (words).
    Must be greater than or equal to [Minor_heap_min].
 */
-#define Minor_heap_max (1 << 28)
+#define Minor_heap_max (1 << 21)
 
 /* Default size of the minor zone. (words)  */
 #define Minor_heap_def 262144


### PR DESCRIPTION
This PR will most likely turn out differently in the end, so I'm submitting it separately from #731.
As mentioned in #731 `afl-fuzz` runs a tested program with a `setrlimit`-inforced memory budget. By default there is not a lot to work with:
```
$ afl-fuzz | grep -- '-m'
  -m megs       - memory limit for child process (50 MB)
```
Incidentally this also explains why #497 reports of different behaviours when run under a 50MB budget (crash) compared to running without limitations (`-m none` - unlock-error/`No instrumentation`). Nevertheless, the low 50MB  default has been sufficient up to now, e.g., for fuzzng the one-line example from #497 with `ocaml 4.10.0`.

So how much does multicore need in comparison?
With the fork unlock fix from #731 multicore requires `-m 513G` (513GB) to run the example from #497 on my machine.
This bound can be confirmed with either `afl-fuzz` or the simpler `afl-showmap`: 
```
echo 0 | afl-showmap -m 513G -o out fuzz/test-5.00-forkfix
afl-fuzz -m 513G -i input -o output fuzz/test-5.00-forkfix
```
I understand that this is just a virtual memory reservation, nevertheless for the example to succeed `gdb` tells me that this `caml_mem_map` call passes a `size` of 274877906944 bytes
https://github.com/ocaml-multicore/ocaml-multicore/blob/13a6be2a538434b901404862dc37daadfc862850/runtime/domain.c#L515
which is then doubled and rounded up:
https://github.com/ocaml-multicore/ocaml-multicore/blob/13a6be2a538434b901404862dc37daadfc862850/runtime/platform.c#L134-L136

When AFL's requirements are lower it will instead fail...
In comparison 4.10.0+multicore needs `-m 8197M` on my machine. Since then there was a change to interpret `Minor_heap_max` as words rather than bytes: ade8a064faed15cedac429d45c07896e32aab6f9 I'm not sure it accounts for all of the difference though.

Bottomline: with `afl-fuzz` engineered as it is, this is a visible change from a user's perspective if they try to port a sequential program and fuzz it with 5.00. The PR proposes the simplest fix possible, by setting `Minor_heap_max` to 2097152 words.
This brings down the memory requirement for the example to `-m 4101`.
Perhaps the value should be even lower - or perhaps we should adjust `Max_domains`?