### PR TITLE
Address ocaml/ocaml#10831 unnecessary diff review comments

### DIFF
--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -197,8 +197,8 @@ let emit_frames a =
         if Debuginfo.is_none d then 0 else 1
       | Dbg_alloc dbgs ->
         if !Clflags.debug &&
-          List.exists (fun d ->
-            not (Debuginfo.is_none d.Debuginfo.alloc_dbg)) dbgs
+           List.exists (fun d ->
+             not (Debuginfo.is_none d.Debuginfo.alloc_dbg)) dbgs
         then 3 else 2
     in
     a.efa_code_label fd.fd_lbl;
@@ -375,9 +375,7 @@ let emit_debug_info_gen dbg file_emitter loc_emitter =
             file_num in
         loc_emitter ~file_num ~line ~col;
       end
-    end
-
-(* Emission of block headers immediately prior to function entry points *)
+  end
 
 let emit_debug_info dbg =
   emit_debug_info_gen dbg (fun ~file_num ~file_name ->

--- a/middle_end/flambda/lift_constants.ml
+++ b/middle_end/flambda/lift_constants.ml
@@ -997,7 +997,7 @@ let lift_constants (program : Flambda.program) ~backend =
     constant_definitions
   in
   let effect_tbl =
-    Symbol.Tbl.map effect_tbl (fun (eff, dep) -> rewrite_expr eff, dep)
+    Symbol.Tbl.map effect_tbl (fun (effect, dep) -> rewrite_expr effect, dep)
   in
   let initialize_symbol_tbl =
     Symbol.Tbl.map initialize_symbol_tbl (fun (tag, fields, dep) ->

--- a/middle_end/flambda/lift_let_to_initialize_symbol.ml
+++ b/middle_end/flambda/lift_let_to_initialize_symbol.ml
@@ -264,8 +264,8 @@ let add_extracted introduced program =
       match extracted with
       | Initialisation (symbol, tag, def) ->
         Flambda.Initialize_symbol (symbol, tag, def, program)
-      | Effect eff ->
-        Flambda.Effect (eff, program))
+      | Effect effect ->
+        Flambda.Effect (effect, program))
     introduced program
 
 let rec split_program (program : Flambda.program_body) : Flambda.program_body =

--- a/middle_end/flambda/remove_unused_program_constructs.ml
+++ b/middle_end/flambda/remove_unused_program_constructs.ml
@@ -94,14 +94,14 @@ let rec loop (program : Flambda.program_body)
              Flambda.Effect (field, program), dep)
         (program, dep) fields
     end
-  | Effect (eff, program) ->
+  | Effect (effect, program) ->
     let program, dep = loop program in
-    if Effect_analysis.no_effects eff then begin
+    if Effect_analysis.no_effects effect then begin
       program, dep
     end else begin
-      let new_dep = dependency eff in
+      let new_dep = dependency effect in
       let dep = Symbol.Set.union new_dep dep in
