### PR TITLE
Revert changes to caml_floatarray_blit

### DIFF
--- a/runtime/caml/camlatomic.h
+++ b/runtime/caml/camlatomic.h
@@ -48,7 +48,6 @@ using std::memory_order_seq_cst;
 #define ATOMIC_UINTNAT_INIT(x) (x)
 typedef _Atomic uintnat atomic_uintnat;
 typedef _Atomic intnat atomic_intnat;
-typedef _Atomic double atomic_double;
 
 #elif defined(__GNUC__)
 
@@ -65,7 +64,6 @@ typedef enum memory_order {
 #define ATOMIC_UINTNAT_INIT(x) { (x) }
 typedef struct { uintnat repr; } atomic_uintnat;
 typedef struct { intnat repr; } atomic_intnat;
-typedef struct { double repr; } atomic_double;
 
 #define atomic_load_explicit(x, m) __atomic_load_n(&(x)->repr, (m))
 #define atomic_load(x) atomic_load_explicit((x), memory_order_seq_cst)


### PR DESCRIPTION
Some changes were introduced to caml_floatarray_blit for enforcing the memory model. But they break 32-bit compilation. Hence, revert the change and leave the discussion about the memory model for later.

See the discussion in https://github.com/ocaml-multicore/ocaml-multicore/pull/822#discussion_r778852740. 