### PR TITLE
Rename / hide some global variables

### DIFF
--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -47,7 +47,7 @@ typedef uintnat status;
 struct global_heap_state {
   status MARKED, UNMARKED, GARBAGE;
 };
-extern struct global_heap_state global;
+extern struct global_heap_state caml_global_heap_state;
 
 /* CR mshinwell: ensure this matches [Emitaux] */
 enum {NOT_MARKABLE = 3 << 8};
@@ -61,15 +61,15 @@ Caml_inline header_t With_status_hd(header_t hd, status s) {
 }
 
 Caml_inline int is_garbage(value v) {
-  return Has_status_hd(Hd_val(v), global.GARBAGE);
+  return Has_status_hd(Hd_val(v), caml_global_heap_state.GARBAGE);
 }
 
 Caml_inline int is_unmarked(value v) {
-  return Has_status_hd(Hd_val(v), global.UNMARKED);
+  return Has_status_hd(Hd_val(v), caml_global_heap_state.UNMARKED);
 }
 
 Caml_inline int is_marked(value v) {
-  return Has_status_hd(Hd_val(v), global.MARKED);
+  return Has_status_hd(Hd_val(v), caml_global_heap_state.MARKED);
 }
 
 void caml_redarken_pool(struct pool*, scanning_action, void*);

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -1,3 +1,18 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*      KC Sivaramakrishnan, Indian Institute of Technology, Madras       */
+/*                 Stephen Dolan, University of Cambridge                 */
+/*                                                                        */
+/*   Copyright 2015 Indian Institute of Technology, Madras                */
+/*   Copyright 2015 University of Cambridge                               */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
 #ifndef CAML_SHARED_HEAP_H
 #define CAML_SHARED_HEAP_H
 
@@ -14,7 +29,7 @@ struct pool;
 struct caml_heap_state* caml_init_shared_heap();
 void caml_teardown_shared_heap(struct caml_heap_state* heap);
 
