### PR TITLE
Move Assert -> CAMLassert

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -462,7 +462,7 @@ static void caml_thread_stop(void)
 
   // The main domain thread does not go through caml_thread_stop.
   // There is always one more thread in the chaining at this point in time.
-  Assert(next != Current_thread);
+  CAMLassert(next != Current_thread);
 
   caml_threadstatus_terminate(Terminated(Current_thread->descr));
   caml_thread_remove_info(Current_thread);

--- a/runtime/addrmap.c
+++ b/runtime/addrmap.c
@@ -1,3 +1,17 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*                 Stephen Dolan, University of Cambridge                 */
+/*                                                                        */
+/*   Copyright 2015 University of Cambridge                               */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
 #include "caml/config.h"
 #include "caml/memory.h"
 #include "caml/addrmap.h"
@@ -10,7 +24,7 @@ static uintnat pos_initial(struct addrmap* t, value key)
   pos *= 0xcc9e2d51;
   pos ^= (pos >> 17);
 
-  Assert(Is_power_of_2(t->size));
+  CAMLassert(Is_power_of_2(t->size));
   return pos & (t->size - 1);
 }
 
@@ -23,7 +37,7 @@ int caml_addrmap_contains(struct addrmap* t, value key)
 {
   uintnat pos, i;
 
-  Assert(Is_block(key));
+  CAMLassert(Is_block(key));
   if (!t->entries) return 0;
 
   for (i = 0, pos = pos_initial(t, key);
@@ -39,11 +53,11 @@ value caml_addrmap_lookup(struct addrmap* t, value key)
 {
   uintnat pos;
 
-  Assert(Is_block(key));
-  Assert(t->entries);
+  CAMLassert(Is_block(key));
+  CAMLassert(t->entries);
 
   for (pos = pos_initial(t, key); ; pos = pos_next(t, pos)) {
-    Assert(t->entries[pos].key != ADDRMAP_INVALID_KEY);
+    CAMLassert(t->entries[pos].key != ADDRMAP_INVALID_KEY);
     if (t->entries[pos].key == key)
       return t->entries[pos].value;
   }
@@ -52,7 +66,7 @@ value caml_addrmap_lookup(struct addrmap* t, value key)
 static void addrmap_alloc(struct addrmap* t, uintnat sz)
 {
   uintnat i;
-  Assert(sz > 0 && (sz & (sz - 1)) == 0); /* sz must be a power of 2 */
+  CAMLassert(sz > 0 && (sz & (sz - 1)) == 0); /* sz must be a power of 2 */
   t->entries = caml_stat_alloc(sizeof(struct addrmap_entry) * sz);
   t->size = sz;
   for (i = 0; i < sz; i++) {
@@ -71,7 +85,7 @@ void caml_addrmap_clear(struct addrmap* t) {
 
 value* caml_addrmap_insert_pos(struct addrmap* t, value key) {
   uintnat i, pos;
-  Assert(Is_block(key));
+  CAMLassert(Is_block(key));
   if (!t->entries) {
     /* first call, initialise table with a small initial size */
     addrmap_alloc(t, 256);
@@ -94,7 +108,7 @@ value* caml_addrmap_insert_pos(struct addrmap* t, value key) {
     for (i = 0; i < old_size; i++) {
       if (old_table[i].key != ADDRMAP_INVALID_KEY) {
         value* p = caml_addrmap_insert_pos(t, old_table[i].key);
-        Assert(*p == ADDRMAP_NOT_PRESENT);
+        CAMLassert(*p == ADDRMAP_NOT_PRESENT);
         *p = old_table[i].value;
       }
     }
@@ -105,7 +119,7 @@ value* caml_addrmap_insert_pos(struct addrmap* t, value key) {
 
 void caml_addrmap_insert(struct addrmap* t, value k, value v) {
   value* p = caml_addrmap_insert_pos(t, k);
-  Assert(*p == ADDRMAP_NOT_PRESENT);
+  CAMLassert(*p == ADDRMAP_NOT_PRESENT);
   *p = v;
 }
 

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -44,9 +44,10 @@ Caml_inline value save_and_clear_stack_parent(caml_domain_state* domain_state) {
   return cont;
 }
 
-Caml_inline void restore_stack_parent(caml_domain_state* domain_state, value cont) {
+Caml_inline void restore_stack_parent(caml_domain_state* domain_state,
+                                      value cont) {
   struct stack_info* parent_stack = Ptr_val(Op_val(cont)[0]);
-  Assert(Stack_parent(domain_state->current_stack) == NULL);
+  CAMLassert(Stack_parent(domain_state->current_stack) == NULL);
   Stack_parent(domain_state->current_stack) = parent_stack;
 }
 
@@ -88,14 +89,16 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[])
 
   CAMLassert(narg + 4 <= 256);
   domain_state->current_stack->sp -= narg + 4;
-  for (i = 0; i < narg; i++) domain_state->current_stack->sp[i] = args[i]; /* arguments */
+  for (i = 0; i < narg; i++)
+    domain_state->current_stack->sp[i] = args[i]; /* arguments */
 
   if (!callback_code_inited) init_callback_code();
 
   callback_code[1] = narg + 3;
   callback_code[3] = narg;
 
-  domain_state->current_stack->sp[narg] = (value)(callback_code + 4); /* return address */
+  domain_state->current_stack->sp[narg] =
+                     (value)(callback_code + 4); /* return address */
   domain_state->current_stack->sp[narg + 1] = Val_unit;    /* environment */
   domain_state->current_stack->sp[narg + 2] = Val_long(0); /* extra args */
   domain_state->current_stack->sp[narg + 3] = closure;
@@ -103,7 +106,8 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[])
   cont = save_and_clear_stack_parent(domain_state);
 
   res = caml_interprete(callback_code, sizeof(callback_code));
-  if (Is_exception_result(res)) domain_state->current_stack->sp += narg + 4; /* PR#3419 */
+  if (Is_exception_result(res))
+    domain_state->current_stack->sp += narg + 4; /* PR#3419 */
 
   restore_stack_parent(domain_state, cont);
 
@@ -141,7 +145,9 @@ static void init_callback_code(void)
 {
 }
 
-typedef value (callback_stub)(caml_domain_state* state, value closure, value* args);
+typedef value (callback_stub)(caml_domain_state* state,
+                              value closure,
+                              value* args);
 
 callback_stub caml_callback_asm, caml_callback2_asm, caml_callback3_asm;
 

--- a/runtime/caml/addrmap.h
+++ b/runtime/caml/addrmap.h
@@ -1,3 +1,16 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*                 Stephen Dolan, University of Cambridge                 */
+/*                                                                        */
+/*   Copyright 2015 University of Cambridge                               */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
 #include "mlvalues.h"
 
 #ifndef CAML_ADDRMAP_H
@@ -31,17 +44,19 @@ void caml_addrmap_iter(struct addrmap* t, void (*f)(value, value));
 
 /* iteration */
 typedef uintnat addrmap_iterator;
-Caml_inline addrmap_iterator caml_addrmap_iter_ok(struct addrmap* t, addrmap_iterator i)
+Caml_inline addrmap_iterator caml_addrmap_iter_ok(struct addrmap* t,
+                                                  addrmap_iterator i)
 {
   if (i < t->size) {
-    Assert(t->entries[i].key != ADDRMAP_INVALID_KEY);
+    CAMLassert(t->entries[i].key != ADDRMAP_INVALID_KEY);
     return 1;
   } else {
     return 0;
   }
 }
 
-Caml_inline addrmap_iterator caml_addrmap_next(struct addrmap* t, addrmap_iterator i)
+Caml_inline addrmap_iterator caml_addrmap_next(struct addrmap* t,
+                                               addrmap_iterator i)
 {
   if (!t->entries) return (uintnat)(-1);
   i++;
@@ -52,21 +67,24 @@ Caml_inline addrmap_iterator caml_addrmap_next(struct addrmap* t, addrmap_iterat
   return i;
 }
 
-Caml_inline value caml_addrmap_iter_key(struct addrmap* t, addrmap_iterator i)
+Caml_inline value caml_addrmap_iter_key(struct addrmap* t,
+                                        addrmap_iterator i)
 {
-  Assert(caml_addrmap_iter_ok(t, i));
+  CAMLassert(caml_addrmap_iter_ok(t, i));
   return t->entries[i].key;
 }
 
-Caml_inline value caml_addrmap_iter_value(struct addrmap* t, addrmap_iterator i)
+Caml_inline value caml_addrmap_iter_value(struct addrmap* t,
+                                          addrmap_iterator i)
 {
-  Assert(caml_addrmap_iter_ok(t, i));
+  CAMLassert(caml_addrmap_iter_ok(t, i));
   return t->entries[i].value;
 }
 
-Caml_inline value* caml_addrmap_iter_val_pos(struct addrmap* t, addrmap_iterator i)
+Caml_inline value* caml_addrmap_iter_val_pos(struct addrmap* t,
+                                             addrmap_iterator i)
 {
-  Assert(caml_addrmap_iter_ok(t, i));
+  CAMLassert(caml_addrmap_iter_ok(t, i));
   return &t->entries[i].value;
 }
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -209,10 +209,6 @@ CAMLnoreturn_end;
 #define CAMLassert(x) ((void) 0)
 #endif
 
-#ifndef CAML_AVOID_CONFLICTS
-#define Assert CAMLassert
-#endif
-
 #ifdef __GNUC__
 #define CAMLcheckresult __attribute__((warn_unused_result))
 #define CAMLlikely(e)   __builtin_expect((e), 1)
@@ -257,9 +253,11 @@ CAMLextern void caml_fatal_error (char *, ...)
   __attribute__ ((format (printf, 1, 2)))
 #endif
 CAMLnoreturn_end;
-CAMLextern void caml_fatal_error_arg (const char *fmt, const char *arg) Noreturn;
+CAMLextern void caml_fatal_error_arg (const char *fmt, const char *arg)
+                                     Noreturn;
 CAMLextern void caml_fatal_error_arg2 (const char *fmt1, const char *arg1,
-                                       const char *fmt2, const char *arg2) Noreturn;
+                                       const char *fmt2, const char *arg2)
+                                      Noreturn;
 
 /* Detection of available C built-in functions, the Clang way. */
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -147,9 +147,9 @@ static struct {
 
 static void add_to_stw_domains(dom_internal* dom) {
   int i;
-  Assert(stw_domains.participating_domains < Max_domains);
+  CAMLassert(stw_domains.participating_domains < Max_domains);
   for(i=stw_domains.participating_domains; stw_domains.domains[i]!=dom; ++i) {
-    Assert(i<Max_domains);
+    CAMLassert(i<Max_domains);
   }
 
   /* swap passed domain with domain at stw_domains.participating_domains */
@@ -163,9 +163,9 @@ static void add_to_stw_domains(dom_internal* dom) {
 static void remove_from_stw_domains(dom_internal* dom) {
   int i;
   for(i=0; stw_domains.domains[i]!=dom; ++i) {
-    Assert(i<Max_domains);
+    CAMLassert(i<Max_domains);
   }
-  Assert(i < stw_domains.participating_domains);
+  CAMLassert(i < stw_domains.participating_domains);
 
   /* swap passed domain to first free domain */
   stw_domains.participating_domains--;
@@ -178,7 +178,7 @@ static dom_internal* next_free_domain() {
   if (stw_domains.participating_domains == Max_domains)
     return NULL;
 
-  Assert(stw_domains.participating_domains < Max_domains);
+  CAMLassert(stw_domains.participating_domains < Max_domains);
   return stw_domains.domains[stw_domains.participating_domains];
 }
 
@@ -219,7 +219,7 @@ static void stw_handler(caml_domain_state* domain);
 static uintnat handle_incoming(struct interruptor* s)
 {
   uintnat handled = atomic_load_acq(&s->interrupt_pending);
-  Assert (s->running);
+  CAMLassert (s->running);
   if (handled) {
     atomic_store_rel(&s->interrupt_pending, 0);
 
@@ -242,7 +242,7 @@ void caml_handle_incoming_interrupts()
 int caml_send_interrupt(struct interruptor* target)
 {
   /* signal that there is an interrupt pending */
-  Assert(!atomic_load_acq(&target->interrupt_pending));
+  CAMLassert(!atomic_load_acq(&target->interrupt_pending));
   atomic_store_rel(&target->interrupt_pending, 1);
 
   /* Signal the condition variable, in case the target is
@@ -293,7 +293,7 @@ asize_t caml_norm_minor_heap_size (intnat wsize)
 int caml_reallocate_minor_heap(asize_t wsize)
 {
   caml_domain_state* domain_state = Caml_state;
-  Assert(domain_state->young_ptr == domain_state->young_end);
+  CAMLassert(domain_state->young_ptr == domain_state->young_end);
 
   /* free old minor heap.
      instead of unmapping the heap, we decommit it, so there's
@@ -332,7 +332,7 @@ int caml_reallocate_minor_heap(asize_t wsize)
 /* must be run on the domain's thread */
 static void create_domain(uintnat initial_minor_heap_wsize) {
   dom_internal* d = 0;
-  Assert (domain_self == 0);
+  CAMLassert (domain_self == 0);
 
   caml_plat_lock(&all_domains_lock);
 
@@ -342,8 +342,8 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
   d = next_free_domain();
   if (d) {
     struct interruptor* s = &d->interruptor;
-    Assert(!s->running);
-    Assert(!s->interrupt_pending);
+    CAMLassert(!s->running);
+    CAMLassert(!s->interrupt_pending);
     if (!s->interrupt_word) {
       caml_domain_state* domain_state;
       atomic_uintnat* young_limit;
@@ -373,7 +373,7 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
     domain_state->id = d->id;
     domain_state->unique_id = d->interruptor.unique_id;
     d->state = domain_state;
-    Assert(!d->interruptor.interrupt_pending);
+    CAMLassert(!d->interruptor.interrupt_pending);
 
     domain_state->extra_heap_resources = 0.0;
     domain_state->extra_heap_resources_minor = 0.0;
@@ -564,7 +564,7 @@ void caml_init_domains(uintnat minor_heap_wsz) {
 }
 
 void caml_init_domain_self(int domain_id) {
-  Assert (domain_id >= 0 && domain_id < Max_domains);
+  CAMLassert (domain_id >= 0 && domain_id < Max_domains);
   domain_self = &all_domains[domain_id];
   SET_Caml_state(domain_self->state);
 }
@@ -617,7 +617,7 @@ static void* backup_thread_func(void* v)
 
   msg = atomic_load_acq (&di->backup_thread_msg);
   while (msg != BT_TERMINATE) {
-    Assert (msg <= BT_TERMINATE);
+    CAMLassert (msg <= BT_TERMINATE);
     switch (msg) {
       case BT_IN_BLOCKING_SECTION:
         /* Handle interrupts on behalf of the main thread:
@@ -670,7 +670,7 @@ static void install_backup_thread (dom_internal* di)
   int err;
 
   if (di->backup_thread_running == 0) {
-    Assert (di->backup_thread_msg == BT_INIT ||     /* Using fresh domain */
+    CAMLassert (di->backup_thread_msg == BT_INIT || /* Using fresh domain */
             di->backup_thread_msg == BT_TERMINATE); /* Reusing domain */
 
     while (atomic_load_acq(&di->backup_thread_msg) != BT_INIT) {
@@ -798,7 +798,7 @@ CAMLprim value caml_domain_spawn(value callback, value mutex)
        p.ml_values is now owned by that domain */
     pthread_detach(th);
   } else {
-    Assert (p.status == Dom_failed);
+    CAMLassert (p.status == Dom_failed);
     /* failed */
     pthread_join(th, 0);
     free_domain_ml_values(p.ml_values);
@@ -980,8 +980,8 @@ int caml_try_run_on_all_domains_with_spin_work(
       if(all_domains[i].interruptor.running)
         domains_participating++;
     }
-    Assert(domains_participating == stw_domains.participating_domains);
-    Assert(domains_participating > 0);
+    CAMLassert(domains_participating == stw_domains.participating_domains);
+    CAMLassert(domains_participating > 0);
   }
 #endif
 
@@ -992,7 +992,7 @@ int caml_try_run_on_all_domains_with_spin_work(
     if (d != domain_state) {
       caml_send_interrupt(&stw_domains.domains[i]->interruptor);
     } else {
-      Assert(!domain_self->interruptor.interrupt_pending);
+      CAMLassert(!domain_self->interruptor.interrupt_pending);
     }
   }
 
@@ -1141,7 +1141,7 @@ CAMLexport void caml_bt_enter_ocaml(void)
 {
   dom_internal* self = domain_self;
 
-  Assert(caml_domain_alone() || self->backup_thread_running);
+  CAMLassert(caml_domain_alone() || self->backup_thread_running);
 
   if (self->backup_thread_running) {
     atomic_store_rel(&self->backup_thread_msg, BT_ENTERING_OCAML);
@@ -1158,7 +1158,7 @@ CAMLexport void caml_bt_exit_ocaml(void)
 {
   dom_internal* self = domain_self;
 
-  Assert(caml_domain_alone() || self->backup_thread_running);
+  CAMLassert(caml_domain_alone() || self->backup_thread_running);
 
   if (self->backup_thread_running) {
     atomic_store_rel(&self->backup_thread_msg, BT_IN_BLOCKING_SECTION);
@@ -1182,8 +1182,8 @@ static void handover_ephemerons(caml_domain_state* domain_state)
     return;
 
   caml_add_to_orphaned_ephe_list(domain_state->ephe_info);
-  Assert (domain_state->ephe_info->live == 0);
-  Assert (domain_state->ephe_info->todo == 0);
+  CAMLassert (domain_state->ephe_info->live == 0);
+  CAMLassert (domain_state->ephe_info->todo == 0);
 }
 
 static void handover_finalisers(caml_domain_state* domain_state)
@@ -1196,7 +1196,7 @@ static void handover_finalisers(caml_domain_state* domain_state)
       /* Force a major GC cycle to simplify constraints for
        * handing over finalisers. */
       caml_finish_major_cycle();
-      Assert(caml_gc_phase == Phase_sweep_and_mark_main);
+      CAMLassert(caml_gc_phase == Phase_sweep_and_mark_main);
     }
     caml_add_orphaned_finalisers (f);
     /* Create a dummy final info */
@@ -1261,7 +1261,7 @@ static void domain_terminate()
       caml_plat_broadcast(&s->cond);
       caml_plat_unlock(&s->lock);
 
-      Assert (domain_self->backup_thread_running);
+      CAMLassert (domain_self->backup_thread_running);
       domain_self->backup_thread_running = 0;
     }
     caml_plat_unlock(&all_domains_lock);

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -312,7 +312,7 @@ void caml_scan_stack(scanning_action f, void* fdata,
   value *low, *high, *sp;
 
   while (stack != NULL) {
-    Assert(stack->magic == 42);
+    CAMLassert(stack->magic == 42);
 
     high = Stack_high(stack);
     low = stack->sp;

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -321,7 +321,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
 #ifdef DEBUG
  next_instr:
   if (caml_icount-- == 0) caml_stop_here ();
-  Assert(Stack_base(domain_state->current_stack) <= sp &&
+  CAMLassert(Stack_base(domain_state->current_stack) <= sp &&
          sp <= Stack_high(domain_state->current_stack));
 #endif
   goto *(void *)(jumptbl_base + *pc++); /* Jump to the first instruction */
@@ -339,7 +339,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       caml_trace_accu_sp_file(accu,sp,prog,prog_size,stdout);
       fflush(stdout);
     };
-    Assert(Stack_base(domain_state->current_stack) <= sp &&
+    CAMLassert(Stack_base(domain_state->current_stack) <= sp &&
            sp <= Stack_high(domain_state->current_stack));
 
 #endif
@@ -552,7 +552,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
         struct stack_info* old_stack = domain_state->current_stack;
         struct stack_info* parent_stack = Stack_parent(old_stack);
         value hval = Stack_handle_value(old_stack);
-        Assert(parent_stack != NULL);
+        CAMLassert(parent_stack != NULL);
 
         old_stack->sp = sp;
         domain_state->current_stack = parent_stack;

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -130,7 +130,7 @@ Caml_inline void write_barrier(
   value obj, intnat field, value old_val, value new_val)
 {
   /* HACK: can't assert when get old C-api style pointers
-    Assert (Is_block(obj)); */
+    CAMLassert (Is_block(obj)); */
 
   if (!Is_young(obj)) {
 
@@ -205,10 +205,10 @@ CAMLexport CAMLweakdef void caml_initialize (value *fp, value val)
 {
 #ifdef DEBUG
   if (Is_young((value)fp))
-    Assert(*fp == Debug_uninit_minor ||
+    CAMLassert(*fp == Debug_uninit_minor ||
            *fp == Val_unit);
   else
-    Assert(*fp == Debug_uninit_major ||
+    CAMLassert(*fp == Debug_uninit_major ||
            *fp == Val_unit);
 #endif
   write_barrier((value)fp, 0, *fp, val);
@@ -311,7 +311,7 @@ CAMLprim value caml_atomic_fetch_add (value ref, value incr)
 CAMLexport void caml_set_fields (value obj, value v)
 {
   int i;
-  Assert (Is_block(obj));
+  CAMLassert (Is_block(obj));
 
   for (i = 0; i < Wosize_val(obj); i++) {
     caml_modify(&Field(obj, i), v);
@@ -323,12 +323,12 @@ CAMLexport void caml_blit_fields (
 {
   CAMLparam2(src, dst);
   int i;
-  Assert(Is_block(src));
-  Assert(Is_block(dst));
-  Assert(srcoff + n <= Wosize_val(src));
-  Assert(dstoff + n <= Wosize_val(dst));
-  Assert(Tag_val(src) != Infix_tag);
-  Assert(Tag_val(dst) != Infix_tag);
+  CAMLassert(Is_block(src));
+  CAMLassert(Is_block(dst));
+  CAMLassert(srcoff + n <= Wosize_val(src));
+  CAMLassert(dstoff + n <= Wosize_val(dst));
+  CAMLassert(Tag_val(src) != Infix_tag);
+  CAMLassert(Tag_val(dst) != Infix_tag);
 
   /* we can't use memcpy/memmove since they may not do atomic word writes.
      for instance, they may copy a byte at a time */

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -1,3 +1,18 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*      KC Sivaramakrishnan, Indian Institute of Technology, Madras       */
+/*                   Stephen Dolan, University of Cambridge               */
+/*                                                                        */
+/*   Copyright 2016 Indian Institute of Technology, Madras                */
+/*   Copyright 2016 University of Cambridge                               */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
 #define CAML_INTERNALS
 
 #include <sys/mman.h>
@@ -57,7 +72,9 @@ static void caml_plat_cond_init_aux(caml_plat_cond *cond)
 {
   pthread_condattr_t attr;
   pthread_condattr_init(&attr);
-#if defined(_POSIX_TIMERS) && defined(_POSIX_MONOTONIC_CLOCK) && _POSIX_MONOTONIC_CLOCK != (-1)
+#if defined(_POSIX_TIMERS) && \
+    defined(_POSIX_MONOTONIC_CLOCK) && \
+    _POSIX_MONOTONIC_CLOCK != (-1)
   pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
 #endif
   pthread_cond_init(&cond->cond, &attr);
@@ -121,7 +138,7 @@ void caml_plat_cond_free(caml_plat_cond* cond)
   ((align) != 0 && ((align) & ((align) - 1)) == 0)
 
 static uintnat round_up(uintnat size, uintnat align) {
-  Assert(Is_power_2(align));
+  CAMLassert(Is_power_2(align));
   return (size + align - 1) & ~(align - 1);
 }
 
@@ -137,10 +154,10 @@ void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only)
   void* mem;
   uintnat base, aligned_start, aligned_end;
 
-  Assert(Is_power_2(alignment));
+  CAMLassert(Is_power_2(alignment));
   alignment = caml_mem_round_up_pages(alignment);
 
-  Assert (alloc_sz > size);
+  CAMLassert (alloc_sz > size);
   mem = mmap(0, alloc_sz, reserve_only ? PROT_NONE : (PROT_READ | PROT_WRITE),
              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   if (mem == MAP_FAILED) {


### PR DESCRIPTION
This PR removes `Assert` and moves the codebase to `CAMLassert`.
See [742#comment](https://github.com/ocaml-multicore/ocaml-multicore/issues/742#issuecomment-974252129); the meeting resolved that we should go to `CAMLassert`.

(along the way we fix license files and line lengths to keep check-typo happy)