### PR TITLE
Fix check typo for sync files

### DIFF
--- a/runtime/caml/sync.h
+++ b/runtime/caml/sync.h
@@ -1,3 +1,17 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*          Xavier Leroy and Damien Doligez, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 1996 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
 
 /* POSIX thread implementation of the user facing Mutex and Condition */
 

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -1,3 +1,17 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*          Xavier Leroy and Damien Doligez, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 1996 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
 
 #define CAML_INTERNALS
 
@@ -188,7 +202,7 @@ CAMLprim value caml_ml_condition_new(value unit)        /* ML */
   return wrapper;
 }
 
-CAMLprim value caml_ml_condition_wait(value wcond, value wmut)           /* ML */
+CAMLprim value caml_ml_condition_wait(value wcond, value wmut)     /* ML */
 {
   sync_condvar cond = Condition_val(wcond);
   sync_mutex mut = Mutex_val(wmut);
@@ -219,4 +233,3 @@ CAMLprim value caml_ml_condition_broadcast(value wrapper)           /* ML */
                  "Condition.broadcast");
   return Val_unit;
 }
-


### PR DESCRIPTION
This PR fixes check-typo errors for `sync.c` and `sync.h`.