### PR TITLE
RFC: generalize the Domain.DLS interface to split PRNG state for child domains

### DIFF
--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -215,6 +215,7 @@ stdlib__Domain.cmo : domain.ml \
     stdlib.cmi \
     stdlib__Obj.cmi \
     stdlib__Mutex.cmi \
+    stdlib__List.cmi \
     stdlib__Atomic.cmi \
     stdlib__Array.cmi \
     stdlib__Domain.cmi
@@ -223,6 +224,7 @@ stdlib__Domain.cmx : domain.ml \
     stdlib.cmx \
     stdlib__Obj.cmx \
     stdlib__Mutex.cmx \
+    stdlib__List.cmx \
     stdlib__Atomic.cmx \
     stdlib__Array.cmx \
     stdlib__Domain.cmi

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -46,10 +46,6 @@ type 'a t = {
 module DLS = struct
 
   type dls_state = Obj.t array
-  (* The DLS state, of type [Obj.t array], is in fact manipulated as
-     an heterogeneous array of ['a slot] values. This is an
-     "unboxed-option" (uoption) array, with [unique_value] used to
-     represent [None]. *)
 
   let unique_value = Obj.repr (ref 0)
 
@@ -58,100 +54,80 @@ module DLS = struct
   external set_dls_state : dls_state -> unit =
     "caml_domain_dls_set" [@@noalloc]
 
-  let initial_dynarray_size = 8
-
   let create_dls () =
-    let st = Array.make initial_dynarray_size unique_value in
+    let st = Array.make 8 unique_value in
     set_dls_state st
 
   let _ = create_dls ()
 
-  type 'a key_protocol = {
-    init_orphan: unit -> 'a;
-    split_from_parent: ('a -> 'a Lazy.t) option;
-  }
-
-  type 'a key = int * 'a key_protocol
-
-  type 'a slot = {
-    mutable value: 'a Lazy.t;
-    protocol: 'a key_protocol;
-  }
+  type 'a key = int * (unit -> 'a)
 
   let key_counter = Atomic.make 0
 
-  let new_key ?split_from_parent init_orphan =
-    let k = Atomic.fetch_and_add key_counter 1 in
-    (k, { init_orphan; split_from_parent })
+  type key_initializer =
+    KI: 'a key * ('a -> 'a) -> key_initializer
 
-  let maybe_grow arr idx =
-    let sz = Array.length arr in
-    if idx < sz then arr
+  let parent_keys = Atomic.make ([] : key_initializer list)
+
+  let rec add_parent_key ki =
+    let l = Atomic.get parent_keys in
+    if not (Atomic.compare_and_set parent_keys l (ki :: l))
+    then add_parent_key ki
+
+  let new_key ?split_from_parent init_orphan =
+    let idx = Atomic.fetch_and_add key_counter 1 in
+    let k = (idx, init_orphan) in
+    begin match split_from_parent with
+    | None -> ()
+    | Some split -> add_parent_key (KI(k, split))
+    end;
+    k
+
+  (* If necessary, grow the current domain's local state array such that [idx]
+   * is a valid index in the array. *)
+  let maybe_grow idx =
+    let st = get_dls_state () in
+    let sz = Array.length st in
+    if idx < sz then st
     else begin
       let rec compute_new_size s =
         if idx < s then s else compute_new_size (2 * s)
       in
       let new_sz = compute_new_size sz in
-      let new_arr = Array.make new_sz unique_value in
-      Array.blit arr 0 new_arr 0 sz;
-      new_arr
+      let new_st = Array.make new_sz unique_value in
+      Array.blit st 0 new_st 0 sz;
+      set_dls_state new_st;
+      new_st
     end
 
