### PR TITLE
remove Int/Long/Bool_field macros

### DIFF
--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -246,7 +246,7 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
 /* Another special case: objects */
 #define Object_tag 248
 #define Class_val(val) Field((val), 0)
-#define Oid_val(val) Long_field((val), 1)
+#define Oid_val(val) Long_val(Field((val), 1))
 CAMLextern value caml_get_public_method (value obj, value tag);
 /* Called as:
    caml_callback(caml_get_public_method(obj, caml_hash_variant(name)), obj) */
@@ -439,10 +439,6 @@ CAMLextern value caml_atom(tag_t);
 #define Is_some(v) Is_block(v)
 
 CAMLextern value caml_set_oo_id(value obj);
-
-#define Int_field(x, i) Int_val(Field(x, i))
-#define Long_field(x, i) Long_val(Field(x, i))
-#define Bool_field(x, i) Bool_val(Field(x, i))
 
 /* Header for out-of-heap blocks. */
 

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -165,9 +165,9 @@ CAMLprim value caml_gc_set(value v)
   uintnat new_custom_maj, new_custom_min, new_custom_sz;
   CAML_EV_BEGIN(EV_EXPLICIT_GC_SET);
 
-  caml_change_max_stack_size (Long_field (v, 5));
+  caml_change_max_stack_size (Long_val (Field (v, 5)));
 
-  newpf = norm_pfree (Long_field (v, 2));
+  newpf = norm_pfree (Long_val (Field (v, 2)));
   if (newpf != caml_percent_free){
     caml_percent_free = newpf;
     caml_gc_message (0x20, "New space overhead: %"
@@ -201,7 +201,7 @@ CAMLprim value caml_gc_set(value v)
 
   /* Minor heap size comes last because it will trigger a minor collection
      (thus invalidating [v]) and it can raise [Out_of_memory]. */
-  newminwsz = caml_norm_minor_heap_size (Long_field (v, 0));
+  newminwsz = caml_norm_minor_heap_size (Long_val (Field (v, 0)));
   if (newminwsz != Caml_state->minor_heap_wsz){
     caml_gc_message (0x20, "New minor heap size: %"
                      ARCH_SIZET_PRINTF_FORMAT "uk words\n", newminwsz / 1024);

--- a/testsuite/tests/callback/minor_named_.c
+++ b/testsuite/tests/callback/minor_named_.c
@@ -5,6 +5,6 @@
 value incr_ref(value unit) {
   static const value* v;
   if (!v) v = caml_named_value("incr_ref");
-  caml_modify(&Field(*v, 0), Val_int(Int_field(*v, 0) + 1));
+  caml_modify(&Field(*v, 0), Val_int(Int_val(Field(*v, 0)) + 1));
   return Val_unit;
 }


### PR DESCRIPTION
These were originally introduced (and were more complex) when we had a read barrier. Now only the Long_field macro is used, so we can reduce the size of the diff to trunk by removing them and just using Long_val(Field()) instead.