### PR TITLE
signal_alloc testcase fix

### DIFF
--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -80,7 +80,7 @@ sp is a local copy of the global variable Caml_state->extern_sp. */
 #define Restore_after_gc \
   { sp = domain_state->current_stack->sp; accu = sp[0]; env = sp[1]; sp += 3; }
 #define Enter_gc \
-  { Setup_for_gc; caml_handle_gc_interrupt(); \
+  { Setup_for_gc; \
     caml_process_pending_actions();         \
     Restore_after_gc; }
 

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -81,7 +81,7 @@ sp is a local copy of the global variable Caml_state->extern_sp. */
   { sp = domain_state->current_stack->sp; accu = sp[0]; env = sp[1]; sp += 3; }
 #define Enter_gc \
   { Setup_for_gc; caml_handle_gc_interrupt(); \
-    caml_check_for_pending_signals();         \
+    caml_process_pending_actions();         \
     Restore_after_gc; }
 
 /* We store [pc+1] in the stack so that, in case of an exception, the

--- a/testsuite/tests/callback/signals_alloc.ml
+++ b/testsuite/tests/callback/signals_alloc.ml
@@ -2,8 +2,6 @@
    include unix
    modules = "callbackprim.c"
    * libunix
-   * skip
-   reason = "singals alloc changes: https://github.com/ocaml/ocaml/pull/9027"
    ** bytecode
    ** native
 *)


### PR DESCRIPTION
@moyodiallo noticed that #722 failed to actually re-enable the `signals_alloc` testcase, and that it was broken on bytecode.
This likely happened on the recent rebase of 722, and was not caught because the testcase got lost in the midst of the `disabled` file removal.
This PR addresses both issues.
