### PR TITLE
Fix reachable words, part deux

### DIFF
--- a/Changes
+++ b/Changes
@@ -438,6 +438,16 @@ OCaml 4.14.0
 - #10763, #10764: fix miscompilation of method delegation
   (Alain Frisch, review by Vincent Laviron and Jacques Garrigue)
 
+- #10822, #10823: Bad interaction between ambivalent types and subtyping
+  coercions (Jacques Garrigue, report and review by Frédéric Bour)
+
+- #10849: Display the result of `let _ : <type> = <expr>` in the native
+  toplevel, as in the bytecode toplevel.
+  (David Allsopp, report by Nathan Rebours, review by Gabriel Scherer)
+
+- #10853: `Obj.reachable_words` could crash if called after a marshaling
+  operation in `NO_SHARING` mode.
+  (Xavier Leroy, report by Anil Madhavapeddy, review by Alain Frisch)
 
 OCaml 4.13 maintenance branch
 -----------------------------

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -1209,6 +1209,7 @@ CAMLprim value caml_obj_reachable_words(value v)
   struct caml_extern_state *s = get_extern_state ();
 
   s->obj_counter = 0;
+  s->extern_flags = 0;
   extern_init_position_table(s);
   sp = s->extern_stack;
   size = 0;

--- a/testsuite/tests/lib-obj/reachable_words_bug.ml
+++ b/testsuite/tests/lib-obj/reachable_words_bug.ml
@@ -1,0 +1,9 @@
+(* TEST
+*)
+
+let _ =
+  (* In 4.13 this causes Obj.reachable_words to segfault
+     because of a missing initialization in caml_obj_reachable_words *)
+  ignore (Marshal.(to_string 123 [No_sharing]));
+  let n = Obj.reachable_words (Obj.repr (Array.init 10 (fun i -> i))) in
+  assert (n = 11)


### PR DESCRIPTION
This cherry-picks @xavierleroy's commits to 4.14 on https://github.com/ocaml/ocaml/pull/10853, adapted for the 5.00 branch. Follow up to discussion in https://github.com/ocaml-multicore/ocaml-multicore/pull/828