### PR TITLE
More comments for domains

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -45,11 +45,7 @@
 #include "caml/sync.h"
 #include "caml/weak.h"
 
-/* Since we support both heavyweight OS threads and lightweight
-   userspace threads, the word "thread" is ambiguous. This file deals
-   with OS-level threads, called "domains".
-
-   From a runtime perspective, domains must handle stop-the-world (STW)
+/* From a runtime perspective, domains must handle stop-the-world (STW)
    sections, during which:
     - they are within a section no mutator code is running
     - all domains will execute the section in parallel

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -632,7 +632,7 @@ static void* backup_thread_func(void* v)
         break;
       case BT_ENTERING_OCAML:
         /* Main thread wants to enter OCaml
-         * Will be woken from caml_enter_blocking_section
+         * Will be woken from caml_bt_exit_ocaml
          * or domain_terminate
          */
         caml_plat_lock(&di->domain_lock);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -51,7 +51,7 @@
 
    From a runtime perspective, domains must handle stop-the-world (STW)
    sections, during which:
-    - within a section no mutator code is running
+    - they are within a section no mutator code is running
     - all domains will execute the section in parallel
     - barriers are provided to know all domains have reached the
       same stage within a section

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -163,6 +163,7 @@ let cas r vold vnew =
 
 let spawn f =
   do_at_first_spawn ();
+  (* the termination_mutex is used to block a joining thread *)
   let termination_mutex = Mutex.create () in
   let state = Atomic.make Running in
   let at_startup = Atomic.get startup_function in


### PR DESCRIPTION
This PR increases the comments in `domain.c` and `domain.ml` to help the reader understand:
 - the high level design of stop-the-world sections
 - the state machine for the backup thread
 - how signalling is handled with a mutex for `Domain.join`
 - how locking protects the stop-the-world participant set