### PR TITLE
Systhreads WG3 comments

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -370,6 +370,9 @@ static void caml_thread_initialize_domain()
   new_thread =
     (caml_thread_t) caml_stat_alloc_noexc(sizeof(struct caml_thread_struct));
 
+  if (new_thread == NULL)
+    caml_raise_out_of_memory();
+
   new_thread->descr = caml_thread_new_descriptor(Val_unit);
   new_thread->next = new_thread;
   new_thread->prev = new_thread;
@@ -527,6 +530,10 @@ CAMLprim value caml_thread_new(value clos)          /* ML */
 #endif
   /* Create a thread info block */
   th = caml_thread_new_info();
+
+  if (th == NULL)
+    caml_raise_out_of_memory();
+
   th->descr = caml_thread_new_descriptor(clos);
 
   th->next = Current_thread->next;

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -77,12 +77,12 @@ struct caml_thread_struct {
   value ** gc_regs_slot;     /* saved value of Caml_state->gc_regs_slot */
   void * exn_handler;        /* saved value of Caml_state->exn_handler */
 
-  #ifndef NATIVE_CODE
+#ifndef NATIVE_CODE
   intnat trap_sp_off;      /* saved value of Caml_state->trap_sp_off */
   intnat trap_barrier_off; /* saved value of Caml_state->trap_barrier_off */
   /* saved value of Caml_state->external_raise */
   struct caml_exception_context* external_raise;
-  #endif
+#endif
 
 };
 
@@ -180,11 +180,11 @@ void caml_thread_save_runtime_state(void)
   Current_thread->backtrace_pos = Caml_state->backtrace_pos;
   Current_thread->backtrace_buffer = Caml_state->backtrace_buffer;
   Current_thread->backtrace_last_exn = Caml_state->backtrace_last_exn;
-  #ifndef NATIVE_CODE
+#ifndef NATIVE_CODE
   Current_thread->trap_sp_off = Caml_state->trap_sp_off;
   Current_thread->trap_barrier_off = Caml_state->trap_barrier_off;
   Current_thread->external_raise = Caml_state->external_raise;
-  #endif
+#endif
 }
 
 void caml_thread_restore_runtime_state(void)
@@ -199,11 +199,11 @@ void caml_thread_restore_runtime_state(void)
   Caml_state->backtrace_pos = Current_thread->backtrace_pos;
   Caml_state->backtrace_buffer = Current_thread->backtrace_buffer;
   Caml_state->backtrace_last_exn = Current_thread->backtrace_last_exn;
-  #ifndef NATIVE_CODE
+#ifndef NATIVE_CODE
   Caml_state->trap_sp_off = Current_thread->trap_sp_off;
   Caml_state->trap_barrier_off = Current_thread->trap_barrier_off;
   Caml_state->external_raise = Current_thread->external_raise;
-  #endif
+#endif
 }
 
 /* Hooks for caml_enter_blocking_section and caml_leave_blocking_section */
@@ -267,11 +267,11 @@ static caml_thread_t caml_thread_new_info(void)
   th->gc_regs_slot = NULL;
   th->exn_handler = NULL;
 
-  #ifndef NATIVE_CODE
+#ifndef NATIVE_CODE
   th->trap_sp_off = 1;
   th->trap_barrier_off = 2;
   th->external_raise = NULL;
-  #endif
+#endif
 
   return th;
 }
@@ -377,9 +377,9 @@ static void caml_thread_initialize_domain()
   new_thread->next = new_thread;
   new_thread->prev = new_thread;
   new_thread->backtrace_last_exn = Val_unit;
-  #ifdef NATIVE_CODE
+#ifdef NATIVE_CODE
   new_thread->exit_buf = &caml_termination_jmpbuf;
-  #endif
+#endif
 
   st_tls_newkey(&Thread_key);
   st_tls_set(Thread_key, (void *) new_thread);

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -32,9 +32,7 @@
 #include "caml/signals.h"
 #include "caml/sys.h"
 #include "caml/memprof.h"
-
-/* threads.h is *not* included since it contains the _external_ declarations for
-   the caml_c_thread_register and caml_c_thread_unregister functions. */
+#include "threads.h"
 
 /* Max computation time before rescheduling, in milliseconds */
 #define Thread_timeout 50

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -371,7 +371,7 @@ static void caml_thread_initialize_domain()
     (caml_thread_t) caml_stat_alloc_noexc(sizeof(struct caml_thread_struct));
 
   if (new_thread == NULL)
-    caml_raise_out_of_memory();
+    caml_fatal_error("could not allocate initial thread descriptor");
 
   new_thread->descr = caml_thread_new_descriptor(Val_unit);
   new_thread->next = new_thread;

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -256,6 +256,10 @@ static caml_thread_t caml_thread_new_info(void)
   th->prev = NULL;
   th->domain_id = domain_state->id;
   th->current_stack = caml_alloc_main_stack(Stack_size / sizeof(value));;
