### PR TITLE
Signals changes from sync review and WG3

### DIFF
--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -309,11 +309,6 @@ static void * caml_thread_tick(void * arg)
   caml_domain_state *domain;
   uintnat *domain_id = (uintnat *) arg;
   struct timeval timeout;
-  sigset_t mask;
-
-  /* Block all signals so that we don't try to execute an OCaml signal handler*/
-  sigfillset(&mask);
-  pthread_sigmask(SIG_BLOCK, &mask, NULL);
 
   caml_init_domain_self(*domain_id);
   domain = Caml_state;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -590,10 +590,8 @@ struct domain_startup_params {
   struct domain_ml_values* ml_values;
   dom_internal* newdom;
   uintnat unique_id;
-  #ifdef POSIX_SIGNALS
   /* signal mask to set after it is safe to do so */
   sigset_t mask;
-  #endif
 };
 
 static void* backup_thread_func(void* v)
@@ -665,9 +663,7 @@ static void* backup_thread_func(void* v)
 static void install_backup_thread (dom_internal* di)
 {
   int err;
-  #ifdef POSIX_SIGNALS
   sigset_t mask, old_mask;
-  #endif
 
   if (di->backup_thread_running == 0) {
     CAMLassert (di->backup_thread_msg == BT_INIT || /* Using fresh domain */
@@ -680,18 +676,15 @@ static void install_backup_thread (dom_internal* di)
       caml_plat_lock (&di->domain_lock);
     }
 
-    #ifdef POSIX_SIGNALS
     /* No signals on the backup thread */
     sigfillset(&mask);
     pthread_sigmask(SIG_BLOCK, &mask, &old_mask);
-    #endif
 
     atomic_store_rel(&di->backup_thread_msg, BT_ENTERING_OCAML);
     err = pthread_create(&di->backup_thread, 0, backup_thread_func, (void*)di);
 
-    #ifdef POSIX_SIGNALS
     pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
-    #endif
+
     if (err)
       caml_failwith("failed to create domain backup thread");
     di->backup_thread_running = 1;
@@ -750,10 +743,10 @@ static void* domain_thread_func(void* v)
 
   if (domain_self) {
     install_backup_thread(domain_self);
-    #ifdef POSIX_SIGNALS
+
     /* it is now safe for us to handle signals */
     pthread_sigmask(SIG_SETMASK, &p->mask, NULL);
-    #endif
+
     caml_gc_log("Domain starting (unique_id = %"ARCH_INTNAT_PRINTF_FORMAT"u)",
                 domain_self->interruptor.unique_id);
     caml_domain_set_name(T("Domain"));
@@ -776,9 +769,7 @@ CAMLprim value caml_domain_spawn(value callback, value mutex)
   struct domain_startup_params p;
   pthread_t th;
   int err;
-  #ifdef POSIX_SIGNALS
   sigset_t mask, old_mask;
-  #endif
 
   CAML_EV_BEGIN(EV_DOMAIN_SPAWN);
   p.parent = &domain_self->interruptor;
@@ -792,7 +783,6 @@ CAMLprim value caml_domain_spawn(value callback, value mutex)
   }
   init_domain_ml_values(p.ml_values, callback, mutex);
 
-#ifdef POSIX_SIGNALS
 /* we block all signals while we spawn the new domain, this is because
    pthread_create inherits the current signals set and we want to avoid
    a signal handler being triggered in the new domain before
@@ -800,12 +790,9 @@ CAMLprim value caml_domain_spawn(value callback, value mutex)
   sigfillset(&mask);
   pthread_sigmask(SIG_BLOCK, &mask, &old_mask);
   p.mask = old_mask;
-#endif
   err = pthread_create(&th, 0, domain_thread_func, (void*)&p);
-#ifdef POSIX_SIGNALS
   /* we can restore the signal mask we had initially now */
   pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
-#endif
 
   if (err) {
     caml_failwith("failed to create domain thread");

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -115,7 +115,7 @@ CAMLexport void caml_process_pending_signals(void) {
 
 CAMLexport void caml_record_signal(int signal_number)
 {
-  atomic_fetch_add_explicit
+  atomic_store_explicit
     (&caml_pending_signals[signal_number], 1, memory_order_seq_cst);
 
   caml_interrupt_self();

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -64,10 +64,10 @@ CAMLexport value caml_process_pending_signals_exn(void)
   sigset_t set;
 #endif
 
-/* Check that there is indeed a pending signal before issuing the
-    syscall in [pthread_sigmask]. */
-if (!check_for_pending_signals())
-  return Val_unit;
+  /* Check that there is indeed a pending signal before issuing the
+      syscall in [pthread_sigmask]. */
+  if (!check_for_pending_signals())
+    return Val_unit;
 
 #ifdef POSIX_SIGNALS
   pthread_sigmask(/* dummy */ SIG_BLOCK, NULL, &set);

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -86,7 +86,7 @@ if (!check_for_pending_signals())
     if( specific_signal_pending > 0 ) {
       if( !atomic_compare_exchange_strong(
             &caml_pending_signals[i],
-             &specific_signal_pending, specific_signal_pending - 1) ) {
+             &specific_signal_pending, 0) ) {
         /* We failed our CAS because another thread beat us to processing
            this signal. Try again to see if there are more of this signal
            to process. */


### PR DESCRIPTION
This PR implements the three changes coming out of @xavierleroy 's review of the signal code and the comments from the runtime working group:

1. We now block all signals before spawning a domain and then unblock afterwards immediately and when safe to do so for the parent and child respectively. This is https://github.com/ocaml-multicore/ocaml-multicore/commit/3b1db34d0f84ac44d5382bcb638f1e482cc4c7f5
2. We have removed the `total_signals_pending`. This makes some things a little more expensive but the intention is we could potentially optimise these with bitvector tricks or suchlike at a later stage. This is https://github.com/ocaml-multicore/ocaml-multicore/commit/7b389fa4b980732825d4b0fc67b9a18b4190934e
3. We now coalesce signals by signal number. This is https://github.com/ocaml-multicore/ocaml-multicore/commit/5dc58d93ac82021f6771d9cfb9725f8fe46302f7
4. Suspicious indentation in `caml_process_pending_signals_exn` is fixed. This is https://github.com/ocaml-multicore/ocaml-multicore/commit/8de958914bea7188b9a56a158a2762f81f518305 (https://github.com/ocaml-multicore/ocaml-multicore/issues/742)