-  (* If necessary, grow the current domain's local state array such that [idx]
-   * is a valid index in the array. *)
-  let maybe_grow_dls idx =
-    let st = get_dls_state () in
-    let st = maybe_grow st idx in
-    set_dls_state st;
-    st
+  let set (idx, _init) x =
+    let st = maybe_grow idx in
+    (* [Sys.opaque_identity] ensures that flambda does not look at the type of
+     * [x], which may be a [float] and conclude that the [st] is a float array.
+     * We do not want OCaml's float array optimisation kicking in here. *)
+    st.(idx) <- Obj.repr (Sys.opaque_identity x)
 
-  let get (type a) ((idx, protocol) : a key) : a =
-    let st = maybe_grow_dls idx in
-    let slot = st.(idx) in
-    if slot == unique_value then begin
-      let v = protocol.init_orphan () in
-      let slot : a slot = { value = Lazy.from_val v; protocol } in
-      st.(idx) <- Obj.repr slot;
-      v
-    end else
-      Lazy.force (Obj.obj slot : a slot).value
+  let get (idx, init) =
+    let st = maybe_grow idx in
+    let v = st.(idx) in
+    if v == unique_value then
+      let v' = Obj.repr (init ()) in
+      st.(idx) <- (Sys.opaque_identity v');
+      Obj.magic v'
+    else Obj.magic v
 
-  let init key = ignore (get key)
+  let get_initial_keys () : (int * Obj.t) list =
+    List.map
+      (fun (KI ((idx, _) as k, split)) ->
+           (idx, Obj.repr (split (get k))))
+      (Atomic.get parent_keys)
 
-  let set (type a) ((idx, protocol) : a key) (x : a) =
-    let st = maybe_grow_dls idx in
-    let slot = st.(idx) in
-    let x = Lazy.from_val x in
-    if slot == unique_value then begin
-      let slot : a slot = { value = x; protocol } in
-      st.(idx) <- Obj.repr slot;
-    end else
-      (Obj.obj slot : a slot).value <- x
+  let set_initial_keys (l: (int * Obj.t) list) =
+    List.iter
+      (fun (idx, v) ->
+        let st = maybe_grow idx in st.(idx) <- v)
+      l
 
-  (* Keys with a [split_from_parent] function are "inherited keys".
-     When a new domain is spawned, their values in the new domain are
-     computed according to their protocol. *)
-  let inherit_dls dls =
-    let inh : Obj.t array ref =
-      (* Note: we could use the size of the [dls] array, but this
-         would waste memory in the possibly-common case where most
-         keys are Local *)
-      ref (Array.make initial_dynarray_size unique_value) in
-    for idx = 0 to Array.length dls - 1 do
-      let slot : Obj.t = dls.(idx) in
-      if slot == unique_value then ()
-      else begin fun (type a) ->
-        let slot = (Obj.obj slot : a slot) in
-        match slot.protocol.split_from_parent with
-        | None -> ()
-        | Some inheritance ->
-            let v = Lazy.force slot.value in
-            let inherited_slot = { slot with value = inheritance v } in
-            inh := maybe_grow !inh idx;
-            !inh.(idx) <- Obj.repr (inherited_slot : a slot)
-      end
-    done;
-    !inh
 end
 
 (* first spawn and at exit functionality *)
@@ -201,12 +177,11 @@ let cas r vold vnew =
 
 let spawn f =
   do_at_first_spawn ();
+  let pk = DLS.get_initial_keys () in
   let termination_mutex = Mutex.create () in
   let state = Atomic.make Running in
-  let parent_dls = DLS.get_dls_state () in
-  let child_dls = DLS.inherit_dls parent_dls in
   let body () =
-    let result = match DLS.set_dls_state child_dls; f () with
+    let result = match DLS.create_dls (); DLS.set_initial_keys pk; f () with
       | x -> Ok x
       | exception ex -> Error ex
     in

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -74,7 +74,7 @@ module DLS = struct
   type 'a key = int * 'a key_protocol
 
   type 'a slot = {
-    mutable value: 'a;
+    mutable value: 'a Lazy.t;
     protocol: 'a key_protocol;
   }
 
@@ -105,47 +105,33 @@ module DLS = struct
     set_dls_state st;
     st
 
-  let get (type a) ((idx, protocol) : a key) =
+  let get (type a) ((idx, protocol) : a key) : a =
     let st = maybe_grow_dls idx in
     let slot = st.(idx) in
     if slot == unique_value then begin
-      let value = protocol.init_orphan () in
-      let slot : a slot = { value; protocol } in
+      let v = protocol.init_orphan () in
+      let slot : a slot = { value = Lazy.from_val v; protocol } in
       st.(idx) <- Obj.repr slot;
-      slot.value
+      v
     end else
-      (Obj.obj slot : a slot).value
+      Lazy.force (Obj.obj slot : a slot).value
 
   let init key = ignore (get key)
 
   let set (type a) ((idx, protocol) : a key) (x : a) =
     let st = maybe_grow_dls idx in
     let slot = st.(idx) in
+    let x = Lazy.from_val x in
     if slot == unique_value then begin
       let slot : a slot = { value = x; protocol } in
       st.(idx) <- Obj.repr slot;
     end else
       (Obj.obj slot : a slot).value <- x
 
-  type 'a inherited_slot = {
-    child_data: 'a Lazy.t;
-    child_protocol: 'a key_protocol;
-  }
-
   (* Keys with a [split_from_parent] function are "inherited keys".
      When a new domain is spawned, their values in the new domain are
-     computed according to their protocol.
-
-     This requires first some computation on the parent side,
-     performed by [dls_inheritance_data] below, which maps the
-     heterogeneous ['a slot] uoption array into a ['a inherited_slot]
-     uoption array.
-
-     The the new child computes actual slot values from the
-     inheritance data using [become_dls]. This step is performed as an
-     in-place rewriting on the underlying [Obj.t] array, which becomes
-     the DLS state for the new thread. *)
-  let dls_inheritance_data dls =
+     computed according to their protocol. *)
+  let inherit_dls dls =
     let inh : Obj.t array ref =
       (* Note: we could use the size of the [dls] array, but this
          would waste memory in the possibly-common case where most
@@ -159,30 +145,13 @@ module DLS = struct
         match slot.protocol.split_from_parent with
         | None -> ()
         | Some inheritance ->
-            let child_data = inheritance slot.value in
-            let inherited_slot = { child_data; child_protocol = slot.protocol } in
+            let v = Lazy.force slot.value in
+            let inherited_slot = { slot with value = inheritance v } in
             inh := maybe_grow !inh idx;
-            !inh.(idx) <- Obj.repr (inherited_slot : a inherited_slot)
+            !inh.(idx) <- Obj.repr (inherited_slot : a slot)
       end
     done;
     !inh
-
-  let become_dls inh =
-    (* this function mutates [inh] in place, turning it from a heterogeneous
-       ['a inheritance_data] array into a heterogeneous ['a slot] array, both
-       represented as [Obj.t] arrays. *)
-    let st : Obj.t array = inh in
-    for idx = 0 to Array.length inh - 1 do
-      let data : Obj.t = inh.(idx) in
-      if data == unique_value then ()
-      else begin fun (type a) ->
-        let data = (Obj.obj data : a inherited_slot) in
-        let value = Lazy.force data.child_data in
-        let slot : a slot = { value; protocol = data.child_protocol } in
-        st.(idx) <- Obj.repr slot
-      end
-    done;
-    set_dls_state st
 end
 
 (* first spawn and at exit functionality *)
@@ -235,9 +204,9 @@ let spawn f =
   let termination_mutex = Mutex.create () in
   let state = Atomic.make Running in
   let parent_dls = DLS.get_dls_state () in
-  let dls_inheritance = DLS.dls_inheritance_data parent_dls in
+  let child_dls = DLS.inherit_dls parent_dls in
   let body () =
-    let result = match DLS.become_dls dls_inheritance; f () with
+    let result = match DLS.set_dls_state child_dls; f () with
       | x -> Ok x
       | exception ex -> Error ex
     in

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -46,6 +46,10 @@ type 'a t = {
 module DLS = struct
 
   type dls_state = Obj.t array
+  (* The DLS state, of type [Obj.t array], is in fact manipulated as
+     an heterogeneous array of ['a slot] values. This is an
+     "unboxed-option" (uoption) array, with [unique_value] used to
+     represent [None]. *)
 
   let unique_value = Obj.repr (ref 0)
 
@@ -54,53 +58,131 @@ module DLS = struct
   external set_dls_state : dls_state -> unit =
     "caml_domain_dls_set" [@@noalloc]
 
+  let initial_dynarray_size = 8
+
   let create_dls () =
-    let st = Array.make 8 unique_value in
+    let st = Array.make initial_dynarray_size unique_value in
     set_dls_state st
 
   let _ = create_dls ()
 
-  type 'a key = int * (unit -> 'a)
+  type 'a key_protocol = {
+    init_orphan: unit -> 'a;
+    split_from_parent: ('a -> 'a Lazy.t) option;
+  }
+
+  type 'a key = int * 'a key_protocol
+
+  type 'a slot = {
+    mutable value: 'a;
+    protocol: 'a key_protocol;
+  }
 
   let key_counter = Atomic.make 0
 
