### PR TITLE
Revert asmgen testsuite and ocamltest to trunk

### DIFF
--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -633,40 +633,19 @@ let mklib log env =
 
 let ocamlmklib = Actions.make "ocamlmklib" mklib
 
-let finalise_codegen_cc test_basename log env =
-  (* HACKED for multicore asmgen tests *)
-  let obj = Filename.make_filename test_basename Ocamltest_config.objext in
-  let src = Filename.make_filename test_basename "s" in
-  let what = "Running assembler on codegen" in
-  Printf.fprintf log "%s\n%!" what;
-  let commandline = [Ocamltest_config.asm; "-o"; obj; src] in
-  let expected_exit_status = 0 in
-  let exit_status =
-    Actions_helpers.run_cmd
-      ~environment:default_ocaml_env
-      ~stdout_variable:Ocaml_variables.compiler_output
-      ~stderr_variable:Ocaml_variables.compiler_output
-      ~append:true
-      log env commandline in
-  if exit_status=expected_exit_status
-  then begin
-    let archmod = Ocaml_files.asmgen_archmod in
-    let modules = obj ^ " " ^ archmod in
-    let program = Filename.make_filename test_basename "out" in
-    let env = Environments.add_bindings
-    [
-      Builtin_variables.program, program;
-      Ocaml_variables.all_modules, modules;
-      Ocaml_variables.flags,
-        (Environments.safe_lookup Builtin_variables.arguments env);
-    ] env in
-    (Result.pass, env)
-  end else begin
-    let reason =
-      (Actions_helpers.mkreason
-        what (String.concat " " commandline) exit_status) in
-    (Result.fail_with_reason reason, env)
-  end
+let finalise_codegen_cc test_basename _log env =
+  let test_module =
+    Filename.make_filename test_basename "s"
+  in
+  let archmod = Ocaml_files.asmgen_archmod in
+  let modules = test_module ^ " " ^ archmod in
+  let program = Filename.make_filename test_basename "out" in
+  let env = Environments.add_bindings
+  [
+    Ocaml_variables.modules, modules;
+    Builtin_variables.program, program;
+  ] env in
+  (Result.pass, env)
 
 let finalise_codegen_msvc test_basename log env =
   let obj = Filename.make_filename test_basename Ocamltest_config.objext in

--- a/ocamltest/ocaml_tests.ml
+++ b/ocamltest/ocaml_tests.ml
@@ -117,9 +117,9 @@ let asmgen_actions =
   if not Ocamltest_config.native_compiler then [asmgen_skip_on_bytecode_only]
   else if msvc64 then [asmgen_skip_on_msvc64]
   else [
-    setup_ocamlc_opt_build_env;
+    setup_simple_build_env;
     codegen;
-    ocamlc_opt;
+    cc;
   ]
 
 let asmgen =

