### PR TITLE
move frame descriptors header and fix typos

### DIFF
--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -19,7 +19,9 @@
 #ifndef CAML_FRAME_DESCRIPTORS_H
 #define CAML_FRAME_DESCRIPTORS_H
 
-#include "caml/config.h"
+#ifdef CAML_INTERNALS
+
+#include "config.h"
 
 #define Hash_retaddr(addr, mask)                          \
   (((uintnat)(addr) >> 3) & (mask))
@@ -59,5 +61,11 @@ caml_frame_descrs caml_get_frame_descrs(void);
 /* Find the current table of frame descriptors.
    The resulting structure is only valid until the next GC */
 frame_descr* caml_find_frame_descr(caml_frame_descrs fds, uintnat pc);
+
+
+frame_descr * caml_next_frame_descriptor
+    (caml_frame_descrs fds, uintnat * pc, char ** sp, struct stack_info* stack);
+
+#endif /* CAML_INTERNALS */
 
 #endif /* CAML_FRAME_DESCRIPTORS_H */

--- a/runtime/dynlink_nat.c
+++ b/runtime/dynlink_nat.c
@@ -25,7 +25,7 @@
 #include "caml/intext.h"
 #include "caml/osdeps.h"
 #include "caml/fail.h"
-#include "frame_descriptors.h"
+#include "caml/frame_descriptors.h"
 #include "caml/globroots.h"
 #include "caml/signals.h"
 

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -33,7 +33,7 @@
 #include "caml/startup_aux.h"
 #ifdef NATIVE_CODE
 #include "caml/stack.h"
-#include "frame_descriptors.h"
+#include "caml/frame_descriptors.h"
 #endif
 
 #ifdef DEBUG

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -18,8 +18,8 @@
 
 #define CAML_INTERNALS
 
-#include "frame_descriptors.h"
 #include "caml/platform.h"
+#include "caml/frame_descriptors.h"
 #include "caml/major_gc.h" /* for caml_major_cycles_completed */
 #include "caml/memory.h"
 #include <stddef.h>

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -28,7 +28,7 @@
 #include "caml/mlvalues.h"
 #ifdef NATIVE_CODE
 #include "caml/stack.h"
-#include "frame_descriptors.h"
+#include "caml/frame_descriptors.h"
 #endif
 #include "caml/domain.h"
 #include "caml/fiber.h"

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -30,7 +30,7 @@
 #include "caml/domain.h"
 #include "caml/fail.h"
 #include "caml/fiber.h"
-#include "frame_descriptors.h"
+#include "caml/frame_descriptors.h"
 #include "caml/memory.h"
 #include "caml/osdeps.h"
 #include "caml/signals.h"


### PR DESCRIPTION
This PR moves the frame descriptors header from `runtime` to `runtime/caml` and ifdefs with `CAML_INTERNALS`. Adds a check for null that could happen if code is compiled without -g. Also a few sacrifices to check-typo.