### PR TITLE
Cherry pick: Merge pull request #701 from ocaml-multicore/really_flush

### DIFF
--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1038,6 +1038,7 @@ let buffered_out_flush oc key () =
   let len = Buffer.length buf in
   let str = Buffer.contents buf in
   output_substring oc str 0 len ;
+  Stdlib.flush oc;
   Buffer.clear buf
 
 let std_buf_key = Domain.DLS.new_key (fun () -> Buffer.create pp_buffer_size)


### PR DESCRIPTION
Really flush output when pre-defined formatters are used in parallel.