--- a/testsuite/tests/asmgen/catch-float.cmm
+++ b/testsuite/tests/asmgen/catch-float.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DFLOAT_CATCH -ccopt -DFUN=catch_float main.c"
+arguments = "-DFLOAT_CATCH -DFUN=catch_float main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/catch-multiple.cmm
+++ b/testsuite/tests/asmgen/catch-multiple.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DINT_INT -ccopt -DFUN=catch_multiple main.c"
+arguments = "-DINT_INT -DFUN=catch_multiple main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/catch-rec-deadhandler.cmm
+++ b/testsuite/tests/asmgen/catch-rec-deadhandler.cmm
@@ -1,7 +1,7 @@
 (* TEST
 flags = "-dlive"
 readonly_files = "main.c"
-arguments = "-ccopt -DUNIT_INT -ccopt -DFUN=catch_rec_deadhandler main.c"
+arguments = "-DUNIT_INT -DFUN=catch_rec_deadhandler main.c"
 * asmgen
 ** run
 *** check-program-output

--- a/testsuite/tests/asmgen/catch-rec.cmm
+++ b/testsuite/tests/asmgen/catch-rec.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DINT_INT -ccopt -DFUN=catch_fact main.c"
+arguments = "-DINT_INT -DFUN=catch_fact main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/catch-try-float.cmm
+++ b/testsuite/tests/asmgen/catch-try-float.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DFLOAT_CATCH -ccopt -DFUN=catch_try_float main.c"
+arguments = "-DFLOAT_CATCH -DFUN=catch_try_float main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/catch-try.cmm
+++ b/testsuite/tests/asmgen/catch-try.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DINT_INT -ccopt -DFUN=catch_exit main.c"
+arguments = "-DINT_INT -DFUN=catch_exit main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/checkbound.cmm
+++ b/testsuite/tests/asmgen/checkbound.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DCHECKBOUND main.c"
+arguments = "-DCHECKBOUND main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/even-odd-spill-float.cmm
+++ b/testsuite/tests/asmgen/even-odd-spill-float.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DINT_FLOAT -ccopt -DFUN=is_even main.c"
+arguments = "-DINT_FLOAT -DFUN=is_even main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/even-odd-spill.cmm
+++ b/testsuite/tests/asmgen/even-odd-spill.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DINT_INT -ccopt -DFUN=is_even main.c"
+arguments = "-DINT_INT -DFUN=is_even main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/even-odd.cmm
+++ b/testsuite/tests/asmgen/even-odd.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DINT_INT -ccopt -DFUN=is_even main.c"
+arguments = "-DINT_INT -DFUN=is_even main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/fib.cmm
+++ b/testsuite/tests/asmgen/fib.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DINT_INT -ccopt -DFUN=fib main.c"
+arguments = "-DINT_INT -DFUN=fib main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/integr.cmm
+++ b/testsuite/tests/asmgen/integr.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DINT_FLOAT -ccopt -DFUN=test main.c"
+arguments = "-DINT_FLOAT -DFUN=test main.c"
 * skip
 reason = "This test is currently broken"
 ** asmgen

--- a/testsuite/tests/asmgen/main.c
+++ b/testsuite/tests/asmgen/main.c
@@ -24,6 +24,10 @@ void caml_call_gc()
 {
 
 }
+void caml_call_realloc_stack()
+{
+
+};
 #endif
 
 void caml_ml_array_bound_error(void)

--- a/testsuite/tests/asmgen/pgcd.cmm
+++ b/testsuite/tests/asmgen/pgcd.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DINT_INT -ccopt -DFUN=pgcd_30030 main.c"
+arguments = "-DINT_INT -DFUN=pgcd_30030 main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/quicksort.cmm
+++ b/testsuite/tests/asmgen/quicksort.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DSORT -ccopt -DFUN=quicksort main.c"
+arguments = "-DSORT -DFUN=quicksort main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/quicksort2.cmm
+++ b/testsuite/tests/asmgen/quicksort2.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DSORT -ccopt -DFUN=quicksort main.c"
+arguments = "-DSORT -DFUN=quicksort main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/soli.cmm
+++ b/testsuite/tests/asmgen/soli.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DUNIT_INT -ccopt -DFUN=solitaire main.c"
+arguments = "-DUNIT_INT -DFUN=solitaire main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/tagged-fib.cmm
+++ b/testsuite/tests/asmgen/tagged-fib.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DINT_INT -ccopt -DFUN=fib main.c"
+arguments = "-DINT_INT -DFUN=fib main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/tagged-integr.cmm
+++ b/testsuite/tests/asmgen/tagged-integr.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DINT_FLOAT -ccopt -DFUN=test main.c"
+arguments = "-DINT_FLOAT -DFUN=test main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/tagged-quicksort.cmm
+++ b/testsuite/tests/asmgen/tagged-quicksort.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DSORT -ccopt -DFUN=quicksort main.c"
+arguments = "-DSORT -DFUN=quicksort main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/tagged-tak.cmm
+++ b/testsuite/tests/asmgen/tagged-tak.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DUNIT_INT -ccopt -DFUN=takmain main.c"
+arguments = "-DUNIT_INT -DFUN=takmain main.c"
 * asmgen
 *)
 

--- a/testsuite/tests/asmgen/tak.cmm
+++ b/testsuite/tests/asmgen/tak.cmm
@@ -1,6 +1,6 @@
 (* TEST
 readonly_files = "main.c"
-arguments = "-ccopt -DUNIT_INT -ccopt -DFUN=takmain main.c"
+arguments = "-DUNIT_INT -DFUN=takmain main.c"
 * asmgen
 *)
 


### PR DESCRIPTION
This shaves the diff off by a sizeable amount.
Gist of it was: there was a missing stub for `caml_call_realloc_stack` in `asmgen/main.c`, causing the linker to fail when using trunks code.
Multicore version was linking the program properly with the runtime, actually resolving the symbols, when trunk just stubs these out. (as they don't matter for these testcases.)