### PR TITLE
Remove difference in stack resize with debug runtime

### DIFF
--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -48,8 +48,7 @@ struct stack_info {
    * size is pooled. If unpooled, it is NULL.
    *
    * Stacks may be unpooled if either the stack size is not 2**N multiple of
-   * [caml_fiber_wsz] (may be the case in debug mode) or the stack is bigger
-   * than pooled sizes. */
+   * [caml_fiber_wsz] or the stack is bigger than pooled sizes. */
   struct stack_info** size_bucket;
   uintnat magic;
 };

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -386,16 +386,12 @@ int caml_try_realloc_stack(asize_t required_space)
 
   old_stack = Caml_state->current_stack;
   stack_used = Stack_high(old_stack) - (value*)old_stack->sp;
-#ifdef DEBUG
-  size = stack_used + stack_used / 16 + required_space;
-  if (size >= caml_max_stack_size) return 0;
-#else
   size = Stack_high(old_stack) - Stack_base(old_stack);
   do {
     if (size >= caml_max_stack_size) return 0;
     size *= 2;
   } while (size < stack_used + required_space);
-#endif
+
   if (size > 4096 / sizeof(value)) {
     caml_gc_log ("Growing stack to %"
                  ARCH_INTNAT_PRINTF_FORMAT "uk bytes",


### PR DESCRIPTION
This PR removes the difference in stack resizing between the standard and debug runtimes. This is a good thing to do because it means that a bug experienced with a standard runtime then has the same stack resizes (assuming sufficient determinism) in the debug runtime. 

This was spotted in review: [742#comment](https://github.com/ocaml-multicore/ocaml-multicore/issues/742#issuecomment-979317516)

(The history for why this was different in DEBUG mode was to provoke a greater number of stack resizes)