### PR TITLE
Allow Dynlink only on Domain 0.

### DIFF
--- a/otherlibs/dynlink/dynlink_common.ml
+++ b/otherlibs/dynlink/dynlink_common.ml
@@ -20,6 +20,14 @@
 
 open! Dynlink_compilerlibs
 
+(* Dynlink is only allowed on the main domain.
+   Entrypoints to public functions should check for this. *)
+let is_dynlink_allowed () =
+  if not (Domain.is_main_domain ()) then
+    failwith "Dynlink can only be called from the main domain."
+  else
+    ()
+
 module String = struct
   include Misc.Stdlib.String
 
@@ -79,6 +87,7 @@ module Make (P : Dynlink_platform_intf.S) = struct
   let unsafe_allowed = ref false
 
   let allow_unsafe_modules b =
+    is_dynlink_allowed();
     unsafe_allowed := b
 
   let check_symbols_disjoint ~descr syms1 syms2 =
@@ -137,6 +146,7 @@ module Make (P : Dynlink_platform_intf.S) = struct
     global_state := state
 
   let init () =
+    is_dynlink_allowed();
     if not !inited then begin
       P.init ();
       default_available_units ();
@@ -270,6 +280,7 @@ module Make (P : Dynlink_platform_intf.S) = struct
     end
 
   let set_allowed_units allowed_units =
+    is_dynlink_allowed();
     let allowed_units = String.Set.of_list allowed_units in
     let state =
       let state = !global_state in
@@ -280,6 +291,7 @@ module Make (P : Dynlink_platform_intf.S) = struct
     global_state := state
 
   let allow_only units =
+    is_dynlink_allowed();
     let allowed_units =
       String.Set.inter (!global_state).allowed_units
         (String.Set.of_list units)
@@ -293,6 +305,7 @@ module Make (P : Dynlink_platform_intf.S) = struct
     global_state := state
 
   let prohibit units =
+    is_dynlink_allowed();
     let allowed_units =
       String.Set.diff (!global_state).allowed_units
         (String.Set.of_list units)

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1331,3 +1331,9 @@ CAMLprim value caml_ml_domain_set_name(value name)
   caml_stat_free(name_os);
   CAMLreturn(Val_unit);
 }
+
+CAMLprim value caml_ml_domain_is_main_domain(value unused)
+{
+  CAMLnoalloc;
+  return Caml_state->id == 0 ? Val_true : Val_false;
+}

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -205,3 +205,5 @@ let get_id { domain; _ } = domain
 let self () = Raw.self ()
 
 external set_name : string -> unit = "caml_ml_domain_set_name"
+
+external is_main_domain : unit -> bool = "caml_ml_domain_is_main_domain"

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -60,6 +60,9 @@ val set_name : string -> unit
     than 15 characters. If [s] is longer than 15 characters,
     raise Invalid_argument. *)
 
+val is_main_domain : unit -> bool
+(** [is_main_domain ()] returns true if called from the initial domain. *)
+
 module DLS : sig
 (** Domain-local Storage *)
 

--- a/testsuite/tests/backtrace/backtrace_dynlink.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.reference
@@ -1,18 +1,18 @@
 Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
 Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
 Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 337, characters 13-44
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 350, characters 13-44
 Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 335, characters 8-240
-Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 347, characters 26-45
+Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 348, characters 8-240
+Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 360, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 35, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
 Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
 Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 10-149
 Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 337, characters 13-44
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 350, characters 13-44
 Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 335, characters 8-240
-Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 345, characters 8-17
-Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 347, characters 26-45
+Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 348, characters 8-240
+Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 358, characters 8-17
+Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 360, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 35, characters 4-52

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -5,8 +5,8 @@ Called from Test10_plugin.f in file "test10_plugin.ml", line 6, characters 2-6
 Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
 Called from Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 137, characters 16-25
 Re-raised at Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 139, characters 6-137
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 337, characters 13-44
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 350, characters 13-44
 Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 335, characters 8-240
-Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 345, characters 8-17
+Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 348, characters 8-240
+Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 358, characters 8-17
 Called from Test10_main in file "test10_main.ml", line 51, characters 13-69

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -2,9 +2,9 @@ Error: Failure("Plugin error")
 Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
 Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 10-149
 Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 337, characters 13-44
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 350, characters 13-44
 Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 335, characters 8-240
-Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 345, characters 8-17
-Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 347, characters 26-45
+Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 348, characters 8-240
+Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 358, characters 8-17
+Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 360, characters 26-45
 Called from Test10_main in file "test10_main.ml", line 49, characters 30-87


### PR DESCRIPTION
As per WG3 synchronous reviews, this PR will prevent any non-Domain 0 from using Dynlink.
This implementation may be a bit heavy handed, I am open to a better approach.