-      Effect (eff, program), dep
+      Effect (effect, program), dep
     end
   | End symbol -> program, Symbol.Set.singleton symbol
 

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -142,9 +142,9 @@ static void st_masterlock_init(st_masterlock * m)
 
 static void st_bt_lock_acquire(st_masterlock *m) {
 
-  // We do not want to signal the backup thread is it is not "working"
-  // as it may very well not be, because we could have just resumed
-  // execution from another thread right away.
+  /* We do not want to signal the backup thread is it is not "working"
+     as it may very well not be, because we could have just resumed
+     execution from another thread right away. */
   if (caml_bt_is_in_blocking_section()) {
     caml_bt_enter_ocaml();
   }
@@ -156,9 +156,9 @@ static void st_bt_lock_acquire(st_masterlock *m) {
 
 static void st_bt_lock_release(st_masterlock *m) {
 
-  // Here we do want to signal the backup thread iff there's
-  // no thread waiting to be scheduled, and the backup thread is currently
-  // idle.
+  /* Here we do want to signal the backup thread iff there's
+     no thread waiting to be scheduled, and the backup thread is currently
+     idle. */
   if (atomic_load_acq(&m->waiters) == 0 &&
       caml_bt_is_in_blocking_section() == 0) {
     caml_bt_exit_ocaml();
@@ -224,10 +224,10 @@ Caml_inline void st_thread_yield(st_masterlock * m)
   m->busy = 0;
   atomic_fetch_add(&m->waiters, +1);
   pthread_cond_signal(&m->is_free);
-  // releasing the domain lock but not triggering bt messaging
-  // messaging the bt should not be required because yield assumes
-  // that a thread will resume execution (be it the yielding thread
-  // or a waiting thread
+  /* releasing the domain lock but not triggering bt messaging
+     messaging the bt should not be required because yield assumes
+     that a thread will resume execution (be it the yielding thread
+     or a waiting thread */
   caml_release_domain_lock();
 
   do {

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -65,7 +65,7 @@ struct caml_thread_struct {
   value descr;              /* The heap-allocated descriptor (root) */
   struct caml_thread_struct * next; /* Doubly-linked list of running threads */
   struct caml_thread_struct * prev;
-  int domain_id;      /* The id of the domain to which this thread belong to */
+  int domain_id;      /* The id of the domain to which this thread belongs */
   struct stack_info* current_stack;      /* saved Caml_state->current_stack */
   struct c_stack_link* c_stack;          /* saved Caml_state->c_stack */
   struct caml__roots_block *local_roots; /* saved value of local_roots */
@@ -82,8 +82,8 @@ struct caml_thread_struct {
 #ifndef NATIVE_CODE
   intnat trap_sp_off;      /* saved value of Caml_state->trap_sp_off */
   intnat trap_barrier_off; /* saved value of Caml_state->trap_barrier_off */
-  /* saved value of Caml_state->external_raise */
   struct caml_exception_context* external_raise;
+    /* saved value of Caml_state->external_raise */
 #endif
 
 #ifdef POSIX_SIGNALS
@@ -768,7 +768,7 @@ CAMLprim value caml_thread_exit(value unit)   /* ML */
   } else {
     /* Bytecode, or thread created from C */
     st_thread_exit();
-  };
+  }
   return Val_unit;  /* not reached */
 }
 

--- a/otherlibs/unix/signals.c
+++ b/otherlibs/unix/signals.c
@@ -35,7 +35,7 @@ static void decode_sigset(value vset, sigset_t * set)
 {
   sigemptyset(set);
   while (vset != Val_int(0)) {
-    int sig = caml_convert_signal_number(Int_field(vset, 0));
+    int sig = caml_convert_signal_number(Int_val(Field(vset, 0)));
     sigaddset(set, sig);
     vset = Field(vset, 1);
   }

--- a/runtime/afl.c
+++ b/runtime/afl.c
@@ -115,7 +115,7 @@ CAMLexport value caml_setup_afl(value unit)
   afl_read();
 
   /* ensure that another module has not already spawned a domain */
-  if (!caml_domain_alone())
+  if (!caml_domain_is_multicore())
     caml_fatal_error("afl-fuzz: cannot fork with multiple domains running");
 
   while (1) {

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -156,8 +156,9 @@ static value caml_array_unsafe_set_addr(value array, value index,value newval)
 
 /* [ floatarray -> int -> float -> unit ] */
 /* [MM]: [caml_array_unsafe_set_addr] has a fence for enforcing the OCaml
-   memory model through its use of [caml_modify]. [caml_floatarray_unsafe_set]
-   will also need a similar fence in [Store_double_flat_field]. */
+   memory model through its use of [caml_modify].
+   [MM] [TODO]: [caml_floatarray_unsafe_set] will also need a similar fence in
+   [Store_double_flat_field]. */
 CAMLprim value caml_floatarray_unsafe_set(value array, value index,value newval)
 {
   intnat idx = Long_val(index);

--- a/runtime/caml/alloc.h
+++ b/runtime/caml/alloc.h
@@ -44,12 +44,9 @@ CAMLextern value caml_alloc_8(tag_t, value, value, value, value,
 CAMLextern value caml_alloc_9(tag_t, value, value, value, value,
                               value, value, value, value, value);
 CAMLextern value caml_alloc_small (mlsize_t, tag_t);
-#define Init_field_small(o, i, x) (Op_val(o)[i] = (x))
-CAMLextern value caml_alloc_small_with_my_or_given_profinfo (mlsize_t wosize,
-  tag_t tag, uintnat profinfo);
 CAMLextern value caml_alloc_tuple (mlsize_t);
 CAMLextern value caml_alloc_float_array (mlsize_t len);
-CAMLextern value caml_alloc_string (mlsize_t); /* len in bytes (chars) */
+CAMLextern value caml_alloc_string (mlsize_t len);  /* len in bytes (chars) */
 CAMLextern value caml_alloc_initialized_string (mlsize_t len, const char *);
 CAMLextern value caml_copy_string (char const *);
 CAMLextern value caml_copy_string_array (char const * const*);
@@ -73,6 +70,21 @@ CAMLextern value caml_alloc_final (mlsize_t, /*size in words*/
                                    mlsize_t  /*max resources*/);
 
 CAMLextern int caml_convert_flag_list (value, const int *);
+
+/* Convenience functions to deal with unboxable types. */
+Caml_inline value caml_alloc_unboxed (value arg) { return arg; }
+Caml_inline value caml_alloc_boxed (value arg) {
+  value result = caml_alloc_small (1, 0);
+  Field (result, 0) = arg;
+  return result;
+}
+Caml_inline value caml_field_unboxed (value arg) { return arg; }
+Caml_inline value caml_field_boxed (value arg) { return Field (arg, 0); }
+
+/* Unannotated unboxable types are boxed by default. (may change in the
+   future) */
+#define caml_alloc_unboxable caml_alloc_boxed
+#define caml_field_unboxable caml_field_boxed
 
 #ifdef __cplusplus
 }

--- a/runtime/caml/hash.h
+++ b/runtime/caml/hash.h
@@ -35,4 +35,5 @@ CAMLextern uint32_t caml_hash_mix_string(uint32_t h, value s);
 }
 #endif
 
+
 #endif /* CAML_HASH_H */

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -50,8 +50,10 @@ CAMLextern value caml_alloc_shr_preserving_profinfo (mlsize_t, tag_t,
 #endif /* WITH_PROFINFO */
 CAMLextern value caml_alloc_shr_no_raise (mlsize_t wosize, tag_t);
 CAMLextern void caml_adjust_gc_speed (mlsize_t, mlsize_t);
-CAMLextern void caml_alloc_dependent_memory (mlsize_t);
-CAMLextern void caml_free_dependent_memory (mlsize_t);
+CAMLextern void caml_alloc_dependent_memory (mlsize_t bsz);
+CAMLextern void caml_free_dependent_memory (mlsize_t bsz);
+CAMLextern void caml_modify (value *, value);
+CAMLextern void caml_initialize (value *, value);
 CAMLextern int caml_atomic_cas_field (value, intnat, value, value);
 CAMLextern value caml_check_urgent_gc (value);
 #ifdef CAML_INTERNALS
@@ -62,9 +64,6 @@ CAMLextern int caml_add_to_heap (char *mem);
 
 CAMLextern int caml_huge_fallback_count; /* FIXME KC: Make per domain */
 
-/* old CAPI function compatability */
-CAMLextern void caml_modify (value *, value);
-CAMLextern void caml_initialize (value *, value);
 
 /* [caml_stat_*] functions below provide an interface to the static memory
    manager built into the runtime, which can be used for managing static
@@ -197,7 +196,7 @@ extern uintnat caml_use_huge_pages;
 #define DEBUG_clear(result, wosize) do{ \
   uintnat caml__DEBUG_i; \
   for (caml__DEBUG_i = 0; caml__DEBUG_i < (wosize); ++ caml__DEBUG_i){ \
-    Op_val (result)[caml__DEBUG_i] = Debug_uninit_minor; \
+    Field ((result), caml__DEBUG_i) = Debug_uninit_minor; \
   } \
 }while(0)
 #else
@@ -546,7 +545,6 @@ struct caml__roots_block {
 
 #define End_roots() CAML_LOCAL_ROOTS = caml__roots_block.next; }
 
-/** Compatability with old C-API **/
 
 /* [caml_register_global_root] registers a global C variable as a memory root
    for the duration of the program, or until [caml_remove_global_root] is

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -138,15 +138,6 @@ CAMLextern clock_t caml_win32_clock(void);
 
 #endif /* _WIN32 */
 
-/* Returns the current value of a counter that increments once per nanosecond.
-   On systems that support it, this uses a monotonic timesource which ignores
-   changes in the system time (so that this counter increases by 1000000 each
-   millisecond, even if the system clock was set back by an hour during that
-   millisecond). This makes it useful for benchmarking and timeouts, but not
-   for telling the time. The units are always nanoseconds, but the achieved
-   resolution may be less. The starting point is unspecified. */
-extern int64_t caml_time_counter(void);
-
 extern void caml_init_os_params(void);
 
 #endif /* CAML_INTERNALS */

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -128,41 +128,41 @@ static intnat do_compare_val(struct compare_stack* stk,
         return Long_val(v1) - Long_val(v2);
       /* Subtraction above cannot overflow and cannot result in UNORDERED */
       switch (Tag_val(v2)) {
-      case Forward_tag:
-        v2 = Forward_val(v2);
-        continue;
-      case Custom_tag: {
-        int res;
-        int (*compare)(value v1, value v2) = Custom_ops_val(v2)->compare_ext;
-        if (compare == NULL) break;  /* for backward compatibility */
-        Caml_state->compare_unordered = 0;
-        res = compare(v1, v2);
-        if (Caml_state->compare_unordered && !total) return UNORDERED;
-        if (res != 0) return res;
-        goto next_item;
-      }
-      default: /*fallthrough*/;
-      }
+        case Forward_tag:
+          v2 = Forward_val(v2);
+          continue;
+        case Custom_tag: {
+          int res;
+          int (*compare)(value v1, value v2) = Custom_ops_val(v2)->compare_ext;
+          if (compare == NULL) break;  /* for backward compatibility */
+          Caml_state->compare_unordered = 0;
+          res = compare(v1, v2);
+          if (Caml_state->compare_unordered && !total) return UNORDERED;
+          if (res != 0) return res;
+          goto next_item;
+        }
+        default: /*fallthrough*/;
+        }
 
       return LESS;                /* v1 long < v2 block */
     }
     if (Is_long(v2)) {
       switch (Tag_val(v1)) {
-      case Forward_tag:
-        v1 = Forward_val(v1);
-        continue;
-      case Custom_tag: {
-        int res;
-        int (*compare)(value v1, value v2) = Custom_ops_val(v1)->compare_ext;
-        if (compare == NULL) break;  /* for backward compatibility */
-        Caml_state->compare_unordered = 0;
-        res = compare(v1, v2);
-        if (Caml_state->compare_unordered && !total) return UNORDERED;
-        if (res != 0) return res;
-        goto next_item;
-      }
-      default: /*fallthrough*/;
-      }
+        case Forward_tag:
+          v1 = Forward_val(v1);
+          continue;
+        case Custom_tag: {
+          int res;
+          int (*compare)(value v1, value v2) = Custom_ops_val(v1)->compare_ext;
+          if (compare == NULL) break;  /* for backward compatibility */
+          Caml_state->compare_unordered = 0;
+          res = compare(v1, v2);
+          if (Caml_state->compare_unordered && !total) return UNORDERED;
+          if (res != 0) return res;
+          goto next_item;
+        }
+        default: /*fallthrough*/;
+        }
       return GREATER;            /* v1 block > v2 long */
     }
     t1 = Tag_val(v1);
@@ -280,8 +280,8 @@ static intnat do_compare_val(struct compare_stack* stk,
       if (sz1 > 1) {
         sp++;
         if (sp >= stk->limit) sp = compare_resize_stack(stk, sp);
-        sp->v1 = Op_val(v1) + 1;
-        sp->v2 = Op_val(v2) + 1;
+        sp->v1 = &Field(v1, 1);
+        sp->v2 = &Field(v2, 1);
         sp->count = sz1 - 1;
       }
       /* Continue comparison with first field */

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -72,7 +72,7 @@ CAMLexport void caml_raise_with_args(value tag, int nargs, value args[])
 {
   CAMLparam1 (tag);
   CAMLxparamN (args, nargs);
-  CAMLlocal1(bucket);
+  value bucket;
   int i;
 
   CAMLassert(1 + nargs <= Max_young_wosize);
@@ -164,57 +164,49 @@ CAMLexport void caml_array_bound_error(void)
 CAMLexport void caml_raise_out_of_memory(void)
 {
   check_global_data("Out_of_memory");
-  caml_raise_constant(Field(caml_global_data,
-                                OUT_OF_MEMORY_EXN));
+  caml_raise_constant(Field(caml_global_data, OUT_OF_MEMORY_EXN));
 }
 
 CAMLexport void caml_raise_stack_overflow(void)
 {
   check_global_data("Stack_overflow");
-  caml_raise_constant(Field(caml_global_data,
-                                STACK_OVERFLOW_EXN));
+  caml_raise_constant(Field(caml_global_data, STACK_OVERFLOW_EXN));
 }
 
 CAMLexport void caml_raise_sys_error(value msg)
 {
   check_global_data_param("Sys_error", String_val(msg));
-  caml_raise_with_arg(Field(caml_global_data,
-                                SYS_ERROR_EXN), msg);
+  caml_raise_with_arg(Field(caml_global_data, SYS_ERROR_EXN), msg);
 }
 
 CAMLexport void caml_raise_end_of_file(void)
 {
   check_global_data("End_of_file");
-  caml_raise_constant(Field(caml_global_data,
-                                END_OF_FILE_EXN));
+  caml_raise_constant(Field(caml_global_data, END_OF_FILE_EXN));
 }
 
 CAMLexport void caml_raise_zero_divide(void)
 {
   check_global_data("Division_by_zero");
-  caml_raise_constant(Field(caml_global_data,
-                                ZERO_DIVIDE_EXN));
+  caml_raise_constant(Field(caml_global_data, ZERO_DIVIDE_EXN));
 }
 
 CAMLexport void caml_raise_not_found(void)
 {
   check_global_data("Not_found");
-  caml_raise_constant(Field(caml_global_data,
-                                NOT_FOUND_EXN));
+  caml_raise_constant(Field(caml_global_data, NOT_FOUND_EXN));
 }
 
 CAMLexport void caml_raise_sys_blocked_io(void)
 {
   check_global_data("Sys_blocked_io");
-  caml_raise_constant(Field(caml_global_data,
-                                SYS_BLOCKED_IO));
+  caml_raise_constant(Field(caml_global_data, SYS_BLOCKED_IO));
 }
 
 CAMLexport void caml_raise_continuation_already_taken(void)
 {
   check_global_data("Continuation_already_taken");
-  caml_raise_constant(Field(caml_global_data,
-                                CONTINUATION_ALREADY_TAKEN_EXN));
+  caml_raise_constant(Field(caml_global_data, CONTINUATION_ALREADY_TAKEN_EXN));
 }
 
 CAMLexport value caml_raise_if_exception(value res)

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -110,7 +110,7 @@ void caml_raise_with_args(value tag, int nargs, value args[])
 {
   CAMLparam1 (tag);
   CAMLxparamN (args, nargs);
-  CAMLlocal1 (bucket);
+  value bucket;
   int i;
 
   bucket = caml_alloc (1 + nargs, 0);

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -135,7 +135,7 @@ sp is a local copy of the global variable Caml_state->extern_sp. */
 
 #define Check_trap_barrier \
   if (domain_state->trap_sp_off >= domain_state->trap_barrier_off) \
-      caml_debugger(TRAP_BARRIER, Val_unit)
+    caml_debugger(TRAP_BARRIER, Val_unit)
 
 /* Register optimization.
    Some compilers underestimate the use of the local variables representing
@@ -322,8 +322,8 @@ value caml_interprete(code_t prog, asize_t prog_size)
 #ifdef DEBUG
  next_instr:
   if (caml_icount-- == 0) caml_stop_here ();
-  CAMLassert(Stack_base(domain_state->current_stack) <= sp &&
-         sp <= Stack_high(domain_state->current_stack));
+  CAMLassert(Stack_base(domain_state->current_stack) <= sp);
+  CAMLassert(sp <= Stack_high(domain_state->current_stack));
 #endif
   goto *(void *)(jumptbl_base + *pc++); /* Jump to the first instruction */
 #else
@@ -341,8 +341,8 @@ value caml_interprete(code_t prog, asize_t prog_size)
       caml_trace_accu_sp_file(accu,sp,prog,prog_size,stdout);
       fflush(stdout);
     };
-    CAMLassert(Stack_base(domain_state->current_stack) <= sp &&
-           sp <= Stack_high(domain_state->current_stack));
+    CAMLassert(Stack_base(domain_state->current_stack) <= sp);
+    CAMLassert(sp <= Stack_high(domain_state->current_stack));
 
 #endif
     curr_instr = *pc++;

--- a/runtime/lexing.c
+++ b/runtime/lexing.c
@@ -130,10 +130,10 @@ static void run_mem(char *pc, value mem, value curr_pos) {
     src = *pc++ ;
     if (src == 0xff) {
       /*      fprintf(stderr,"[%hhu] <- %d\n",dst,Int_val(curr_pos)) ;*/
-      Store_field(mem,dst,curr_pos);
+      Field(mem,dst) = curr_pos ;
     } else {
       /*      fprintf(stderr,"[%hhu] <- [%hhu]\n",dst,src) ; */
-      Store_field(mem,dst,Val_long(Long_field(mem, src)));
+      Field(mem,dst) = Field(mem,src) ;
     }
   }
 }
@@ -148,10 +148,10 @@ static void run_tag(char *pc, value mem) {
     src = *pc++ ;
     if (src == 0xff) {
       /*      fprintf(stderr,"[%hhu] <- -1\n",dst) ; */
-      Store_field(mem,dst,Val_int(-1));
+      Field(mem,dst) = Val_int(-1) ;
     } else {
       /*      fprintf(stderr,"[%hhu] <- [%hhu]\n",dst,src) ; */
-      Store_field(mem,dst, Val_long(Long_field(mem, src)));
+      Field(mem,dst) = Field(mem,src) ;
     }
   }
 }

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -138,7 +138,7 @@ CAMLprim value caml_obj_block(value tag, value size)
 CAMLprim value caml_obj_with_tag(value new_tag_v, value arg)
 {
   CAMLparam2 (new_tag_v, arg);
-  CAMLlocal2 (res, x);
+  CAMLlocal1 (res);
   mlsize_t sz, i;
   tag_t tg;
 
@@ -280,7 +280,7 @@ CAMLprim value caml_lazy_update_to_forcing (value v)
 
 CAMLprim value caml_get_public_method (value obj, value tag)
 {
-  value meths = Field(obj, 0);
+  value meths = Field (obj, 0);
   int li = 3, hi = Field(meths,0), mi;
   while (li < hi) {
     mi = ((li+hi) >> 1) | 1;

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -200,7 +200,7 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
     if (errflag < 3) {
       errflag = 3;
       while (1) {
-        state1 = Int_field(env->s_stack, sp);
+        state1 = Int_val(Field(env->s_stack, sp));
         n1 = Short(tables->sindex, state1);
         n2 = n1 + ERRCODE;
         if (n1 != 0 && n2 >= 0 && n2 <= Int_val(tables->tablesize) &&
@@ -245,8 +245,8 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
   case STACKS_GROWN_1:
     RESTORE;
   push:
-    Store_field (env->s_stack, sp, Val_int(state));
-    Store_field (env->v_stack, sp, env->lval);
+    Field(env->s_stack, sp) = Val_int(state);
+    caml_modify(&Field(env->v_stack, sp), env->lval);
     Store_field (env->symb_start_stack, sp, env->symb_start);
     Store_field (env->symb_end_stack, sp, env->symb_end);
     goto loop;
@@ -260,7 +260,7 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
     env->rule_len = Val_int(m);
     sp = sp - m + 1;
     m = Short(tables->lhs, n);
-    state1 = Int_field(env->s_stack, sp - 1);
+    state1 = Int_val(Field(env->s_stack, sp - 1));
     n1 = Short(tables->gindex, m);
     n2 = n1 + state1;
     if (n1 != 0 && n2 >= 0 && n2 <= Int_val(tables->tablesize) &&
@@ -281,7 +281,7 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
                                 /* The ML code calls the semantic action */
   case SEMANTIC_ACTION_COMPUTED:
     RESTORE;
-    Store_field(env->s_stack, sp, Val_int(state));
+    Field(env->s_stack, sp) = Val_int(state);
     caml_modify(&Field(env->v_stack, sp), arg);
     asp = Int_val(env->asp);
     Store_field (env->symb_end_stack, sp, Field(env->symb_end_stack, asp));

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -431,8 +431,8 @@ CAMLprim value caml_sys_get_argv(value unit)
   CAMLlocal2 (exe_name, res);
   exe_name = caml_copy_string_of_os(caml_params->exe_name);
   res = caml_alloc_small(2, 0);
-  caml_initialize(&Field(res, 0), exe_name);
-  caml_initialize(&Field(res, 1), main_argv);
+  Field(res, 0) = exe_name;
+  Field(res, 1) = main_argv;
   CAMLreturn(res);
 }
 
@@ -454,7 +454,6 @@ CAMLprim value caml_sys_executable_name(value unit)
 
 void caml_sys_init(char_os * exe_name, char_os **argv)
 {
-  value v;
 #ifdef _WIN32
   /* Initialises the caml_win32_* globals on Windows with the version of
      Windows which is running */
@@ -464,9 +463,8 @@ void caml_sys_init(char_os * exe_name, char_os **argv)
 #endif
 #endif
   caml_init_exe_name(exe_name);
-  v = caml_alloc_array((void *)caml_copy_string_of_os,
-                       (char const **) argv);
-  main_argv = v;
+  main_argv = caml_alloc_array((void *)caml_copy_string_of_os,
+                               (char const **) argv);
   caml_register_generational_global_root(&main_argv);
 }
 
@@ -585,7 +583,7 @@ int caml_unix_random_seed(intnat data[16])
     while (nread > 0) data[n++] = buffer[--nread];
   }
   /* If the read from /dev/urandom fully succeeded, we now have 96 bits
-    of good random data and can stop here. */
+     of good random data and can stop here. */
   if (n >= 12) return n;
   /* Otherwise, complement whatever we got (probably nothing)
      with some not-very-random data. */

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1159,11 +1159,3 @@ void caml_init_os_params(void)
   now.HighPart = stamp.dwHighDateTime;
   now.QuadPart *= 100;
 }
-
-int64_t caml_time_counter(void)
-{
-  LARGE_INTEGER now;
-  /* Windows 2000 is no longer supported, so this function always succeeds */
-  QueryPerformanceCounter(&now);
-  return (now.QuadPart * frequency.QuadPart + clock_offset.QuadPart);
-}


### PR DESCRIPTION
This PR addresses a collection of unnecessary diffs between multicore and trunk coming out of the review of https://github.com/ocaml/ocaml/pull/10831.

(It also removes `caml_time_counter` which is unused and fixes the `//` comment style in `st_posix.h`)