### PR TITLE
stdlib: simplify is_main_domain

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1349,9 +1349,3 @@ CAMLprim value caml_ml_domain_set_name(value name)
   caml_stat_free(name_os);
   CAMLreturn(Val_unit);
 }
-
-CAMLprim value caml_ml_domain_is_main_domain(value unused)
-{
-  CAMLnoalloc;
-  return Caml_state->id == 0 ? Val_true : Val_false;
-}

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -220,4 +220,4 @@ let self () = Raw.self ()
 
 external set_name : string -> unit = "caml_ml_domain_set_name"
 
-external is_main_domain : unit -> bool = "caml_ml_domain_is_main_domain"
+let is_main_domain () = (self () :> int) == 0


### PR DESCRIPTION
This is a followup to #777.
It makes `is_main_domain` simpler and remove the underlying primitive.