### PR TITLE
add caml_check_pending_actions, caml_process_pending_actions

### DIFF
--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -37,7 +37,6 @@ int caml_reallocate_minor_heap(asize_t);
 
 int caml_incoming_interrupts_queued(void);
 
-int caml_check_pending_actions();
 void caml_handle_gc_interrupt(void);
 void caml_handle_gc_interrupt_no_async_exceptions(void);
 void caml_handle_incoming_interrupts(void);

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -34,6 +34,15 @@ CAMLextern void caml_enter_blocking_section (void);
 CAMLextern void caml_enter_blocking_section_no_pending (void);
 CAMLextern void caml_leave_blocking_section (void);
 
+CAMLextern void caml_process_pending_actions (void);
+/* Checks for pending actions and executes them. This includes pending
+   minor and major collections, signal handlers, finalisers, and
+   Memprof callbacks. Assumes that the runtime lock is held. Can raise
+   exceptions asynchronously into OCaml code. */
+
+CAMLextern int caml_check_pending_actions (void);
+/* Returns 1 if there are pending actions, 0 otherwise. */
+
 #ifdef CAML_INTERNALS
 CAMLextern atomic_intnat caml_pending_signals[];
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1122,6 +1122,7 @@ static void handle_gc_interrupt() {
 CAMLexport void caml_process_pending_actions(void)
 {
   handle_gc_interrupt();
+  caml_process_pending_signals();
 }
 
 void caml_handle_gc_interrupt_no_async_exceptions()

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1121,11 +1121,7 @@ static void handle_gc_interrupt() {
 
 CAMLexport void caml_process_pending_actions(void)
 {
-  CAMLparam0();
-
   handle_gc_interrupt();
-
-  CAMLreturn0;
 }
 
 void caml_handle_gc_interrupt_no_async_exceptions()

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -1011,8 +1011,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
 
     process_signal:
       Setup_for_event;
-      caml_handle_gc_interrupt();
-      caml_process_pending_signals();
+      caml_process_pending_actions();
       Restore_after_event;
       Next;
 

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -118,7 +118,7 @@ static void check_pending(struct channel *channel)
     /* Temporarily unlock the channel, to ensure locks are not held
        while any signal handlers (or finalisers, etc) are running */
     Unlock(channel);
-    caml_handle_gc_interrupt();
+    caml_process_pending_actions();
     Lock(channel);
   }
 }

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -89,8 +89,7 @@ void caml_garbage_collection()
 
     if (nallocs == 0) {
       /* This is a poll */
-      caml_handle_gc_interrupt(); // process pending actions?
-      caml_process_pending_signals();
+      caml_process_pending_actions();
       return;
     }
     else
@@ -115,8 +114,7 @@ void caml_garbage_collection()
       single call to caml_handle_gc_interrupt does not lead to that. We do it
       in a loop to ensure it. */
     do {
-      caml_handle_gc_interrupt();
-      caml_process_pending_signals();
+      caml_process_pending_actions();
     } while
        ( (uintnat)(Caml_state->young_ptr - whsize) <= Caml_state->young_limit );
 


### PR DESCRIPTION
This PR adds `caml_check_pending_actions` and `caml_process_pending_actions` which are part of the C API that is currently missing.

There's also `caml_process_pending_actions_exn` which I will create an issue for in a minute.