### PR TITLE
relaxed -> acquire in minor_gc header read

### DIFF
--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -166,7 +166,7 @@ static void spin_on_header(value v) {
 }
 
 Caml_inline header_t get_header_val(value v) {
-  header_t hd = atomic_load_explicit(Hp_atomic_val(v), memory_order_relaxed);
+  header_t hd = atomic_load_explicit(Hp_atomic_val(v), memory_order_acquire);
   if (!Is_update_in_progress(hd))
     return hd;
 


### PR DESCRIPTION
relaxed -> acquire in minor_gc header read because we read the forwarding pointer straight afterward.

This reimplements https://github.com/ocaml-multicore/ocaml-multicore/pull/365 but against 5.00