### PR TITLE
Use void parameter, remove unused features.

### DIFF
--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -37,14 +37,14 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
 
   CAMLassert (tag < 256);
   CAMLassert (tag != Infix_tag);
-  if (wosize == 0){
-    result = Atom (tag);
-  } else if (wosize <= Max_young_wosize) {
-    Alloc_small (result, wosize, tag,
-                 { caml_handle_gc_interrupt_no_async_exceptions(); });
-    if (tag < No_scan_tag){
-      for (i = 0; i < wosize; i++) {
-        Field(result, i) = Val_unit;
+  if (wosize <= Max_young_wosize){
+    if (wosize == 0){
+      result = Atom (tag);
+    }else{
+      Alloc_small (result, wosize, tag,
+                   { caml_handle_gc_interrupt_no_async_exceptions(); });
+      if (tag < No_scan_tag){
+        for (i = 0; i < wosize; i++) Field (result, i) = Val_unit;
       }
     }
   } else {
@@ -52,9 +52,8 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
     if (tag < No_scan_tag) {
       for (i = 0; i < wosize; i++) Field (result, i) = Val_unit;
     }
-    result = caml_check_urgent_gc(result);
+    result = caml_check_urgent_gc (result);
   }
-
   return result;
 }
 
@@ -182,10 +181,17 @@ CAMLexport value caml_alloc_tuple(mlsize_t n)
 /* [len] is a number of bytes (chars) */
 CAMLexport value caml_alloc_string (mlsize_t len)
 {
+  value result;
   mlsize_t offset_index;
   mlsize_t wosize = (len + sizeof (value)) / sizeof (value);
-  value result = caml_alloc(wosize, String_tag);
 
+  if (wosize <= Max_young_wosize) {
+    Alloc_small (result, wosize, String_tag,
+                 { caml_handle_gc_interrupt_no_async_exceptions(); });
+  }else{
+    result = caml_alloc_shr (wosize, String_tag);
+    result = caml_check_urgent_gc (result);
+  }
   Field (result, wosize - 1) = 0;
   offset_index = Bsize_wsize (wosize) - 1;
   Byte (result, offset_index) = offset_index - len;
@@ -229,14 +235,13 @@ CAMLexport value caml_alloc_array(value (*funct)(char const *),
 
   nbr = 0;
   while (arr[nbr] != 0) nbr++;
-  if (nbr == 0) {
-    CAMLreturn (Atom(0));
-  } else {
-    result = caml_alloc (nbr, 0);
-    for (n = 0; n < nbr; n++) {
-      Store_field(result, n, funct(arr[n]));
-    }
-    CAMLreturn (result);
+  result = caml_alloc (nbr, 0);
+  for (n = 0; n < nbr; n++) {
+    /* The two statements below must be separate because of evaluation
+       order (don't take the address &Field(result, n) before
+       calling funct, which may cause a GC and move result). */
+    v = funct(arr[n]);
+    caml_modify(&Field(result, n), v);
   }
   CAMLreturn (result);
 }
@@ -250,11 +255,12 @@ value caml_alloc_float_array(mlsize_t len)
   /* For consistency with [caml_make_vect], which can't tell whether it should
      create a float array or not when the size is zero, the tag is set to
      zero when the size is zero. */
-  if (wosize == 0) {
-    return Atom(0);
-  } else if (wosize <= Max_young_wosize) {
-    Alloc_small (result, wosize, Double_array_tag,
-                 { caml_handle_gc_interrupt_no_async_exceptions(); });
+  if (wosize <= Max_young_wosize){
+    if (wosize == 0)
+      return Atom(0);
+    else
+      Alloc_small (result, wosize, Double_array_tag,
+                   { caml_handle_gc_interrupt_no_async_exceptions(); });
   } else {
     result = caml_alloc_shr (wosize, Double_array_tag);
     result = caml_check_urgent_gc (result);
@@ -276,7 +282,7 @@ CAMLexport int caml_convert_flag_list(value list, const int *flags)
   int res;
   res = 0;
   while (list != Val_int(0)) {
-    res |= flags[Int_field(list, 0)];
+    res |= flags[Int_val(Field(list, 0))];
     list = Field(list, 1);
   }
   return res;

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -257,7 +257,8 @@ value caml_remove_debug_info(code_t start)
   CAMLreturn(Val_unit);
 }
 
-int caml_alloc_backtrace_buffer(void){
+int caml_alloc_backtrace_buffer (void)
+{
   CAMLassert(Caml_state->backtrace_pos == 0);
   Caml_state->backtrace_buffer =
     caml_stat_alloc_noexc(BACKTRACE_BUFFER_SIZE * sizeof(code_t));

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -280,7 +280,8 @@ struct named_value {
 static struct named_value * named_value_table[Named_value_size] = { NULL, };
 static caml_plat_mutex named_value_lock = CAML_PLAT_MUTEX_INITIALIZER;
 
-void caml_init_callbacks() {
+void caml_init_callbacks(void)
+{
   init_callback_code();
 }
 

--- a/runtime/caml/codefrag.h
+++ b/runtime/caml/codefrag.h
@@ -38,7 +38,7 @@ struct code_fragment {
 
 /* Initialise codefrag. This must be done before any of the other
    operations in codefrag. */
-void caml_init_codefrag();
+void caml_init_codefrag(void);
 
 /* Register a code fragment for addresses [start] (included)
    to [end] (excluded).  This range of addresses is assumed
@@ -81,7 +81,7 @@ extern unsigned char * caml_digest_of_code_fragment(struct code_fragment *);
 
 /* Cleans up (and frees) removed code fragments. Must be called from a stop the
    world pause by only a single thread. */
-extern void caml_code_fragment_cleanup();
+extern void caml_code_fragment_cleanup(void);
 
 #endif
 

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -64,13 +64,13 @@ CAMLextern atomic_uintnat caml_num_domains_running;
 CAMLextern uintnat caml_minor_heaps_base;
 CAMLextern uintnat caml_minor_heaps_end;
 
-Caml_inline intnat caml_domain_alone()
+Caml_inline intnat caml_domain_alone(void)
 {
   return atomic_load_acq(&caml_num_domains_running) == 1;
 }
 
 #ifdef DEBUG
-int caml_domain_is_in_stw();
+int caml_domain_is_in_stw(void);
 #endif
 
 int caml_try_run_on_all_domains_with_spin_work(
@@ -86,11 +86,11 @@ int caml_try_run_on_all_domains(
 
 /* barriers */
 typedef uintnat barrier_status;
-void caml_global_barrier();
-barrier_status caml_global_barrier_begin();
+void caml_global_barrier(void);
+barrier_status caml_global_barrier_begin(void);
 int caml_global_barrier_is_final(barrier_status);
 void caml_global_barrier_end(barrier_status);
-int caml_global_barrier_num_domains();
+int caml_global_barrier_num_domains(void);
 
 int caml_domain_is_terminating(void);
 

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -114,7 +114,7 @@ void caml_scan_stack(scanning_action f, void* fdata,
    returns nonzero on success */
 int caml_try_realloc_stack (asize_t required_size);
 void caml_change_max_stack_size (uintnat new_max_size);
-void caml_maybe_expand_stack();
+void caml_maybe_expand_stack(void);
 CAMLextern void caml_free_stack(struct stack_info* stk);
 
 #ifdef NATIVE_CODE

--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -23,7 +23,7 @@
 extern uintnat caml_max_stack_size;
 extern uintnat caml_fiber_wsz;
 
-void caml_init_gc ();
+void caml_init_gc (void);
 value caml_gc_stat(value);
 value caml_gc_major(value);
 

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -38,7 +38,7 @@ Caml_inline char caml_gc_phase_char(gc_phase_t phase) {
   }
 }
 
-intnat caml_opportunistic_major_work_available ();
+intnat caml_opportunistic_major_work_available (void);
 void caml_opportunistic_major_collection_slice (intnat);
 /* auto-triggered slice from within the GC */
 #define AUTO_TRIGGERED_MAJOR_SLICE -1
@@ -47,7 +47,6 @@ void caml_opportunistic_major_collection_slice (intnat);
 void caml_major_collection_slice (intnat);
 void caml_finish_sweeping(void);
 void caml_finish_marking (void);
-uintnat caml_get_num_domains_to_mark(void);
 int caml_init_major_gc(caml_domain_state*);
 void caml_teardown_major_gc(void);
 void caml_darken(void*, value, value* ignored);
@@ -58,7 +57,7 @@ void caml_finish_major_cycle(void);
 
 /* Ephemerons and finalisers */
 void caml_ephe_todo_list_emptied(void);
-void caml_orphan_allocated_words();
+void caml_orphan_allocated_words(void);
 void caml_add_to_orphaned_ephe_list(struct caml_ephe_info* ephe_info);
 void caml_add_orphaned_finalisers (struct caml_final_info*);
 void caml_final_domain_terminate (caml_domain_state *domain_state);

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -66,15 +66,15 @@ extern void caml_set_minor_heap_size (asize_t); /* size in bytes */
 extern void caml_empty_minor_heap_no_major_slice_from_stw
   (caml_domain_state* domain, void* unused, int participating_count,
     caml_domain_state** participating); /* in STW */
-extern int caml_try_stw_empty_minor_heap_on_all_domains(); /* out STW */
-extern void caml_empty_minor_heaps_once(); /* out STW */
+extern int caml_try_stw_empty_minor_heap_on_all_domains(void); /* out STW */
+extern void caml_empty_minor_heaps_once(void); /* out STW */
 CAMLextern void garbage_collection (void); /* def in asmrun/signals.c */
 header_t caml_get_header_val(value v);
 void caml_alloc_table (struct caml_ref_table *tbl, asize_t sz, asize_t rsv);
 extern void caml_realloc_ref_table (struct caml_ref_table *);
 extern void caml_realloc_ephe_ref_table (struct caml_ephe_ref_table *);
 extern void caml_realloc_custom_table (struct caml_custom_table *);
-struct caml_minor_tables* caml_alloc_minor_tables();
+struct caml_minor_tables* caml_alloc_minor_tables(void);
 void caml_free_minor_tables(struct caml_minor_tables*);
 void caml_empty_minor_heap_setup(caml_domain_state* domain);
 

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -149,10 +149,6 @@ extern int64_t caml_time_counter(void);
 
 extern void caml_init_os_params(void);
 
-#if defined(DEBUG) || defined(NATIVE_CODE)
-extern void caml_print_trace(void);
-#endif
-
 #endif /* CAML_INTERNALS */
 
 #ifdef _WIN32

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -92,7 +92,7 @@ void caml_plat_mutex_init(caml_plat_mutex*);
 Caml_inline void caml_plat_lock(caml_plat_mutex*);
 Caml_inline int caml_plat_try_lock(caml_plat_mutex*);
 void caml_plat_assert_locked(caml_plat_mutex*);
-void caml_plat_assert_all_locks_unlocked();
+void caml_plat_assert_all_locks_unlocked(void);
 Caml_inline void caml_plat_unlock(caml_plat_mutex*);
 void caml_plat_mutex_free(caml_plat_mutex*);
 typedef struct { pthread_cond_t cond; caml_plat_mutex* mutex; } caml_plat_cond;
@@ -101,7 +101,6 @@ void caml_plat_cond_init(caml_plat_cond*, caml_plat_mutex*);
 void caml_plat_wait(caml_plat_cond*);
 /* like caml_plat_wait, but if nanoseconds surpasses the second parameter
    without a signal, then this function returns 1. */
-int caml_plat_timedwait(caml_plat_cond*, int64_t);
 void caml_plat_broadcast(caml_plat_cond*);
 void caml_plat_signal(caml_plat_cond*);
 void caml_plat_cond_free(caml_plat_cond*);

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -26,7 +26,7 @@
 struct caml_heap_state;
 struct pool;
 
-struct caml_heap_state* caml_init_shared_heap();
+struct caml_heap_state* caml_init_shared_heap(void);
 void caml_teardown_shared_heap(struct caml_heap_state* heap);
 
 value* caml_shared_try_alloc(struct caml_heap_state*, mlsize_t, tag_t, int);
@@ -87,7 +87,7 @@ void caml_cycle_heap(struct caml_heap_state*);
 /* Heap invariant verification (for debugging) */
 
 /* caml_verify_begin must only be called while all domains are paused */
-struct heap_verify_state* caml_verify_begin();
+struct heap_verify_state* caml_verify_begin(void);
 void caml_verify_root(void*, value, value*);
 void caml_verify_heap(struct heap_verify_state*); /* deallocates arg */
 

--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -39,7 +39,7 @@ static struct lf_skiplist code_fragments_by_num;
 
 static int _Atomic code_fragments_counter = 1;
 
-void caml_init_codefrag() {
+void caml_init_codefrag(void) {
   caml_lf_skiplist_init(&code_fragments_by_pc);
   caml_lf_skiplist_init(&code_fragments_by_num);
 }
@@ -139,7 +139,8 @@ caml_find_code_fragment_by_digest(unsigned char digest[16]) {
 }
 
 /* This is only ever called from a stw by one domain */
-void caml_code_fragment_cleanup() {
+void caml_code_fragment_cleanup (void)
+{
   struct code_fragment_garbage *curr;
 
   caml_lf_skiplist_free_garbage(&code_fragments_by_pc);

--- a/runtime/eventlog.c
+++ b/runtime/eventlog.c
@@ -86,9 +86,10 @@ static atomic_uintnat eventlog_paused = 0;
 
 static __thread uint8_t is_backup_thread = 0;
 
-void caml_eventlog_is_backup_thread() {
+void caml_eventlog_is_backup_thread (void)
+{
   is_backup_thread = 1;
-};
+}
 
 static int64_t time_counter(void)
 {
@@ -300,7 +301,7 @@ static void teardown_eventlog(void)
   }
 }
 
-void caml_eventlog_init()
+void caml_eventlog_init (void)
 {
   char_os *toggle = caml_secure_getenv(T("OCAML_EVENTLOG_ENABLED"));
 
@@ -385,7 +386,7 @@ void caml_ev_alloc(uint64_t sz)
   }
 }
 
-void caml_ev_flush()
+void caml_ev_flush (void)
 {
   if (!eventlog_enabled) return;
   if (eventlog_paused) return;
@@ -397,7 +398,7 @@ void caml_ev_flush()
   };
 }
 
-void caml_eventlog_disable()
+void caml_eventlog_disable (void)
 {
   atomic_store_rel(&eventlog_enabled, 0);
 }

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -116,7 +116,7 @@ struct caml_extern_state {
   struct output_block * extern_output_block;
 };
 
-static struct caml_extern_state* get_extern_state ()
+static struct caml_extern_state* get_extern_state (void)
 {
   struct caml_extern_state* extern_state;
 
@@ -140,7 +140,7 @@ static struct caml_extern_state* get_extern_state ()
   return extern_state;
 }
 
-void caml_free_extern_state ()
+void caml_free_extern_state (void)
 {
   if (Caml_state->extern_state != NULL) {
     caml_stat_free(Caml_state->extern_state);

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -57,7 +57,8 @@ void caml_change_max_stack_size (uintnat new_max_size)
   caml_max_stack_size = new_max_size;
 }
 
-struct stack_info** caml_alloc_stack_cache () {
+struct stack_info** caml_alloc_stack_cache (void)
+{
   int i;
 
   struct stack_info** stack_cache =
@@ -245,7 +246,7 @@ void caml_scan_stack(scanning_action f, void* fdata,
   }
 }
 
-void caml_maybe_expand_stack ()
+void caml_maybe_expand_stack (void)
 {
   struct stack_info* stk = Caml_state->current_stack;
   uintnat stack_available =

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -138,7 +138,7 @@ int caml_final_update_last (caml_domain_state* d)
   return 0;
 }
 
-void caml_final_do_calls ()
+void caml_final_do_calls (void)
 {
   struct final f;
   value res;
@@ -400,7 +400,7 @@ CAMLprim value caml_final_release (value unit)
   return Val_unit;
 }
 
-struct caml_final_info* caml_alloc_final_info ()
+struct caml_final_info* caml_alloc_final_info (void)
 {
   struct caml_final_info* f =
     caml_stat_alloc_noexc (sizeof(struct caml_final_info));

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -163,7 +163,7 @@ void caml_register_frametable(intnat *table)
   caml_plat_unlock(&descr_mutex);
 }
 
-caml_frame_descrs caml_get_frame_descrs()
+caml_frame_descrs caml_get_frame_descrs(void)
 {
   struct frametable_version *ft =
     (struct frametable_version*)atomic_load_acq(&current_frametable);

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -87,7 +87,7 @@ CAMLprim value caml_gc_quick_stat(value v)
   CAMLreturn (res);
 }
 
-double caml_gc_minor_words_unboxed()
+double caml_gc_minor_words_unboxed (void)
 {
   return (Caml_state->stat_minor_words
           + ((double) ((uintnat)Caml_state->young_end -
@@ -287,7 +287,7 @@ CAMLprim value caml_get_minor_free (value v)
     ((uintnat)Caml_state->young_ptr - (uintnat)Caml_state->young_start);
 }
 
-void caml_init_gc ()
+void caml_init_gc (void)
 {
   caml_max_stack_size = caml_params->init_max_stack_wsz;
   caml_fiber_wsz = caml_params->init_fiber_wsz;

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -37,7 +37,9 @@ extern code_t caml_start_code;
 
 __thread intnat caml_icount = 0;
 
-void caml_stop_here () {}
+void caml_stop_here (void)
+{
+}
 
 char * caml_instr_string (code_t pc);
 

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -86,7 +86,7 @@ struct caml_intern_state {
 };
 
 /* Allocates the domain local intern state if needed */
-static struct caml_intern_state* get_intern_state ()
+static struct caml_intern_state* get_intern_state (void)
 {
   struct caml_intern_state* s;
 
@@ -110,7 +110,7 @@ static struct caml_intern_state* get_intern_state ()
   return s;
 }
 
-void caml_free_intern_state ()
+void caml_free_intern_state (void)
 {
   if (Caml_state->intern_state != NULL)
     caml_stat_free(Caml_state->intern_state);

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -85,7 +85,7 @@ static void clear_table (struct generic_table *tbl)
     tbl->limit = tbl->threshold;
 }
 
-struct caml_minor_tables* caml_alloc_minor_tables()
+struct caml_minor_tables* caml_alloc_minor_tables(void)
 {
   struct caml_minor_tables *r =
       caml_stat_alloc_noexc(sizeof(struct caml_minor_tables));
@@ -750,7 +750,7 @@ void caml_empty_minor_heap_no_major_slice_from_stw(caml_domain_state* domain,
 }
 
 /* must be called outside a STW section */
-int caml_try_stw_empty_minor_heap_on_all_domains ()
+int caml_try_stw_empty_minor_heap_on_all_domains (void)
 {
   #ifdef DEBUG
   CAMLassert(!caml_domain_is_in_stw());
@@ -766,7 +766,7 @@ int caml_try_stw_empty_minor_heap_on_all_domains ()
 
 /* must be called outside a STW section, will retry until we have emptied our
    minor heap */
-void caml_empty_minor_heaps_once ()
+void caml_empty_minor_heaps_once (void)
 {
   uintnat saved_minor_cycle = atomic_load(&caml_minor_cycles_started);
 

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -51,7 +51,6 @@ void caml_failed_assert (char * expr, char_os * file_os, int line)
   char* file = caml_stat_strdup_of_os(file_os);
   fprintf(stderr, "[%02d] file %s; line %d ### Assertion failed: %s\n",
           Caml_state ? Caml_state->id : -1, file, line, expr);
-  caml_print_trace();
   fflush(stderr);
   caml_stat_free(file);
   abort();
@@ -60,7 +59,7 @@ void caml_failed_assert (char * expr, char_os * file_os, int line)
 
 #if defined(DEBUG)
 static __thread int noalloc_level = 0;
-int caml_noalloc_begin()
+int caml_noalloc_begin(void)
 {
   return noalloc_level++;
 }
@@ -69,7 +68,7 @@ void caml_noalloc_end(int* noalloc)
   int curr = --noalloc_level;
   CAMLassert(*noalloc == curr);
 }
-void caml_alloc_point_here()
+void caml_alloc_point_here(void)
 {
   CAMLassert(noalloc_level == 0);
 }

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -170,10 +170,10 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
   case TOKEN_READ:
     RESTORE;
     if (Is_block(arg)) {
-      env->curr_char = Val_int(Int_field(tables->transl_block, Tag_val(arg)));
+      env->curr_char = Field(tables->transl_block, Tag_val(arg));
       caml_modify(&env->lval, Field(arg, 0));
     } else {
-      env->curr_char = Val_int(Int_field(tables->transl_const, Int_val(arg)));
+      env->curr_char = Field(tables->transl_const, Int_val(arg));
       caml_modify(&env->lval, Val_long(0));
     }
     if (trace()) print_token(tables, state, arg);

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -61,7 +61,7 @@ void caml_plat_assert_locked(caml_plat_mutex* m)
 #endif
 }
 
-void caml_plat_assert_all_locks_unlocked()
+void caml_plat_assert_all_locks_unlocked(void)
 {
 #ifdef DEBUG
   if (lockdepth) caml_fatal_error("Locks still locked at termination");
@@ -96,26 +96,6 @@ void caml_plat_wait(caml_plat_cond* cond)
 {
   caml_plat_assert_locked(cond->mutex);
   check_err("wait", pthread_cond_wait(&cond->cond, cond->mutex));
-}
-
-int caml_plat_timedwait(caml_plat_cond* cond, int64_t until)
-{
-  struct timespec t;
-  int err;
-  if (until < 0) {
-    /* until < 0 has definitely timed out, long ago.
-       letting the code below run risks feeding negative tv_nsec
-       to timedwait, since (-1 % 1000000000) = -1. */
-    return 1;
-  }
-  t.tv_sec  = until / 1000000000;
-  t.tv_nsec = until % 1000000000;
-  err = pthread_cond_timedwait(&cond->cond, cond->mutex, &t);
-  if (err == ETIMEDOUT) {
-    return 1;
-  } else {
-    return 0;
-  }
 }
 
 void caml_plat_broadcast(caml_plat_cond* cond)

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -86,7 +86,7 @@ struct caml_heap_state {
   struct heap_stats stats;
 };
 
-struct caml_heap_state* caml_init_shared_heap() {
+struct caml_heap_state* caml_init_shared_heap (void) {
   int i;
   struct caml_heap_state* heap;
 
@@ -665,7 +665,7 @@ struct heap_verify_state {
   struct addrmap seen;
 };
 
-struct heap_verify_state* caml_verify_begin()
+struct heap_verify_state* caml_verify_begin (void)
 {
   struct heap_verify_state init = {0, 0, 0, 0, ADDRMAP_INIT};
   struct heap_verify_state* st = caml_stat_alloc(sizeof init);
@@ -673,7 +673,7 @@ struct heap_verify_state* caml_verify_begin()
   return st;
 }
 
-static void verify_push(void* st_v, value v, value* p)
+static void verify_push (void* st_v, value v, value* p)
 {
   struct heap_verify_state* st = st_v;
   if (!Is_block(v)) return;
@@ -830,7 +830,7 @@ static void verify_swept (struct caml_heap_state* local) {
   CAMLassert(local->stats.large_blocks == large_stats.live_blocks);
 }
 
-void caml_cycle_heap_stw() {
+void caml_cycle_heap_stw (void) {
   struct global_heap_state oldg = caml_global_heap_state;
   struct global_heap_state newg;
   newg.UNMARKED     = oldg.MARKED;

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -170,7 +170,7 @@ CAMLexport void caml_leave_blocking_section(void)
 
 static value caml_signal_handlers;
 
-void caml_init_signal_handling() {
+void caml_init_signal_handling(void) {
   mlsize_t i;
 
   caml_signal_handlers = caml_alloc_shr(NSIG, 0);
@@ -345,7 +345,7 @@ CAMLexport int caml_rev_convert_signal_number(int signo)
   return signo;
 }
 
-int caml_init_signal_stack()
+int caml_init_signal_stack(void)
 {
 #ifdef POSIX_SIGNALS
   stack_t stk;
@@ -378,7 +378,7 @@ int caml_init_signal_stack()
   return 0;
 }
 
-void caml_free_signal_stack()
+void caml_free_signal_stack(void)
 {
 #ifdef POSIX_SIGNALS
   stack_t stk, disable = {0};

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -57,7 +57,7 @@ extern signal_handler caml_win32_signal(int sig, signal_handler action);
    Only generated assembly code can call [caml_garbage_collection],
    via the caml_call_gc assembly stubs.  */
 
-void caml_garbage_collection()
+void caml_garbage_collection(void)
 {
   frame_descr* d;
   intnat allocsz = 0;

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -40,7 +40,7 @@ extern void caml_win32_unregister_overflow_detection (void);
 static struct caml_params params;
 const struct caml_params* const caml_params = &params;
 
-static void init_startup_params()
+static void init_startup_params(void)
 {
 #ifndef NATIVE_CODE
   char_os * cds_file;

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -269,7 +269,7 @@ extern void caml_signal_thread(void * lpParam);
 #if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
 
 /* PR 4887: avoid crash box of windows runtime on some system calls */
-extern void caml_install_invalid_parameter_handler();
+extern void caml_install_invalid_parameter_handler(void);
 
 #endif
 

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -85,7 +85,7 @@ extern void caml_win32_overflow_detection (void);
 #if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
 
 /* PR 4887: avoid crash box of windows runtime on some system calls */
-extern void caml_install_invalid_parameter_handler();
+extern void caml_install_invalid_parameter_handler(void);
 
 #endif
 

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -50,9 +50,6 @@
 #include <mach-o/dyld.h>
 #endif
 #include <pthread.h>
-#if defined(DEBUG) || defined(NATIVE_CODE)
-#include <execinfo.h>
-#endif
 #include "caml/fail.h"
 #include "caml/memory.h"
 #include "caml/misc.h"
@@ -465,23 +462,3 @@ void caml_init_os_params(void)
   caml_sys_pagesize = sysconf(_SC_PAGESIZE);
   return;
 }
-
-#if defined(DEBUG) || defined(NATIVE_CODE)
-void caml_print_trace(void)
-{
-  void *array[10];
-  size_t size;
-  char **strings;
-  size_t i;
-
-  size = backtrace(array, 10);
-  strings = backtrace_symbols(array, size);
-
-  caml_gc_log("Obtained %ld stack frames.\n", size);
-
-  for (i = 0; i < size; i++)
-    caml_gc_log("[%02zd] %s\n", i, strings[i]);
-
-  free(strings);
-}
-#endif

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -36,7 +36,7 @@ value caml_ephe_none = (value)&caml_dummy[1];
 #define None_val (Val_int(0))
 #define Some_tag 0
 
-struct caml_ephe_info* caml_alloc_ephe_info ()
+struct caml_ephe_info* caml_alloc_ephe_info (void)
 {
   struct caml_ephe_info* e =
     caml_stat_alloc_noexc (sizeof(struct caml_ephe_info));

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -650,7 +650,7 @@ static void invalid_parameter_handler(const wchar_t* expression,
 }
 
 
-void caml_install_invalid_parameter_handler()
+void caml_install_invalid_parameter_handler(void)
 {
   _set_invalid_parameter_handler(invalid_parameter_handler);
 }
@@ -1167,61 +1167,3 @@ int64_t caml_time_counter(void)
   QueryPerformanceCounter(&now);
   return (now.QuadPart * frequency.QuadPart + clock_offset.QuadPart);
 }
-
-#if defined(DEBUG) || defined(NATIVE_CODE)
-void caml_print_trace(void)
-{
-  CONTEXT context;
-  STACKFRAME64 frame;
-  HANDLE hProcess = GetCurrentProcess();
-  HANDLE hThread = GetCurrentThread();
-  static int symbols_loaded = 0;
-  int i = 0;
-
-  memset(&context, 0, sizeof(CONTEXT));
-  memset(&frame, 0, sizeof(STACKFRAME64));
-
-  /* SymCleanup at present is never called */
-  if (!symbols_loaded && SymInitialize(hProcess, NULL, TRUE)) {
-    fprintf(stderr, "Loaded symbols\n");
-    symbols_loaded = 1;
-  }
-
-  context.ContextFlags = CONTEXT_FULL;
-  RtlCaptureContext(&context);
-
-#ifdef _M_X64
-  frame.AddrPC.Mode =
-    frame.AddrFrame.Mode = frame.AddrStack.Mode = AddrModeFlat;
-  frame.AddrPC.Offset = context.Rip;
-  frame.AddrFrame.Offset = context.Rsp;
-  frame.AddrStack.Offset = context.Rsp;
-#else
-#error Unsupported Windows architecture
-#endif
-
-  /* For the symbols to be populated, compile with ocamlopt -g and run
-     `cv2pdb prog.exe` to generate prog.pdb. The output of this stack trace is
-     limited, probably because we make no effort to emit correct DWARF
-     information on Windows.
-
-     cv2pdb can be downloaded from https://github.com/rainers/cv2pdb */
-  while (i++ < 10 && StackWalk64(IMAGE_FILE_MACHINE_AMD64,
-                                 hProcess, hThread,
-                                 &frame, &context, NULL,
-                                 SymFunctionTableAccess64, SymGetModuleBase64,
-                                 NULL)) {
-    char buffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(wchar_t)];
-    PSYMBOL_INFO symbol = (PSYMBOL_INFO)buffer;
-    DWORD64 offset = 0;
-    char *name;
-    symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
-    symbol->MaxNameLen = MAX_SYM_NAME;
-    if (SymFromAddr(hProcess, frame.AddrPC.Offset, &offset, symbol))
-      name = symbol->Name;
-    else
-      name = "???";
-    caml_gc_log("[%02d] %s\n", i, name);
-  }
-}
-#endif

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -148,8 +148,6 @@ type error =
   | No_value_clauses
   | Exception_pattern_disallowed
   | Mixed_value_and_exception_patterns_under_guard
-  | Effect_pattern_below_toplevel
-  | Invalid_continuation_pattern
   | Inlined_record_escape
   | Inlined_record_expected
   | Unrefuted_pattern of pattern
@@ -5819,12 +5817,6 @@ let report_error ~loc env = function
       Location.errorf ~loc
         "@[Mixing value and exception patterns under when-guards is not \
          supported.@]"
-  | Effect_pattern_below_toplevel ->
-      Location.errorf ~loc
-        "@[Effect patterns must be at the top level of a match case.@]"
-  | Invalid_continuation_pattern ->
-      Location.errorf ~loc
-        "@[Invalid continuation pattern: only variables and _ are allowed .@]"
   | Inlined_record_escape ->
       Location.errorf ~loc
         "@[This form is not allowed as the type of the inlined record could \

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -198,8 +198,6 @@ type error =
   | No_value_clauses
   | Exception_pattern_disallowed
   | Mixed_value_and_exception_patterns_under_guard
-  | Effect_pattern_below_toplevel
-  | Invalid_continuation_pattern
   | Inlined_record_escape
   | Inlined_record_expected
   | Unrefuted_pattern of Typedtree.pattern


### PR DESCRIPTION
* Stick to ISO C, and use an explicit `void` parameter when appropriate. 
* Remove unused runtime functions -- `caml_print_trace`, `caml_get_num_domains_to_mark`, `caml_plat_timedwait`.
* Remove unused error patterns in typecore that is left over from effect syntax. 