-value* caml_shared_try_alloc(struct caml_heap_state*, mlsize_t wosize, tag_t tag, int is_pinned);
+value* caml_shared_try_alloc(struct caml_heap_state*, mlsize_t, tag_t, int);
 
 void caml_sample_heap_stats(struct caml_heap_state*, struct heap_stats*);
 

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -272,7 +272,8 @@ static void oldify_one (void* st_v, value v, value *p)
     else
     {
       /* Conflict - fix up what we allocated on the major heap */
-      *Hp_val(result) = Make_header(1, No_scan_tag, global.MARKED);
+      *Hp_val(result) = Make_header(1, No_scan_tag,
+                                    caml_global_heap_state.MARKED);
       #ifdef DEBUG
       Field(result, 0) = Val_long(1);
       #endif
@@ -296,7 +297,8 @@ static void oldify_one (void* st_v, value v, value *p)
       }
     } else {
       /* Conflict - fix up what we allocated on the major heap */
-      *Hp_val(result) = Make_header(sz, No_scan_tag, global.MARKED);
+      *Hp_val(result) = Make_header(sz, No_scan_tag,
+                                    caml_global_heap_state.MARKED);
       #ifdef DEBUG
       {
         int c;
@@ -317,7 +319,8 @@ static void oldify_one (void* st_v, value v, value *p)
     CAMLassert (infix_offset == 0);
     if( !try_update_object_header(v, p, result, 0) ) {
       /* Conflict */
-      *Hp_val(result) = Make_header(sz, No_scan_tag, global.MARKED);
+      *Hp_val(result) = Make_header(sz, No_scan_tag,
+                                    caml_global_heap_state.MARKED);
       #ifdef DEBUG
       for( i = 0; i < sz ; i++ ) {
         Field(result, i) = Val_long(1);
@@ -348,7 +351,8 @@ static void oldify_one (void* st_v, value v, value *p)
         v = f;
         goto tail_call;
       } else {
-        *Hp_val(result) = Make_header(1, No_scan_tag, global.MARKED);
+        *Hp_val(result) = Make_header(1, No_scan_tag,
+                                      caml_global_heap_state.MARKED);
         #ifdef DEBUG
         Field(result, 0) = Val_long(1);
         #endif

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -610,7 +610,7 @@ void caml_redarken_pool(struct pool* r, scanning_action f, void* fdata) {
 }
 
 
-const header_t atoms[256] = {
+static const header_t atoms[256] = {
 #define A(i) Make_header(0, i, NOT_MARKABLE)
 A(0),A(1),A(2),A(3),A(4),A(5),A(6),A(7),A(8),A(9),A(10),
 A(11),A(12),A(13),A(14),A(15),A(16),A(17),A(18),A(19),A(20),

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -33,7 +33,7 @@
 #include "caml/startup_aux.h"
 
 typedef unsigned int sizeclass;
-struct global_heap_state global = {0 << 8, 1 << 8, 2 << 8};
+struct global_heap_state caml_global_heap_state = {0 << 8, 1 << 8, 2 << 8};
 
 typedef struct pool {
   struct pool* next;
@@ -425,7 +425,7 @@ value* caml_shared_try_alloc(struct caml_heap_state* local, mlsize_t wosize,
     p = large_allocate(local, Bsize_wsize(whsize));
     if (!p) return 0;
   }
-  colour = pinned ? NOT_MARKABLE : global.MARKED;
+  colour = pinned ? NOT_MARKABLE : caml_global_heap_state.MARKED;
   Hd_hp (p) = Make_header(wosize, tag, colour);
 #ifdef DEBUG
   {
@@ -471,7 +471,7 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
       if (hd == 0) {
         /* already on freelist */
         all_used = 0;
-      } else if (Has_status_hd(hd, global.GARBAGE)) {
+      } else if (Has_status_hd(hd, caml_global_heap_state.GARBAGE)) {
         CAMLassert(Whsize_hd(hd) <= wh);
         if (Tag_hd (hd) == Custom_tag) {
           void (*final_fun)(value) = Custom_ops_val(Val_hp(p))->finalize;
@@ -526,7 +526,7 @@ static intnat large_alloc_sweep(struct caml_heap_state* local) {
 
   p = (value*)((char*)a + LARGE_ALLOC_HEADER_SZ);
   hd = (header_t)*p;
-  if (Has_status_hd(hd, global.GARBAGE)) {
+  if (Has_status_hd(hd, caml_global_heap_state.GARBAGE)) {
     if (Tag_hd (hd) == Custom_tag) {
       void (*final_fun)(value) = Custom_ops_val(Val_hp(p))->finalize;
       if (final_fun != NULL) final_fun(Val_hp(p));
@@ -602,7 +602,7 @@ void caml_redarken_pool(struct pool* r, scanning_action f, void* fdata) {
 
   while (p + wh <= end) {
     header_t hd = p[0];
-    if (hd != 0 && Has_status_hd(hd, global.MARKED)) {
+    if (hd != 0 && Has_status_hd(hd, caml_global_heap_state.MARKED)) {
       f(fdata, Val_hp(p), 0);
     }
     p += wh;
@@ -710,7 +710,7 @@ static void verify_object(struct heap_verify_state* st, value v) {
   if (Has_status_hd(Hd_val(v), NOT_MARKABLE)) return;
   st->objs++;
 
-  CAMLassert(Has_status_hd(Hd_val(v), global.UNMARKED));
+  CAMLassert(Has_status_hd(Hd_val(v), caml_global_heap_state.UNMARKED));
 
   if (Tag_val(v) == Cont_tag) {
     struct stack_info* stk = Ptr_val(Field(v, 0));
@@ -761,7 +761,7 @@ static void verify_pool(pool* a, sizeclass sz, struct mem_stats* s) {
 
     while (p + wh <= end) {
       header_t hd = (header_t)*p;
-      CAMLassert(hd == 0 || !Has_status_hd(hd, global.GARBAGE));
+      CAMLassert(hd == 0 || !Has_status_hd(hd, caml_global_heap_state.GARBAGE));
       if (hd) {
         s->live += Whsize_hd(hd);
         s->overhead += wh - Whsize_hd(hd);
@@ -780,7 +780,7 @@ static void verify_pool(pool* a, sizeclass sz, struct mem_stats* s) {
 static void verify_large(large_alloc* a, struct mem_stats* s) {
   for (; a; a = a->next) {
     header_t hd = *(header_t*)((char*)a + LARGE_ALLOC_HEADER_SZ);
-    CAMLassert (!Has_status_hd(hd, global.GARBAGE));
+    CAMLassert (!Has_status_hd(hd, caml_global_heap_state.GARBAGE));
     s->alloced += Wsize_bsize(LARGE_ALLOC_HEADER_SZ) + Whsize_hd(hd);
     s->overhead += Wsize_bsize(LARGE_ALLOC_HEADER_SZ);
     s->live_blocks++;
@@ -825,13 +825,13 @@ static void verify_swept (struct caml_heap_state* local) {
 }
 
 void caml_cycle_heap_stw() {
-  struct global_heap_state oldg = global;
+  struct global_heap_state oldg = caml_global_heap_state;
   struct global_heap_state newg;
   newg.UNMARKED     = oldg.MARKED;
   newg.GARBAGE      = oldg.UNMARKED;
   newg.MARKED       = oldg.GARBAGE; /* should be empty because
                                         garbage was swept */
-  global = newg;
+  caml_global_heap_state = newg;
 }
 
 void caml_cycle_heap(struct caml_heap_state* local) {

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -51,7 +51,7 @@ typedef struct large_alloc {
 CAML_STATIC_ASSERT(sizeof(large_alloc) % sizeof(value) == 0);
 #define LARGE_ALLOC_HEADER_SZ sizeof(large_alloc)
 
-struct {
+static struct {
   caml_plat_mutex lock;
   pool* free;
 


### PR DESCRIPTION
The file `shared_heap.c` exports a few unqualified symbols, which can cause [problems](https://github.com/ocaml/opam-repository/pull/20191#issuecomment-990159065) with code that uses the same names.  This PR qualifies or hides the symbols:

* `extern global` ↝ `extern caml_heap_global_state` (4414682)
* `extern pool_freelist` ↝ `static pool_freelist` (3516dac)
* `extern atoms` ↝  `static atoms` (1be595c)