### PR TITLE
Unexport some unprefixed global names

### DIFF
--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -31,7 +31,7 @@ struct code_fragment_garbage {
   struct code_fragment_garbage *next;
 };
 
-struct code_fragment_garbage *_Atomic garbage_head = NULL;
+static struct code_fragment_garbage *_Atomic garbage_head = NULL;
 
 static struct lf_skiplist code_fragments_by_pc;
 

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -246,7 +246,8 @@ void caml_debugger_init(void)
   }
   open_connection();
   caml_debugger_in_use = 1;
-  Caml_state->trap_barrier_off = 2; /* Bigger than default caml_trap_sp_off (1) */
+  /* Bigger than default caml_trap_sp_off (1) */
+  Caml_state->trap_barrier_off = 2;
 }
 
 static value getval(struct channel *chan)

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -35,8 +35,6 @@
 int caml_debugger_in_use = 0;
 uintnat caml_event_count;
 int caml_debugger_fork_mode = 1; /* parent by default */
-value marshal_flags;
-
 #if !defined(HAS_SOCKETS) || defined(NATIVE_CODE)
 
 void caml_debugger_init(void)
@@ -91,6 +89,8 @@ struct sockaddr_un {
 #include "caml/mlvalues.h"
 #include "caml/fiber.h"
 #include "caml/sys.h"
+
+static value marshal_flags;
 
 static int sock_domain;         /* Socket domain for the debugger */
 static union {                  /* Socket address for the debugger */

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -81,7 +81,7 @@ uintnat caml_get_num_domains_to_mark () {
 
 extern value caml_ephe_none; /* See weak.c */
 
-struct ephe_cycle_info_t {
+static struct ephe_cycle_info_t {
   atomic_uintnat num_domains_todo;
   /* Number of domains that need to scan their ephemerons in the current major
    * GC cycle. This field is decremented when ephe_info->todo list at a domain

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -224,7 +224,7 @@ void orph_ephe_list_verify_status (int status)
 #define EPHE_MARK_DEFAULT 0
 #define EPHE_MARK_FORCE_ALIVE 1
 
-intnat ephe_mark (intnat budget, uintnat for_cycle, int force_alive);
+static intnat ephe_mark (intnat budget, uintnat for_cycle, int force_alive);
 
 void caml_add_to_orphaned_ephe_list(struct caml_ephe_info* ephe_info)
 {
@@ -787,9 +787,9 @@ void caml_darken(void* state, value v, value* ignored) {
   }
 }
 
-intnat ephe_mark (intnat budget, uintnat for_cycle,
-                  /* Forces ephemerons and their data to be alive */
-                  int force_alive)
+static intnat ephe_mark (intnat budget, uintnat for_cycle,
+                         /* Forces ephemerons and their data to be alive */
+                         int force_alive)
 {
   value v, data, key, f, todo;
   value* prev_linkp;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -875,7 +875,7 @@ intnat ephe_mark (intnat budget, uintnat for_cycle,
   return budget;
 }
 
-intnat ephe_sweep (caml_domain_state* domain_state, intnat budget)
+static intnat ephe_sweep (caml_domain_state* domain_state, intnat budget)
 {
   value v;
   CAMLassert (caml_gc_phase == Phase_sweep_ephe);

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -94,7 +94,7 @@ struct caml_minor_tables* caml_alloc_minor_tables()
   return r;
 }
 
-void reset_minor_tables(struct caml_minor_tables* r)
+static void reset_minor_tables(struct caml_minor_tables* r)
 {
   reset_table((struct generic_table *)&r->major_ref);
   reset_table((struct generic_table *)&r->ephe_ref);

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -673,7 +673,7 @@ struct heap_verify_state* caml_verify_begin()
   return st;
 }
 
-void verify_push(void* st_v, value v, value* p)
+static void verify_push(void* st_v, value v, value* p)
 {
   struct heap_verify_state* st = st_v;
   if (!Is_block(v)) return;

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -40,7 +40,7 @@
 /* The set of pending signals (received but not yet processed) */
 
 CAMLexport atomic_intnat caml_pending_signals[NSIG];
-caml_plat_mutex signal_install_mutex = CAML_PLAT_MUTEX_INITIALIZER;
+static caml_plat_mutex signal_install_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 
 static int check_for_pending_signals(void)
 {


### PR DESCRIPTION
[Follow up to #779]

Make global variables `static` where they aren't prefixed with `caml_`.

Before:
```
$ readelf -s ./runtime/libcamlrun_shared.so  | grep GLOBAL | egrep -v ' UND | caml_'
   198: 00000000000562a0    40 OBJECT  GLOBAL DEFAULT   26 signal_install_mutex
   549: 0000000000000038     8 TLS     GLOBAL DEFAULT   18 Caml_state
   559: 0000000000056680     8 OBJECT  GLOBAL DEFAULT   26 marshal_flags
   622: 000000000001bf10   178 FUNC    GLOBAL DEFAULT   12 ephe_sweep
   642: 00000000000707e0     8 OBJECT  GLOBAL DEFAULT   26 garbage_head
   665: 000000000001bb80   729 FUNC    GLOBAL DEFAULT   12 ephe_mark
   783: 000000000001dfe0   229 FUNC    GLOBAL DEFAULT   12 reset_minor_tables
  1003: 0000000000052b20    24 OBJECT  GLOBAL DEFAULT   26 ephe_cycle_info
  1025: 00000000000165d0    19 FUNC    GLOBAL DEFAULT   12 main
  1042: 00000000000383e0    87 FUNC    GLOBAL DEFAULT   12 verify_push
   323: 0000000000051000     0 OBJECT  LOCAL  DEFAULT   24 _GLOBAL_OFFSET_TABLE_
   454: 0000000000052b20    24 OBJECT  GLOBAL DEFAULT   26 ephe_cycle_info
   564: 00000000000383e0    87 FUNC    GLOBAL DEFAULT   12 verify_push
   577: 00000000000562a0    40 OBJECT  GLOBAL DEFAULT   26 signal_install_mutex
   637: 00000000000707e0     8 OBJECT  GLOBAL DEFAULT   26 garbage_head
   831: 0000000000000038     8 TLS     GLOBAL DEFAULT   18 Caml_state
   910: 0000000000056680     8 OBJECT  GLOBAL DEFAULT   26 marshal_flags
  1092: 00000000000165d0    19 FUNC    GLOBAL DEFAULT   12 main
  1338: 000000000001bf10   178 FUNC    GLOBAL DEFAULT   12 ephe_sweep
  1424: 000000000001bb80   729 FUNC    GLOBAL DEFAULT   12 ephe_mark
  1437: 000000000001dfe0   229 FUNC    GLOBAL DEFAULT   12 reset_minor_tables
```

After:
```
$ readelf -s ./runtime/libcamlrun_shared.so  | grep GLOBAL | egrep -v ' UND | caml_'
   548: 0000000000000038     8 TLS     GLOBAL DEFAULT   18 Caml_state
  1018: 00000000000165a0    19 FUNC    GLOBAL DEFAULT   12 main
   329: 0000000000051000     0 OBJECT  LOCAL  DEFAULT   24 _GLOBAL_OFFSET_TABLE_
   833: 0000000000000038     8 TLS     GLOBAL DEFAULT   18 Caml_state
  1093: 00000000000165a0    19 FUNC    GLOBAL DEFAULT   12 main
```