### PR TITLE
add caml_young_alloc_start and caml_young_alloc_end in minor_gc.c

### DIFF
--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -63,7 +63,9 @@ CAMLextern void caml_minor_collection (void);
 
 #ifdef CAML_INTERNALS
 extern void caml_set_minor_heap_size (asize_t); /* size in bytes */
-extern void caml_empty_minor_heap_no_major_slice_from_stw (caml_domain_state* domain, void* unused, int participating_count, caml_domain_state** participating); /* in STW */
+extern void caml_empty_minor_heap_no_major_slice_from_stw 
+  (caml_domain_state* domain, void* unused, int participating_count, 
+    caml_domain_state** participating); /* in STW */
 extern int caml_try_stw_empty_minor_heap_on_all_domains(); /* out STW */
 extern void caml_empty_minor_heaps_once(); /* out STW */
 CAMLextern void garbage_collection (void); /* def in asmrun/signals.c */

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -63,8 +63,8 @@ CAMLextern void caml_minor_collection (void);
 
 #ifdef CAML_INTERNALS
 extern void caml_set_minor_heap_size (asize_t); /* size in bytes */
-extern void caml_empty_minor_heap_no_major_slice_from_stw 
-  (caml_domain_state* domain, void* unused, int participating_count, 
+extern void caml_empty_minor_heap_no_major_slice_from_stw
+  (caml_domain_state* domain, void* unused, int participating_count,
     caml_domain_state** participating); /* in STW */
 extern int caml_try_stw_empty_minor_heap_on_all_domains(); /* out STW */
 extern void caml_empty_minor_heaps_once(); /* out STW */

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -23,6 +23,8 @@
 #define caml_young_ptr Caml_state->young_ptr
 #define caml_young_start Caml_state->young_start
 #define caml_young_limit Caml_state->young_limit
+#define caml_young_alloc_start Caml_state->young_start
+#define caml_young_alloc_end Caml_state->young_end
 #define caml_minor_heap_wsz Caml_state->minor_heap_wsz
 
 


### PR DESCRIPTION
This PR aims to fix a retro-compatibility with the package [wall](https://github.com/let-def/wall/tree/master/lib).
The package use "caml_young_alloc_end"  in the file [wall/lib/wall__backend_stubs.c](https://github.com/let-def/wall/blob/master/lib/wall__backend_stubs.c)

`caml_young_alloc_start` and `caml_young_alloc_end` are not present in `ocaml-multicore`. 
I discussed with @Engil about them in `trunk` and we deduced, they should be the same as `young_start` and `young_end`.