+  if (th->current_stack == NULL) {
+    caml_stat_free(th);
+    return NULL;
+  }
   th->c_stack = NULL;
   th->local_roots = NULL;
   th->exit_buf = NULL;

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -393,12 +393,12 @@ CAMLprim value caml_thread_yield(value unit);
 
 void caml_thread_interrupt_hook(void)
 {
+  uintnat is_on = 1;
   caml_domain_state *domain = Caml_state;
   atomic_uintnat* req_external_interrupt =
     (atomic_uintnat*)&domain->requested_external_interrupt;
 
-  if (atomic_load_acq(req_external_interrupt) == 1) {
-    atomic_store_rel(req_external_interrupt, 0);
+  if (atomic_compare_exchange_strong(req_external_interrupt, &is_on, 0)) {
     caml_thread_yield(Val_unit);
   }
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -367,10 +367,7 @@ value caml_thread_initialize_domain(value v)
   st_masterlock_init(&Thread_main_lock);
 
   new_thread =
-    (caml_thread_t) caml_stat_alloc_noexc(sizeof(struct caml_thread_struct));
-
-  if (new_thread == NULL)
-    caml_raise_out_of_memory();
+    (caml_thread_t) caml_stat_alloc(sizeof(struct caml_thread_struct));
 
   new_thread->descr = caml_thread_new_descriptor(Val_unit);
   new_thread->next = new_thread;

--- a/otherlibs/systhreads/thread.ml
+++ b/otherlibs/systhreads/thread.ml
@@ -18,6 +18,8 @@
 type t
 
 external thread_initialize : unit -> unit = "caml_thread_initialize"
+external thread_initialize_domain : unit -> unit =
+            "caml_thread_initialize_domain"
 external thread_cleanup : unit -> unit = "caml_thread_cleanup"
 external thread_new : (unit -> unit) -> t = "caml_thread_new"
 external thread_uncaught_exception : exn -> unit =
@@ -84,6 +86,7 @@ let preempt_signal =
 
 let () =
   Sys.set_signal preempt_signal (Sys.Signal_handle preempt);
+  Domain.at_startup thread_initialize_domain;
   thread_initialize ();
   Callback.register "Thread.at_shutdown" (fun () ->
     thread_cleanup();

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -143,7 +143,9 @@ let startup_function = Atomic.make (fun () -> ())
 let rec at_startup f =
   let old_startup = Atomic.get startup_function in
   let new_startup () = f (); old_startup () in
-  let success = Atomic.compare_and_set startup_function old_startup new_startup in
+  let success =
+    Atomic.compare_and_set startup_function old_startup new_startup
+  in
   if success then
     ()
   else

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -51,6 +51,11 @@ val at_exit : (unit -> unit) -> unit
     function is also registered with {!Stdlib.at_exit}. If the registered
     function raises an exception, the exceptions are ignored. *)
 
+val at_startup : (unit -> unit) -> unit
+(** Register the given function to be called when a domain starts. This
+    function is called before the callback specified to [spawn f] is
+    executed. *)
+
 val cpu_relax : unit -> unit
 (** If busy-waiting, calling cpu_relax () between iterations
     will improve performance on some CPU architectures *)

--- a/testsuite/tests/backtrace/backtrace_systhreads.reference
+++ b/testsuite/tests/backtrace/backtrace_systhreads.reference
@@ -2,24 +2,24 @@ Thread 2 killed on uncaught exception Failure("0")
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 49, characters 8-14
 Thread 3 killed on uncaught exception Failure("1")
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 49, characters 8-14
 Thread 4 killed on uncaught exception Failure("2")
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 49, characters 8-14
 Thread 5 killed on uncaught exception Failure("3")
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 49, characters 8-14
 Thread 1 killed on uncaught exception Failure("backtrace")
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Backtrace_systhreads.thread_backtrace in file "backtrace_systhreads.ml", line 22, characters 6-27
 Re-raised at Backtrace_systhreads.thread_backtrace in file "backtrace_systhreads.ml", line 26, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 49, characters 8-14

--- a/testsuite/tests/backtrace/callstack.reference
+++ b/testsuite/tests/backtrace/callstack.reference
@@ -12,4 +12,4 @@ Raised by primitive operation at Callstack.f0 in file "callstack.ml", line 11, c
 Called from Callstack.f1 in file "callstack.ml", line 12, characters 27-32
 Called from Callstack.f2 in file "callstack.ml", line 13, characters 27-32
 Called from Callstack.f3 in file "callstack.ml", line 14, characters 27-32
-Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 49, characters 8-14

--- a/testsuite/tests/lib-threads/uncaught_exception_handler.reference
+++ b/testsuite/tests/lib-threads/uncaught_exception_handler.reference
@@ -1,12 +1,12 @@
 Thread 1 killed on uncaught exception Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 28, characters 12-113
-Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 49, characters 8-14
 [thread 2] caught Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 28, characters 12-113
-Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 49, characters 8-14
 Thread 2 killed on uncaught exception Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 28, characters 12-113
-Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 49, characters 8-14
 Thread 2 uncaught exception handler raised Uncaught_exception_handler.UncaughtHandlerExn
 Raised at Uncaught_exception_handler.handler in file "uncaught_exception_handler.ml", line 26, characters 2-26
-Called from Thread.create.(fun) in file "thread.ml", line 53, characters 10-41
+Called from Thread.create.(fun) in file "thread.ml", line 55, characters 10-41


### PR DESCRIPTION
This PR addresses a few comments from the WG3 preliminary review cycle.

Commit names should be self-descriptive.

I felt confident with the suggested changes regarding some memory ordering and switch to non-atomic variables (especially for `m->busy`).

For the failure to allocate thread descriptors: I think raising OOM is fine there, but maybe we want these to be fatal errors?