### PR TITLE
Make Domain.id abstract

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1326,9 +1326,3 @@ CAMLprim value caml_ml_domain_set_name(value name)
   caml_stat_free(name_os);
   CAMLreturn(Val_unit);
 }
-
-CAMLprim value caml_ml_domain_is_main_domain(value unused)
-{
-  CAMLnoalloc;
-  return Caml_state->id == 0 ? Val_true : Val_false;
-}

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -216,8 +216,12 @@ let join { termination_mutex; state; _ } =
 
 let get_id { domain; _ } = domain
 
+let string_of_id (id : id) = string_of_int (id :> int)
+
 let self () = Raw.self ()
 
 external set_name : string -> unit = "caml_ml_domain_set_name"
 
-external is_main_domain : unit -> bool = "caml_ml_domain_is_main_domain"
+let is_main_domain () =
+  let id = Raw.self () in
+  (id :> int) == 0

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -31,11 +31,14 @@ val join : 'a t -> 'a
     Domains may only be joined once: subsequent uses of [join d]
     raise Invalid_argument. *)
 
-type id = private int
+type id
 (** Domains have unique integer identifiers *)
 
 val get_id : 'a t -> id
 (** [get_id d] returns the identifier of the domain [d] *)
+
+val string_of_id : id -> string
+(** [string_of_id id] converts the argument to its string representation *)
 
 val self : unit -> id
 (** [self ()] is the identifier of the currently running domain *)

--- a/testsuite/tests/lazy/lazy3.ml
+++ b/testsuite/tests/lazy/lazy3.ml
@@ -2,8 +2,10 @@
    ocamlopt_flags += " -O3 "
 *)
 
+let get_domain_id () = Domain.self () |> Domain.string_of_id |> int_of_string
+
 let f count =
-  let _n = (Domain.self ():> int) in
+  let _n = get_domain_id () in
   let r = ref 0 in
   for i = 1 to count do
     incr r;
@@ -14,7 +16,7 @@ let main () =
   let l = lazy (f 1_000_000_000) in
   let d1 =
     Domain.spawn (fun () ->
-        let _n = (Domain.self ():> int) in
+        let _n = get_domain_id () in
         Lazy.force l)
   in
   let n2 = Lazy.force l in

--- a/testsuite/tests/lazy/lazy5.ml
+++ b/testsuite/tests/lazy/lazy5.ml
@@ -1,6 +1,9 @@
 (* TEST
    ocamlopt_flags += " -O3 "
 *)
+
+let get_domain_id () = Domain.self () |> Domain.string_of_id |> int_of_string
+
 let rec safe_force l =
   try Lazy.force l with
   | Lazy.Undefined ->
@@ -8,7 +11,7 @@ let rec safe_force l =
       safe_force l
 
 let f count =
-  let _n = (Domain.self ():> int) in
+  let _n = get_domain_id () in
   let r = ref 0 in
   for i = 1 to count do
     incr r;
@@ -18,7 +21,7 @@ let f count =
 let l = lazy (f 1_000_000_000)
 let d1 =
   Domain.spawn (fun () ->
-      let _n = (Domain.self ():> int) in
+      let _n = get_domain_id () in
       safe_force l)
 let n2 = safe_force l
 let n1 = Domain.join d1

--- a/testsuite/tests/lazy/lazy7.ml
+++ b/testsuite/tests/lazy/lazy7.ml
@@ -4,6 +4,8 @@
 
 let num_domains = 4
 
+let get_domain_id () = Domain.self () |> Domain.string_of_id |> int_of_string
+
 let rec safe_force l =
   try Lazy.force l with
   | Lazy.Undefined ->
@@ -11,7 +13,7 @@ let rec safe_force l =
       safe_force l
 
 let f count =
-  let _n = (Domain.self ():> int) in
+  let _n = get_domain_id () in
   let r = ref 0 in
   for _ = 1 to count do
     incr r;
@@ -28,7 +30,7 @@ let d1 = Array.init (num_domains - 1) (fun _->
         else wait ()
       in
       wait ();
-      let _n = (Domain.self ():> int) in
+      let _n = get_domain_id () in
       safe_force l))
 let _ = Atomic.set go true
 let n2 = safe_force l

--- a/testsuite/tests/parallel/atomics.ml
+++ b/testsuite/tests/parallel/atomics.ml
@@ -25,7 +25,7 @@ let test_fetch_add () =
   let r = Atomic.make 0 in
   (* step is relatively prime to Array.length arr *)
   let loop () =
-    let self = (Domain.self () :> int) in
+    let self = (Domain.self () |> Domain.string_of_id |> int_of_string) in
     for i = 1 to count do
       let n = Atomic.fetch_and_add r step mod Array.length arr in
       assert (arr.(n) == (-1));

--- a/testsuite/tests/parallel/domain_id.ml
+++ b/testsuite/tests/parallel/domain_id.ml
@@ -12,9 +12,9 @@ let id () = ()
 
 let newdom_id () =
   let d = Domain.spawn id in
-  let n = Domain.get_id d in
+  let n = Domain.get_id d |> string_of_id |> int_of_string in
   join d;
-  (n :> int)
+  n
 
 let test_domain_reuse () =
   (* checks that domain slots are getting reused quickly,


### PR DESCRIPTION
This PR makes `Domain.id` abstract, as discussed during WG2. (noted as a pre-MVP item)

This PR also take this opportunity to simplify #776's implementation of `Domain.is_main_domain`.

Does the API surrounding `id` sounds reasonable at this point? Should be provide as well an equality story (`Domain.compare_id`)? (since we do not want users to reason about the underlying implementation?)