### PR TITLE
fix pthread name setting on FreeBSD/OpenBSD/NetBSD

### DIFF
--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -50,6 +50,9 @@
 #include <mach-o/dyld.h>
 #endif
 #include <pthread.h>
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
+#include <pthread_np.h>
+#endif
 #include "caml/fail.h"
 #include "caml/memory.h"
 #include "caml/misc.h"
@@ -441,20 +444,16 @@ int caml_thread_setname(const char* name)
 {
 #ifdef __APPLE__
   pthread_setname_np(name);
-  return 0;
-#else
-#ifdef _GNU_SOURCE
-  int ret;
+#else /* not apple */
   pthread_t self = pthread_self();
-
-  ret = pthread_setname_np(self, name);
-  if (ret == ERANGE)
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
+  pthread_set_name_np(self, name);
+#else /* linux glibc/musl or NetBSD */
+  if (pthread_setname_np(self, name) != 0)
     return -1;
-  return 0;
-#else /* not glibc, not apple */
-  return 0;
 #endif
 #endif
+  return 0;
 }
 
 void caml_init_os_params(void)


### PR DESCRIPTION
There is an unfortunate portability mess around setting pthread names, so we now use the various permutations on FreeBSD
and OpenBSD (which require another header include as well) and NetBSD (which is similar to Linux, but with a different error
code return).

The code previously used GNU_SOURCE to detect Linux, which isnt much use as GNU_SOURCE is unconditionally defined at the top of unix.c, so we just assume that the 'default' platform is Linux.  pthread_setname_np is only defined in glibc 2.12 or higher, but looking for that specifically makes it complex to also detect musl, so it's simplest to leave it as the default case.

This (along with #828) lets FreeBSD pass the test suite, and for OpenBSD to build. There is one more patch to follow and OpenBSD will also pass the test suite.