### PR TITLE
initialise extern_flags to 0 on extern stat init

### DIFF
--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -129,6 +129,7 @@ static struct caml_extern_state* get_extern_state (void)
     return NULL;
   }
 
+  extern_state->extern_flags = 0;
   extern_state->obj_counter = 0;
   extern_state->size_32 = 0;
   extern_state->size_64 = 0;


### PR DESCRIPTION
Without this the value may potentially contain junk values and is subsequently used in reachable_words, which results in
memory corruption. Fixes Obj.reachable_words on platforms which return junk memory from malloc (e.g. FreeBSD/OpenBSD but also potentially some libcs on Linux)

Fixes https://github.com/ocaml-multicore/ocaml-multicore/issues/824