### PR TITLE
stdlib: make Atomic.t covariant

### DIFF
--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -27,7 +27,7 @@
     import additional compatibility layers. *)
 
 (** An atomic (mutable) reference to a value of type ['a]. *)
-type !'a t
+type +!'a t
 
 (** Create an atomic reference. *)
 val make : 'a -> 'a t

--- a/stdlib/camlinternalAtomic.ml
+++ b/stdlib/camlinternalAtomic.ml
@@ -16,7 +16,7 @@
 
 (* CamlinternalAtomic is a dependency of Stdlib, so it is compiled with
    -nopervasives. *)
-type !'a t
+type +!'a t
 
 (* Atomic is a dependency of Stdlib, so it is compiled with
    -nopervasives. *)

--- a/stdlib/camlinternalAtomic.mli
+++ b/stdlib/camlinternalAtomic.mli
@@ -19,7 +19,7 @@
    modules_before_stdlib used in stdlib/dune does not support the
    Stdlib__ prefix trick. *)
 
-type !'a t
+type +!'a t
 val make : 'a -> 'a t
 val get : 'a t -> 'a
 val set : 'a t -> 'a -> unit


### PR DESCRIPTION
Make type parameter 'a' in 'a Atomic.t covariant as well as injective,
i.e. `+!'a Atomic.t`. Consider a common use case in OCaml where
concurrency libraries are functorised over an IO module:

module type IO = sig
  type +'a t
end

If we were to use 'a Atomic.t as follows,
module Io : IO = struct
  type +'a t = 'a Atomic.t
end

The compilation fails with the following error:

38 |   type +!'a t = 'a Atomic.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^
Error: In this definition, expected parameter variances are not satisfied.
       The 1st type parameter was expected to be injective covariant,
       but it is injective invariant.

Making type parameter 'a' covariant allows the above code to
build/compile successfully.

Signed-off-by: Bikal Lem <gbikal+git@gmail.com>