-  let new_key f =
+  let new_key ?split_from_parent init_orphan =
     let k = Atomic.fetch_and_add key_counter 1 in
-    (k, f)
+    (k, { init_orphan; split_from_parent })
 
-  (* If necessary, grow the current domain's local state array such that [idx]
-   * is a valid index in the array. *)
-  let maybe_grow idx =
-    let st = get_dls_state () in
-    let sz = Array.length st in
-    if idx < sz then st
+  let maybe_grow arr idx =
+    let sz = Array.length arr in
+    if idx < sz then arr
     else begin
       let rec compute_new_size s =
         if idx < s then s else compute_new_size (2 * s)
       in
       let new_sz = compute_new_size sz in
-      let new_st = Array.make new_sz unique_value in
-      Array.blit st 0 new_st 0 sz;
-      set_dls_state new_st;
-      new_st
+      let new_arr = Array.make new_sz unique_value in
+      Array.blit arr 0 new_arr 0 sz;
+      new_arr
     end
 
-  let set (idx, _init) x =
-    let st = maybe_grow idx in
-    (* [Sys.opaque_identity] ensures that flambda does not look at the type of
-     * [x], which may be a [float] and conclude that the [st] is a float array.
-     * We do not want OCaml's float array optimisation kicking in here. *)
-    st.(idx) <- Obj.repr (Sys.opaque_identity x)
+  (* If necessary, grow the current domain's local state array such that [idx]
+   * is a valid index in the array. *)
+  let maybe_grow_dls idx =
+    let st = get_dls_state () in
+    let st = maybe_grow st idx in
+    set_dls_state st;
+    st
 
-  let get (idx, init) =
-    let st = maybe_grow idx in
-    let v = st.(idx) in
-    if v == unique_value then
-      let v' = Obj.repr (init ()) in
-      st.(idx) <- (Sys.opaque_identity v');
-      Obj.magic v'
-    else Obj.magic v
+  let get (type a) ((idx, protocol) : a key) =
+    let st = maybe_grow_dls idx in
+    let slot = st.(idx) in
+    if slot == unique_value then begin
+      let value = protocol.init_orphan () in
+      let slot : a slot = { value; protocol } in
+      st.(idx) <- Obj.repr slot;
+      slot.value
+    end else
+      (Obj.obj slot : a slot).value
 
+  let init key = ignore (get key)
+
+  let set (type a) ((idx, protocol) : a key) (x : a) =
+    let st = maybe_grow_dls idx in
+    let slot = st.(idx) in
+    if slot == unique_value then begin
+      let slot : a slot = { value = x; protocol } in
+      st.(idx) <- Obj.repr slot;
+    end else
+      (Obj.obj slot : a slot).value <- x
+
+  type 'a inherited_slot = {
+    child_data: 'a Lazy.t;
+    child_protocol: 'a key_protocol;
+  }
+
+  (* Keys with a [split_from_parent] function are "inherited keys".
+     When a new domain is spawned, their values in the new domain are
+     computed according to their protocol.
+
+     This requires first some computation on the parent side,
+     performed by [dls_inheritance_data] below, which maps the
+     heterogeneous ['a slot] uoption array into a ['a inherited_slot]
+     uoption array.
+
+     The the new child computes actual slot values from the
+     inheritance data using [become_dls]. This step is performed as an
+     in-place rewriting on the underlying [Obj.t] array, which becomes
+     the DLS state for the new thread. *)
+  let dls_inheritance_data dls =
+    let inh : Obj.t array ref =
+      (* Note: we could use the size of the [dls] array, but this
+         would waste memory in the possibly-common case where most
+         keys are Local *)
+      ref (Array.make initial_dynarray_size unique_value) in
+    for idx = 0 to Array.length dls - 1 do
+      let slot : Obj.t = dls.(idx) in
+      if slot == unique_value then ()
+      else begin fun (type a) ->
+        let slot = (Obj.obj slot : a slot) in
+        match slot.protocol.split_from_parent with
+        | None -> ()
+        | Some inheritance ->
+            let child_data = inheritance slot.value in
+            let inherited_slot = { child_data; child_protocol = slot.protocol } in
+            inh := maybe_grow !inh idx;
+            !inh.(idx) <- Obj.repr (inherited_slot : a inherited_slot)
+      end
+    done;
+    !inh
+
+  let become_dls inh =
+    (* this function mutates [inh] in place, turning it from a heterogeneous
+       ['a inheritance_data] array into a heterogeneous ['a slot] array, both
+       represented as [Obj.t] arrays. *)
+    let st : Obj.t array = inh in
+    for idx = 0 to Array.length inh - 1 do
+      let data : Obj.t = inh.(idx) in
+      if data == unique_value then ()
+      else begin fun (type a) ->
+        let data = (Obj.obj data : a inherited_slot) in
+        let value = Lazy.force data.child_data in
+        let slot : a slot = { value; protocol = data.child_protocol } in
+        st.(idx) <- Obj.repr slot
+      end
+    done;
+    set_dls_state st
 end
 
 (* first spawn and at exit functionality *)
@@ -152,8 +234,10 @@ let spawn f =
   do_at_first_spawn ();
   let termination_mutex = Mutex.create () in
   let state = Atomic.make Running in
+  let parent_dls = DLS.get_dls_state () in
+  let dls_inheritance = DLS.dls_inheritance_data parent_dls in
   let body () =
-    let result = match DLS.create_dls (); f () with
+    let result = match DLS.become_dls dls_inheritance; f () with
       | x -> Ok x
       | exception ex -> Error ex
     in

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -61,20 +61,13 @@ module DLS : sig
     type 'a key
     (** Type of a DLS key *)
 
-    val new_key : ?split_from_parent:('a -> 'a Lazy.t) -> (unit -> 'a) -> 'a key
+    val new_key : ?split_from_parent:('a -> 'a) -> (unit -> 'a) -> 'a key
     (** [new_key f] returns a new key bound to initialiser [f] for accessing
         domain-local variables.
 
         If [split_from_parent] is provided, spawning a domain will derive the
-        child value (for this key) from the parent value. The parent calls
-        [split_from_parent], the child forces the resulting lazy thunk.
+        child value (for this key) from the parent value.
     *)
-
-    val init : 'a key -> unit
-    (** [init k] ensures that the value corresponding to the key [k]
-        in the domain's domain-local state is initialized: it is
-        a no-op if [k] already has a value in the domain, and calls the
-        initialiser of [k] otherwise. *)
 
     val get : 'a key -> 'a
     (** [get k] returns [v] if a value [v] is associated to the key [k] on

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -67,6 +67,11 @@ module DLS : sig
 
         If [split_from_parent] is provided, spawning a domain will derive the
         child value (for this key) from the parent value.
+
+        Note that the [split_from_parent] call is computed in the parent
+        domain, and is always computed regardless of whether the child domain
+        will use it. If the splitting function is expensive or requires
+        client-side computation, consider using ['a Lazy.t key].
     *)
 
     val get : 'a key -> 'a

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -61,18 +61,29 @@ module DLS : sig
     type 'a key
     (** Type of a DLS key *)
 
-    val new_key : (unit -> 'a) -> 'a key
+    val new_key : ?split_from_parent:('a -> 'a Lazy.t) -> (unit -> 'a) -> 'a key
     (** [new_key f] returns a new key bound to initialiser [f] for accessing
-        domain-local variable. *)
+        domain-local variables.
 
-    val set : 'a key -> 'a -> unit
-    (** [set k v] updates the calling domain's domain-local state to associate
-        the key [k] with value [v]. It overwrites any previous values associated
-        to [k], which cannot be restored later. *)
+        If [split_from_parent] is provided, spawning a domain will derive the
+        child value (for this key) from the parent value. The parent calls
+        [split_from_parent], the child forces the resulting lazy thunk.
+    *)
+
+    val init : 'a key -> unit
+    (** [init k] ensures that the value corresponding to the key [k]
+        in the domain's domain-local state is initialized: it is
+        a no-op if [k] already has a value in the domain, and calls the
+        initialiser of [k] otherwise. *)
 
     val get : 'a key -> 'a
     (** [get k] returns [v] if a value [v] is associated to the key [k] on
         the calling domain's domain-local state. Sets [k]'s value with its
         initialiser and returns it otherwise. *)
+
+    val set : 'a key -> 'a -> unit
+    (** [set k v] updates the calling domain's domain-local state to associate
+        the key [k] with value [v]. It overwrites any previous values associated
+        to [k], which cannot be restored later. *)
 
   end

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -328,7 +328,10 @@ let remove_extension name =
 external open_desc: string -> open_flag list -> int -> int = "caml_sys_open"
 external close_desc: int -> unit = "caml_sys_close"
 
-let prng_key = Domain.DLS.new_key Random.State.make_self_init
+let prng_key =
+  Domain.DLS.new_key
+    ~split_from_parent:Random.State.split
+    Random.State.make_self_init
 
 let temp_file_name temp_dir prefix suffix =
   let random_state = Domain.DLS.get prng_key in

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -194,7 +194,7 @@ module State = struct
 
   let split st =
     let seed = Array.init 4 (fun _i -> bits st) in
-    lazy (make seed)
+    make seed
 end
 
 (* This is the state you get with [init 27182818] and then applying

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -215,7 +215,8 @@ let mk_default () = {
   State.idx = 0;
 }
 
-let random_key = Domain.DLS.new_key mk_default
+let random_key =
+  Domain.DLS.new_key ~split_from_parent:State.split mk_default
 
 let bits () = State.bits (Domain.DLS.get random_key)
 let int bound = State.int (Domain.DLS.get random_key) bound

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -192,6 +192,9 @@ module State = struct
     then fun s -> Nativeint.of_int32 (bits32 s)
     else fun s -> Int64.to_nativeint (bits64 s)
 
+  let split st =
+    let seed = Array.init 4 (fun _i -> bits st) in
+    lazy (make seed)
 end
 
 (* This is the state you get with [init 27182818] and then applying

--- a/stdlib/random.mli
+++ b/stdlib/random.mli
@@ -121,7 +121,7 @@ module State : sig
   val copy : t -> t
   (** Return a copy of the given state. *)
 
-  val split : t -> t Lazy.t
+  val split : t -> t
   (** Splits the PRNG state, returning a supposedly-independent state.
       (The current state advances immediately,
        but effect-free initialization of the split state is performed lazily.)

--- a/stdlib/random.mli
+++ b/stdlib/random.mli
@@ -121,6 +121,15 @@ module State : sig
   val copy : t -> t
   (** Return a copy of the given state. *)
 
+  val split : t -> t Lazy.t
+  (** Splits the PRNG state, returning a supposedly-independent state.
+      (The current state advances immediately,
+       but effect-free initialization of the split state is performed lazily.)
+
+      Note: with the current PRNG algorithm, we do not expect splitting to have
+      good statistical properties.
+  *)
+
   val bits : t -> int
   val int : t -> int -> int
   val full_int : t -> int -> int

--- a/testsuite/tests/gc-roots/globroots.ml
+++ b/testsuite/tests/gc-roots/globroots.ml
@@ -30,7 +30,10 @@ module Test(G: GLOBREF) () = struct
 
   let size = 1024
 
-  let random_state = Domain.DLS.new_key Random.State.make_self_init
+  let random_state =
+    Domain.DLS.new_key
+      ~split_from_parent:Random.State.split
+      Random.State.make_self_init
 
   let vals = Array.init size Int.to_string
 

--- a/testsuite/tests/lib-random/parallel.ml
+++ b/testsuite/tests/lib-random/parallel.ml
@@ -7,8 +7,14 @@ let f () =
   let c = Random.int 100 in
   (a, b, c)
 
-let domains = List.init 10 (fun _ -> Domain.spawn f)
+(* We intentionally spawn many more domains than hardware threads, to
+   ensure that we see computations scheduled in a a non-deterministic
+   order. With a small number of domains, it's hard to reliably
+   observe non-determinism. *)
+let domain_count = 1000
+let domains = List.init domain_count (fun _i -> Domain.spawn f)
 let results = List.map Domain.join domains
+let results = List.filteri (fun i _ -> i mod (domain_count / 10) = 0) results
 
 let () =
   results |> List.iter (fun (a, b, c) ->

--- a/testsuite/tests/lib-random/parallel.ml
+++ b/testsuite/tests/lib-random/parallel.ml
@@ -17,5 +17,5 @@ let () =
 
 let () =
   print_endline
-    "Note: the result of this test is currently BROKEN,\n\
-     the random numbers produced by child domain are highly correlated."
+    "Note: we observe in this output that the random numbers of each child domain\n\
+     appear uncorrelated, yet are produced deterministically."

--- a/testsuite/tests/lib-random/parallel.ml
+++ b/testsuite/tests/lib-random/parallel.ml
@@ -1,0 +1,21 @@
+(* TEST *)
+let () = Random.init 42
+
+let f () =
+  let a = Random.int 100 in
+  let b = Random.int 100 in
+  let c = Random.int 100 in
+  (a, b, c)
+
+let domains = List.init 10 (fun _ -> Domain.spawn f)
+let results = List.map Domain.join domains
+
+let () =
+  results |> List.iter (fun (a, b, c) ->
+    Printf.printf "%d %d %d\n%!" a b c
+  )
+
+let () =
+  print_endline
+    "Note: the result of this test is currently BROKEN,\n\
+     the random numbers produced by child domain are highly correlated."

--- a/testsuite/tests/lib-random/parallel.reference
+++ b/testsuite/tests/lib-random/parallel.reference
@@ -1,12 +1,12 @@
 31 7 82
-20 86 99
-3 74 67
-73 1 53
-15 48 91
-48 37 72
-54 68 47
-43 2 60
-41 29 67
-39 43 91
+29 34 8
+77 58 23
+13 34 24
+7 32 68
+3 57 52
+35 60 44
+83 30 33
+90 9 3
+5 6 77
 Note: we observe in this output that the random numbers of each child domain
 appear uncorrelated, yet are produced deterministically.

--- a/testsuite/tests/lib-random/parallel.reference
+++ b/testsuite/tests/lib-random/parallel.reference
@@ -1,12 +1,12 @@
-44 85 82
-44 85 82
-44 85 82
-44 85 82
-44 85 82
-44 85 82
-44 85 82
-44 85 82
-44 85 82
-44 85 82
-Note: the result of this test is currently BROKEN,
-the random numbers produced by child domain are highly correlated.
+31 7 82
+20 86 99
+3 74 67
+73 1 53
+15 48 91
+48 37 72
+54 68 47
+43 2 60
+41 29 67
+39 43 91
+Note: we observe in this output that the random numbers of each child domain
+appear uncorrelated, yet are produced deterministically.

--- a/testsuite/tests/lib-random/parallel.reference
+++ b/testsuite/tests/lib-random/parallel.reference
@@ -1,0 +1,12 @@
+44 85 82
+44 85 82
+44 85 82
+44 85 82
+44 85 82
+44 85 82
+44 85 82
+44 85 82
+44 85 82
+44 85 82
+Note: the result of this test is currently BROKEN,
+the random numbers produced by child domain are highly correlated.

--- a/testsuite/tests/weak-ephe-final/weaklifetime_par.ml
+++ b/testsuite/tests/weak-ephe-final/weaklifetime_par.ml
@@ -3,7 +3,10 @@
 
 let size = 1000;;
 let num_domains = 4;;
-let random_state = Domain.DLS.new_key Random.State.make_self_init
+let random_state =
+  Domain.DLS.new_key
+    ~split_from_parent:Random.State.split
+    Random.State.make_self_init
 
 let random_int = Random.State.int (Domain.DLS.get random_state)
 


### PR DESCRIPTION
This is a "RFC" PR, intended to demonstrate an approach to implement a "proper" PRNG+Domains semantics where spawning a domain "splits" the PRNG state. This required changes to the Domain.DLS interface to support domain-local values that are "inherited" from the parent/spawning domain, with a user-provided function to derive the child state from the parent state.
