### PR TITLE
Revert array.c to trunk. Introduce word-sized memmove.

### DIFF
--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -289,8 +289,6 @@ CAMLprim value caml_convert_raw_backtrace(value bt)
 
   array = caml_alloc(index, 0);
 
-  for (i = 0; i < index; i++) Field(array, i) = Val_unit;
-
   for (i = 0, index = 0; i < Wosize_val(bt); ++i)
   {
     debuginfo dbg;

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -465,8 +465,6 @@ static void read_main_debug_info(struct debug_info *di)
     num_events = caml_getword(chan);
     events = caml_alloc(num_events, 0);
 
-    for (i = 0; i < num_events; i++) Field(events, i) = Val_unit;
-
     for (i = 0; i < num_events; i++) {
       orig = caml_getword(chan);
       evl = caml_input_val(chan);

--- a/runtime/caml/camlatomic.h
+++ b/runtime/caml/camlatomic.h
@@ -48,6 +48,7 @@ using std::memory_order_seq_cst;
 #define ATOMIC_UINTNAT_INIT(x) (x)
 typedef _Atomic uintnat atomic_uintnat;
 typedef _Atomic intnat atomic_intnat;
+typedef _Atomic double atomic_double;
 
 #elif defined(__GNUC__)
 
@@ -64,6 +65,7 @@ typedef enum memory_order {
 #define ATOMIC_UINTNAT_INIT(x) { (x) }
 typedef struct { uintnat repr; } atomic_uintnat;
 typedef struct { intnat repr; } atomic_intnat;
+typedef struct { double repr; } atomic_double;
 
 #define atomic_load_explicit(x, m) __atomic_load_n(&(x)->repr, (m))
 #define atomic_load(x) atomic_load_explicit((x), memory_order_seq_cst)

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -53,8 +53,6 @@ CAMLextern void caml_adjust_gc_speed (mlsize_t, mlsize_t);
 CAMLextern void caml_alloc_dependent_memory (mlsize_t);
 CAMLextern void caml_free_dependent_memory (mlsize_t);
 CAMLextern int caml_atomic_cas_field (value, intnat, value, value);
-CAMLextern void caml_blit_fields (value src, int srcoff, value dst, int dstoff,
-                                  int n);
 CAMLextern value caml_check_urgent_gc (value);
 #ifdef CAML_INTERNALS
 CAMLextern char *caml_alloc_for_heap (asize_t request);   /* Size in bytes. */

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -323,38 +323,6 @@ CAMLexport void caml_set_fields (value obj, value v)
   }
 }
 
-CAMLexport void caml_blit_fields (
-  value src, int srcoff, value dst, int dstoff, int n)
-{
-  CAMLparam2(src, dst);
-  int i;
-  CAMLassert(Is_block(src));
-  CAMLassert(Is_block(dst));
-  CAMLassert(srcoff + n <= Wosize_val(src));
-  CAMLassert(dstoff + n <= Wosize_val(dst));
-  CAMLassert(Tag_val(src) != Infix_tag);
-  CAMLassert(Tag_val(dst) != Infix_tag);
-
-  /* we can't use memcpy/memmove since they may not do atomic word writes.
-     for instance, they may copy a byte at a time */
-  if (src == dst && srcoff < dstoff) {
-    /* copy descending */
-    for (i = n; i > 0; i--) {
-      caml_modify(
-        &Field(dst, dstoff + i - 1),
-        Field(src, srcoff + i - 1));
-    }
-  } else {
-    /* copy ascending */
-    for (i = 0; i < n; i++) {
-      caml_modify(
-        &Field(dst, dstoff + i),
-        Field(src, srcoff + i));
-    }
-  }
-  CAMLreturn0;
-}
-
 Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, int noexc)
 {
   caml_domain_state *dom_st = Caml_state;


### PR DESCRIPTION
The word-sized `memmove` is only used when there is more than 1 domain running. The commit includes other minor changes.

~The PR assumes that it is running on 64-bit (which is true under multicore), where `sizeof(double) == sizeof(value)`.~

For reviewing the PR, it would be useful to compare the new `array.c` file with the one in trunk rather than one in the PR. 