### PR TITLE
Reimplement `caml_alloc_small` like in OCaml 4.x

### DIFF
--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -158,7 +158,15 @@ CAMLexport value caml_alloc_N (mlsize_t wosize, tag_t tag, ...)
 
 CAMLexport value caml_alloc_small (mlsize_t wosize, tag_t tag)
 {
-  return caml_alloc(wosize, tag);
+  value result;
+
+  CAMLassert (wosize > 0);
+  CAMLassert (wosize <= Max_young_wosize);
+  CAMLassert (tag < 256);
+  CAMLassert (tag != Infix_tag);
+  Alloc_small (result, wosize, tag,
+               { caml_handle_gc_interrupt_no_async_exceptions(); });
+  return result;
 }
 
 /* [n] is a number of words (fields) */


### PR DESCRIPTION
The following idiom is here to stay (it's documented in the OCaml/C API, even though it's in the "low-level interface" section):

    v = caml_alloc_small(sz, tag);
    Field(v, 0) = ... ;
    Field(v, 1) = ... ;

At some point in the development of Multicore OCaml, `caml_alloc_small` was made to just call into `caml_alloc`.

If `sz <= Max_young_wosize`, as it should, everything works fine; it's just a bit less efficient than in OCaml 4.x, owing to the pre-initialization of the fields of the new value.

However, if the programmer made a mistake and `sz` is bigger than `Max_young_wosize`, the OCaml 4.x implementation in debug mode catches the problem with an assertion, while the `caml_alloc` implementation says nothing and returns a block allocated in the major heap.  Then, the direct assignments `Field(v, i) = ...` mess up the GC invariants, but this will not be caught easily.

Hence: the OCaml 4.x implementation of `caml_alloc_small` is preferable, and this PR brings it back.