### PR TITLE
mingw-w64 - "backport" to 4.12

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "flexdll"]
+    path = flexdll
+    url = https://github.com/alainfrisch/flexdll.git

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -569,8 +569,13 @@ let emit_instr fallthrough i =
         end;
   | Lop(Iextcall {func; alloc; stack_ofs}) ->
       add_used_symbol func;
-      if stack_ofs > 0 then begin
-        I.lea (mem64 QWORD 0 RSP) r13;
+      let base_stack_size =
+        if Arch.win64 then
+          32 (* Windows x64 rcx+rdx+r8+r9 shadow stack *)
+        else
+          0 in
+      if stack_ofs > base_stack_size then begin
+        I.lea (mem64 QWORD base_stack_size RSP) r13;
         I.lea (mem64 QWORD stack_ofs RSP) r12;
         load_symbol_addr func rax;
         emit_call "caml_c_call_stack_args";

--- a/configure
+++ b/configure
@@ -17099,8 +17099,8 @@ fi
 
 case $host in #(
   *-*-mingw32) :
-    bytecclibs="-lws2_32 -lversion -lpthread -lgcc_eh"
-    nativecclibs="-lws2_32 -lversion -lpthread -lgcc_eh" ;; #(
+    bytecclibs="-lws2_32 -lversion -lpthread -lgcc_eh -lDbgHelp"
+    nativecclibs="-lws2_32 -lversion -lpthread -lgcc_eh -lDbgHelp" ;; #(
   *-pc-windows) :
     bytecclibs="advapi32.lib ws2_32.lib version.lib"
     nativecclibs="advapi32.lib ws2_32.lib version.lib" ;; #(

--- a/configure
+++ b/configure
@@ -12530,11 +12530,10 @@ case $ocaml_cv_cc_vendor in #(
     CPP="$CC -E -Qn" ;; #(
   # suppress generation of Sun PRO ident string
   msvc-*) :
-    CPP="$CC -nologo -EP";
-#  TODO: why can we not use $CPP in multicore, fix this?
-  CPP="$CC -E -P" ;; #(
+    CPP="$CC -nologo -EP" ;; #(
   *) :
-     ;;
+    #  TODO: why can we not use $CPP in multicore, fix this?
+  CPP="$CC -E -P" ;;
 esac
 
 # Libraries to build depending on the host

--- a/configure
+++ b/configure
@@ -15973,6 +15973,7 @@ else
   *-*-mingw32|*-pc-windows) :
     systhread_support=true
       otherlibraries="$otherlibraries systhreads"
+      pthread_link="-lpthread"
       { $as_echo "$as_me:${as_lineno-$LINENO}: the Win32 threads library is supported" >&5
 $as_echo "$as_me: the Win32 threads library is supported" >&6;} ;; #(
   *) :

--- a/configure
+++ b/configure
@@ -17099,8 +17099,8 @@ fi
 
 case $host in #(
   *-*-mingw32) :
-    bytecclibs="-lws2_32 -lversion"
-    nativecclibs="-lws2_32 -lversion" ;; #(
+    bytecclibs="-lws2_32 -lversion -lpthread -lgcc_eh"
+    nativecclibs="-lws2_32 -lversion -lpthread -lgcc_eh" ;; #(
   *-pc-windows) :
     bytecclibs="advapi32.lib ws2_32.lib version.lib"
     nativecclibs="advapi32.lib ws2_32.lib version.lib" ;; #(

--- a/configure
+++ b/configure
@@ -13078,6 +13078,14 @@ fi
 
 
 
+ac_fn_c_check_header_mongrel "$LINENO" "sys/mman.h" "ac_cv_header_sys_mman_h" "$ac_includes_default"
+if test "x$ac_cv_header_sys_mman_h" = xyes; then :
+  $as_echo "#define HAS_SYS_MMAN_H 1" >>confdefs.h
+
+fi
+
+
+
 # Checks for types
 
 ## off_t

--- a/configure.ac
+++ b/configure.ac
@@ -1836,8 +1836,8 @@ AC_CHECK_LIB(execinfo, backtrace, cclibs="$cclibs -lexecinfo",[])
 
 AS_CASE([$host],
   [*-*-mingw32],
-    [bytecclibs="-lws2_32 -lversion -lpthread -lgcc_eh"
-    nativecclibs="-lws2_32 -lversion -lpthread -lgcc_eh"],
+    [bytecclibs="-lws2_32 -lversion -lpthread -lgcc_eh -lDbgHelp"
+    nativecclibs="-lws2_32 -lversion -lpthread -lgcc_eh -lDbgHelp"],
   [*-pc-windows],
     [bytecclibs="advapi32.lib ws2_32.lib version.lib"
     nativecclibs="advapi32.lib ws2_32.lib version.lib"],

--- a/configure.ac
+++ b/configure.ac
@@ -762,6 +762,8 @@ AC_CHECK_HEADER([sys/select.h], [AC_DEFINE([HAS_SYS_SELECT_H])], [],
 
 AC_CHECK_HEADER([stdatomic.h], [AC_DEFINE([HAS_STDATOMIC_H])])
 
+AC_CHECK_HEADER([sys/mman.h], [AC_DEFINE([HAS_SYS_MMAN_H])])
+
 # Checks for types
 
 ## off_t

--- a/configure.ac
+++ b/configure.ac
@@ -484,7 +484,7 @@ AS_CASE([$ocaml_cv_cc_vendor],
   [sunc-*],
     [CPP="$CC -E -Qn"], # suppress generation of Sun PRO ident string
   [msvc-*],
-    [CPP="$CC -nologo -EP"];
+    [CPP="$CC -nologo -EP"],
 #  TODO: why can we not use $CPP in multicore, fix this?
   [CPP="$CC -E -P"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1683,6 +1683,7 @@ AS_IF([test x"$enable_systhreads" = "xno"],
     [*-*-mingw32|*-pc-windows],
       [systhread_support=true
       otherlibraries="$otherlibraries systhreads"
+      pthread_link="-lpthread"
       AC_MSG_NOTICE([the Win32 threads library is supported])],
     [AX_PTHREAD(
       [systhread_support=true

--- a/configure.ac
+++ b/configure.ac
@@ -1836,8 +1836,8 @@ AC_CHECK_LIB(execinfo, backtrace, cclibs="$cclibs -lexecinfo",[])
 
 AS_CASE([$host],
   [*-*-mingw32],
-    [bytecclibs="-lws2_32 -lversion"
-    nativecclibs="-lws2_32 -lversion"],
+    [bytecclibs="-lws2_32 -lversion -lpthread -lgcc_eh"
+    nativecclibs="-lws2_32 -lversion -lpthread -lgcc_eh"],
   [*-pc-windows],
     [bytecclibs="advapi32.lib ws2_32.lib version.lib"
     nativecclibs="advapi32.lib ws2_32.lib version.lib"],

--- a/otherlibs/str/Makefile
+++ b/otherlibs/str/Makefile
@@ -24,6 +24,8 @@ include ../Makefile.otherlibs.common
 str.cmo: str.cmi
 str.cmx: str.cmi
 
+LDOPTS = $(PTHREAD_LINK)
+
 .PHONY: depend
 depend:
 	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml > .depend

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -15,7 +15,6 @@
 
 #define CAML_INTERNALS
 
-#include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
 
@@ -37,7 +36,13 @@
 #include "caml/signals.h"
 
 #include "caml/sync.h"
+
+/* OS-specific code */
+#ifdef _WIN32
+#include "st_win32.h"
+#else
 #include "st_posix.h"
+#endif
 
 /* ML value for a thread descriptor */
 

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -4,7 +4,7 @@
 /*                                                                        */
 /*          Xavier Leroy and Damien Doligez, INRIA Rocquencourt           */
 /*                                                                        */
-/*   Copyright 1996 Institut National de Recherche en Informatique et     */
+/*   Copyright 2009 Institut National de Recherche en Informatique et     */
 /*     en Automatique.                                                    */
 /*                                                                        */
 /*   All rights reserved.  This file is distributed under the terms of    */
@@ -13,24 +13,11 @@
 /*                                                                        */
 /**************************************************************************/
 
-#ifndef CAML_ROOTS_H
-#define CAML_ROOTS_H
+/* Win32 implementation of the "st" interface */
 
-#ifdef CAML_INTERNALS
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0400
+#include <windows.h>
 
-#include "misc.h"
-#include "memory.h"
-
-typedef void (*scanning_action) (void*, value, value *);
-CAMLextern void (*caml_scan_roots_hook)(scanning_action, void*, caml_domain_state*);
-
-CAMLextern void caml_do_roots (scanning_action f, void* data, caml_domain_state* d,
-                               int do_final_val);
-CAMLextern void caml_do_local_roots(scanning_action f, void* data,
-                                    struct caml__roots_block* local_roots,
-                                    struct stack_info *current_stack,
-                                    value * v_gc_regs);
-
-#endif /* CAML_INTERNALS */
-
-#endif /* CAML_ROOTS_H */
+/* FIXME Replace winpthreads implementation with native */
+#include "st_posix.h"

--- a/otherlibs/unix/cstringv.c
+++ b/otherlibs/unix/cstringv.c
@@ -38,7 +38,7 @@ char_os ** cstringvect(value arg, char * cmdname)
     res[i] = caml_stat_strdup_to_os(String_val(x));
   }
   res[size] = NULL;
-  CAMLreturnT (char**, res);
+  CAMLreturnT (char_os **, res);
 }
 
 void cstringvect_free(char_os ** v)

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -94,9 +94,9 @@ libcamlrunpic_OBJECTS := $(BYTECODE_C_SOURCES:.c=.bpic.$(O))
 
 libasmrun_OBJECTS := $(NATIVE_C_SOURCES:.c=.n.$(O)) $(ASM_OBJECTS)
 
-libasmrund_OBJECTS := $(NATIVE_C_SOURCES:.c=.nd.$(O)) $(ASM_OBJECTS)
+libasmrund_OBJECTS := $(NATIVE_C_SOURCES:.c=.nd.$(O)) $(ASM_OBJECTS:.$(O)=.d.$(O))
 
-libasmruni_OBJECTS := $(NATIVE_C_SOURCES:.c=.ni.$(O)) $(ASM_OBJECTS)
+libasmruni_OBJECTS := $(NATIVE_C_SOURCES:.c=.ni.$(O)) $(ASM_OBJECTS:.$(O)=.i.$(O))
 
 libasmrunpic_OBJECTS := $(NATIVE_C_SOURCES:.c=.npic.$(O)) \
   $(ASM_OBJECTS:.$(O)=_libasmrunpic.$(O))
@@ -385,12 +385,19 @@ $(foreach object_type,$(subst %,,$(object_types)), \
 
 # Compilation of assembly files
 
-%.o: %.S
-	$(ASPP) $(ASPPFLAGS) -o $@ $< || \
+ASPP_ERROR = \
 	{ echo "If your assembler produced syntax errors, it is probably";\
           echo "unhappy with the preprocessor. Check your assembler, or";\
           echo "try producing $*.o by hand.";\
           exit 2; }
+%.o: %.S
+	$(ASPP) $(ASPPFLAGS) -o $@ $< || $(ASPP_ERROR)
+
+%.d.o: %.S
+	$(ASPP) $(ASPPFLAGS) $(OC_DEBUG_CPPFLAGS) -o $@ $< || $(ASPP_ERROR)
+
+%.i.o: %.S
+	$(ASPP) $(ASPPFLAGS) $(OC_INSTR_CPPFLAGS) -o $@ $< || $(ASPP_ERROR)
 
 %_libasmrunpic.o: %.S
 	$(ASPP) $(ASPPFLAGS) $(SHAREDLIB_CFLAGS) -o $@ $<
@@ -406,6 +413,18 @@ amd64nt.obj: amd64nt.asm domain_state64.inc
 
 i386nt.obj: i386nt.asm domain_state32.inc
 	$(ASM)$@ $(ASMFLAGS) $<
+
+amd64nt.d.obj: amd64nt.asm domain_state64.inc
+	$(ASM)$@ $(ASMFLAGS) $(OC_DEBUG_CPPFLAGS) $<
+
+i386nt.d.obj: i386nt.asm domain_state32.inc
+	$(ASM)$@ $(ASMFLAGS) $(OC_DEBUG_CPPFLAGS) $<
+
+amd64nt.i.obj: amd64nt.asm domain_state64.inc
+	$(ASM)$@ $(ASMFLAGS) $(OC_INSTR_CPPFLAGS) $<
+
+i386nt.i.obj: i386nt.asm domain_state32.inc
+	$(ASM)$@ $(ASMFLAGS) $(OC_INSTR_CPPFLAGS) $<
 
 %_libasmrunpic.obj: %.asm
 	$(ASM)$@ $(ASMFLAGS) $<

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -907,7 +907,7 @@ CFI_STARTPROC
 LBL(frame_runstack):
         leaq    32(%rsp), %r11 /* SP with exn handler popped */
         movq    Handler_value(%r11), %rbx
-1:      movq    Caml_state(current_stack), %rdi /* arg to caml_free_stack */
+1:      movq    Caml_state(current_stack), C_ARG_1 /* arg to caml_free_stack */
     /* restore parent stack and exn_handler into Caml_state */
         movq    Handler_parent(%r11), %r10
         movq    Stack_exception(%r10), %r11
@@ -920,7 +920,7 @@ LBL(frame_runstack):
         CFI_DEF_CFA_REGISTER(DW_REG_r13)
         movq    %rax, %r12 /* save %rax across C call */
         movq    Caml_state(c_stack), %rsp
-        call    GCALL(caml_free_stack)
+        C_call  (GCALL(caml_free_stack))
     /* switch directly to parent stack with correct return */
         movq    %r13, %rsp
         CFI_RESTORE_STATE

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -229,7 +229,7 @@
         pushq   %r13; CFI_ADJUST (8); CFI_OFFSET(r13, -56); \
         pushq   %r14; CFI_ADJUST (8); CFI_OFFSET(r14, -64); \
         pushq   %r15; CFI_ADJUST (8); CFI_OFFSET(r15, -72); \
-        subq    $(8+10*16), %rsp; CFI_ADJUST (8+10*16); \
+        subq    $(10*16), %rsp; CFI_ADJUST (10*16); \
         movupd  %xmm6, 0*16(%rsp); \
         movupd  %xmm7, 1*16(%rsp); \
         movupd  %xmm8, 2*16(%rsp); \
@@ -252,7 +252,7 @@
         movupd  7*16(%rsp), %xmm13; \
         movupd  8*16(%rsp), %xmm14; \
         movupd  9*16(%rsp), %xmm15; \
-        addq    $(8+10*16), %rsp; CFI_ADJUST (-8-10*16); \
+        addq    $(10*16), %rsp; CFI_ADJUST (-10*16); \
         popq    %r15; CFI_ADJUST(-8); CFI_SAME_VALUE(r15); \
         popq    %r14; CFI_ADJUST(-8); CFI_SAME_VALUE(r14); \
         popq    %r13; CFI_ADJUST(-8); CFI_SAME_VALUE(r13); \

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -46,13 +46,13 @@ void caml_interrupt_self(void);
 
 void caml_print_stats(void);
 
-CAMLexport void caml_reset_domain_lock(void);
-CAMLexport int caml_bt_is_in_blocking_section(void);
-CAMLexport intnat caml_domain_is_multicore (void);
-CAMLexport void caml_bt_enter_ocaml(void);
-CAMLexport void caml_bt_exit_ocaml(void);
-CAMLexport void caml_acquire_domain_lock(void);
-CAMLexport void caml_release_domain_lock(void);
+CAMLextern void caml_reset_domain_lock(void);
+CAMLextern int caml_bt_is_in_blocking_section(void);
+CAMLextern intnat caml_domain_is_multicore (void);
+CAMLextern void caml_bt_enter_ocaml(void);
+CAMLextern void caml_bt_exit_ocaml(void);
+CAMLextern void caml_acquire_domain_lock(void);
+CAMLextern void caml_release_domain_lock(void);
 
 CAMLextern void (*caml_atfork_hook)(void);
 
@@ -60,8 +60,8 @@ CAMLextern void (*caml_domain_start_hook)(void);
 CAMLextern void (*caml_domain_stop_hook)(void);
 CAMLextern void (*caml_domain_external_interrupt_hook)(void);
 
-void caml_init_domains(uintnat minor_heap_size);
-void caml_init_domain_self(int);
+CAMLextern void caml_init_domains(uintnat minor_heap_size);
+CAMLextern void caml_init_domain_self(int);
 
 caml_domain_state* caml_owner_of_young_block(value);
 

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -42,7 +42,7 @@ void caml_handle_gc_interrupt(void);
 void caml_handle_gc_interrupt_no_async_exceptions(void);
 void caml_handle_incoming_interrupts(void);
 
-void caml_interrupt_self(void);
+CAMLextern void caml_interrupt_self(void);
 
 void caml_print_stats(void);
 

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -82,14 +82,14 @@ extern value caml_global_data;
 #define Trap_link(tp) ((tp)[1])
 
 struct stack_info** caml_alloc_stack_cache (void);
-struct stack_info* caml_alloc_main_stack (uintnat init_size);
+CAMLextern struct stack_info* caml_alloc_main_stack (uintnat init_size);
 void caml_scan_stack(scanning_action f, void* fdata, struct stack_info* stack, value* v_gc_regs);
 /* try to grow the stack until at least required_size words are available.
    returns nonzero on success */
 int caml_try_realloc_stack (asize_t required_size);
 void caml_change_max_stack_size (uintnat new_max_size);
 void caml_maybe_expand_stack();
-void caml_free_stack(struct stack_info* stk);
+CAMLextern void caml_free_stack(struct stack_info* stk);
 
 #ifdef NATIVE_CODE
 void caml_get_stack_sp_pc (struct stack_info* stack, char** sp /* out */, uintnat* pc /* out */);

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -80,7 +80,7 @@ CAMLdeprecated_typedef(addr, char *);
 
 #ifndef CAMLDLLIMPORT
   #if defined(SUPPORT_DYNAMIC_LINKING) && defined(ARCH_SIXTYFOUR) \
-      && defined(__CYGWIN__)
+      && (defined(__CYGWIN__) || defined(__MINGW32__))
     #define CAMLDLLIMPORT __declspec(dllimport)
   #else
     #define CAMLDLLIMPORT

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -418,7 +418,7 @@ int caml_runtime_warnings_active(void);
                       | ((uintnat) (x) << 16) \
                       | ((uintnat) (x) << 48))
 #define Is_debug_tag(x) \
-  (((x) & 0xff00ffffff00fffful) == 0xD700D7D7D700D6D7ul)
+  (((x) & INT64_LITERAL(0xff00ffffff00ffffu)) == INT64_LITERAL(0xD700D7D7D700D6D7u))
 #else
 #define Debug_tag(x) (0xD700D6D7ul | ((uintnat) (x) << 16))
 #define Is_debug_tag(x) \

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -167,6 +167,8 @@ CAMLextern void caml_expand_command_line (int *, wchar_t ***);
    resolution may be less. The starting point is unspecified. */
 extern int64_t caml_time_counter(void);
 
+extern void caml_init_os_params(void);
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_OSDEPS_H */

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -169,6 +169,10 @@ extern int64_t caml_time_counter(void);
 
 extern void caml_init_os_params(void);
 
+#if defined(DEBUG) || defined(NATIVE_CODE)
+extern void caml_print_trace(void);
+#endif
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_OSDEPS_H */

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -78,7 +78,7 @@ Caml_inline int caml_plat_try_lock(caml_plat_mutex*);
 void caml_plat_assert_locked(caml_plat_mutex*);
 void caml_plat_assert_all_locks_unlocked();
 Caml_inline void caml_plat_unlock(caml_plat_mutex*);
-void caml_plat_mutex_free(caml_plat_mutex*);
+CAMLextern void caml_plat_mutex_free(caml_plat_mutex*);
 typedef struct { pthread_cond_t cond; caml_plat_mutex* mutex; } caml_plat_cond;
 #define CAML_PLAT_COND_INITIALIZER(m) { PTHREAD_COND_INITIALIZER, m }
 void caml_plat_cond_init(caml_plat_cond*, caml_plat_mutex*);

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -144,5 +144,8 @@ Caml_inline void caml_plat_unlock(caml_plat_mutex* m)
   check_err("unlock", pthread_mutex_unlock(m));
 }
 
+/* On Windows, the SYSTEM_INFO.dwPageSize is a DWORD (32-bit), but conveniently
+   long is also 32-bit */
+extern long caml_sys_pagesize;
 
 #endif /* CAML_PLATFORM_H */

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -64,6 +64,8 @@
 
 #undef HAS_STDATOMIC_H
 
+#undef HAS_SYS_MMAN_H
+
 /* 2. For the Unix library. */
 
 #undef HAS_SOCKETS

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -25,13 +25,13 @@ extern void caml_free_locale(void);
 
 /* readonly after startup */
 struct caml_params {
-  const char* exe_name;
+  const char_os* exe_name;
 
   /* for meta.c */
   const char* section_table;
   asize_t section_table_size;
 
-  const char* cds_file;
+  const char_os* cds_file;
 
   uintnat verb_gc;
   uintnat parser_trace;
@@ -67,7 +67,7 @@ extern int caml_parse_command_line (char_os **argv);
    If [pooling] is 0, [caml_stat_*] functions will not be backed by a pool. */
 extern int caml_startup_aux (int pooling);
 
-void caml_init_exe_name(const char* exe_name);
+void caml_init_exe_name(const char_os* exe_name);
 void caml_init_section_table(const char* section_table,
                              asize_t section_table_size);
 value caml_maybe_print_stats (value v);

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -32,7 +32,8 @@ void caml_change_max_stack_size (uintnat new_max_size)
 
   if (new_max_size < size) new_max_size = size;
   if (new_max_size != caml_max_stack_size){
-    caml_gc_log ("Changing stack limit to %luk bytes",
+    caml_gc_log ("Changing stack limit to %"
+                 ARCH_INTNAT_PRINTF_FORMAT "uk bytes",
                      new_max_size * sizeof (value) / 1024);
   }
   caml_max_stack_size = new_max_size;
@@ -132,7 +133,8 @@ value caml_alloc_stack (value hval, value hexn, value heff) {
 
   if (!stack) caml_raise_out_of_memory();
 
-  fiber_debug_log ("Allocate stack=%p of %lu words", stack, caml_fiber_wsz);
+  fiber_debug_log ("Allocate stack=%p of %" ARCH_INTNAT_PRINTF_FORMAT
+                     "u words", stack, caml_fiber_wsz);
 
   return Val_ptr(stack);
 }

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -289,7 +289,8 @@ void caml_init_gc ()
   caml_max_stack_size = caml_params->init_max_stack_wsz;
   caml_fiber_wsz = caml_params->init_fiber_wsz;
   caml_percent_free = norm_pfree (caml_params->init_percent_free);
-  caml_gc_log ("Initial stack limit: %luk bytes",
+  caml_gc_log ("Initial stack limit: %"
+               ARCH_INTNAT_PRINTF_FORMAT "uk bytes",
                caml_max_stack_size / 1024 * sizeof (value));
 
   caml_custom_major_ratio =

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -331,7 +331,8 @@ value caml_interprete(code_t prog, asize_t prog_size)
 #ifdef DEBUG
     caml_bcodcount++;
     if (caml_icount-- == 0) caml_stop_here ();
-    if (caml_params->trace_level>1) printf("\n##%ld\n", caml_bcodcount);
+    if (caml_params->trace_level>1)
+      printf("\n##%" ARCH_INTNAT_PRINTF_FORMAT "d\n", caml_bcodcount);
     if (caml_params->trace_level) caml_disasm_instr(pc);
     if (caml_params->trace_level>1) {
       printf("env=");

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -635,7 +635,8 @@ void caml_empty_minor_heap_promote (caml_domain_state* domain, int participating
   oldify_mopup (&st, 1); /* ephemerons promoted here */
   CAML_EV_END(EV_MINOR_REMEMBERED_SET_PROMOTE);
   CAML_EV_END(EV_MINOR_REMEMBERED_SET);
-  caml_gc_log("promoted %d roots, %lu bytes", remembered_roots, st.live_bytes);
+  caml_gc_log("promoted %d roots, %" ARCH_INTNAT_PRINTF_FORMAT "u bytes",
+              remembered_roots, st.live_bytes);
 
   CAML_EV_BEGIN(EV_MINOR_FINALIZERS_ADMIN);
   caml_gc_log("running stw minor_heap_domain_finalizers_admin");

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -29,9 +29,6 @@ __declspec(noreturn) void __cdecl abort(void);
 #include <string.h>
 #include <stdarg.h>
 #include <stdlib.h>
-#if defined(DEBUG) || defined(NATIVE_CODE)
-#include <execinfo.h>
-#endif
 #include "caml/config.h"
 #include "caml/misc.h"
 #include "caml/memory.h"
@@ -48,32 +45,13 @@ caml_timing_hook caml_finalise_begin_hook = NULL;
 caml_timing_hook caml_finalise_end_hook = NULL;
 
 #if defined(DEBUG) || defined(NATIVE_CODE)
-
-void print_trace (void)
-{
-  void *array[10];
-  size_t size;
-  char **strings;
-  size_t i;
-
-  size = backtrace (array, 10);
-  strings = backtrace_symbols (array, size);
-
-  caml_gc_log ("Obtained %zd stack frames.", size);
-
-  for (i = 0; i < size; i++)
-    caml_gc_log ("%s", strings[i]);
-
-  free (strings);
-}
-
-void caml_failed_assert (char * expr, char_os * file_os, int line)
+void caml_failed_assert(char * expr, char_os * file_os, int line)
 {
   char* file = caml_stat_strdup_of_os(file_os);
-  fprintf (stderr, "[%02d] file %s; line %d ### Assertion failed: %s\n",
-           Caml_state ? Caml_state->id : -1, file, line, expr);
-  print_trace ();
-  fflush (stderr);
+  fprintf(stderr, "[%02d] file %s; line %d ### Assertion failed: %s\n",
+          Caml_state ? Caml_state->id : -1, file, line, expr);
+  caml_print_trace();
+  fflush(stderr);
   caml_stat_free(file);
   abort();
 }

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -1,12 +1,17 @@
 #define CAML_INTERNALS
 
-#include <sys/mman.h>
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
 #include <sys/time.h>
 #include "caml/platform.h"
 #include "caml/fail.h"
+#ifdef HAS_SYS_MMAN_H
+#include <sys/mman.h>
+#endif
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 /* Mutexes */
 
@@ -132,6 +137,10 @@ uintnat caml_mem_round_up_pages(uintnat size)
   return round_up(size, caml_sys_pagesize);
 }
 
+#ifdef _WIN32
+#define MAP_FAILED 0
+#endif
+
 void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only)
 {
   uintnat alloc_sz = caml_mem_round_up_pages(size + alignment);
@@ -142,8 +151,14 @@ void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only)
   alignment = caml_mem_round_up_pages(alignment);
 
   Assert (alloc_sz > size);
+#ifdef _WIN32
+  /* Memory is only reserved at this point. It'll be committed after the
+     trim. */
+  mem = VirtualAlloc(NULL, alloc_sz, MEM_RESERVE, PAGE_NOACCESS);
+#else
   mem = mmap(0, alloc_sz, reserve_only ? PROT_NONE : (PROT_READ | PROT_WRITE),
              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+#endif
   if (mem == MAP_FAILED) {
     return 0;
   }
@@ -152,10 +167,28 @@ void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only)
   base = (uintnat)mem;
   aligned_start = round_up(base, alignment);
   aligned_end = aligned_start + caml_mem_round_up_pages(size);
+#ifdef _WIN32
+  /* VirtualFree can be used to decommit portions of memory, but it can only
+     release the entire block of memory. For Windows, repeat the call but this
+     time specify the address. */
+  if (!VirtualFree(mem, 0, MEM_RELEASE))
+    printf("The world seems to be upside down\n");
+  mem = VirtualAlloc((void*)aligned_start,
+                     aligned_end - aligned_start + 1,
+                     MEM_RESERVE | (reserve_only ? 0 : MEM_COMMIT),
+                     reserve_only ? PAGE_NOACCESS : PAGE_READWRITE);
+  if (!mem)
+    printf("Trimming failed\n");
+  else if (mem != (void*)aligned_start)
+    printf("Hang on a sec - it's allocated a different block?!\n");
+#else
   caml_mem_unmap((void*)base, aligned_start - base);
   caml_mem_unmap((void*)aligned_end, (base + alloc_sz) - aligned_end);
+#endif
   return (void*)aligned_start;
 }
+
+#ifndef _WIN32
 static void* map_fixed(void* mem, uintnat size, int prot)
 {
   if (mmap((void*)mem, size, prot,
@@ -166,9 +199,13 @@ static void* map_fixed(void* mem, uintnat size, int prot)
     return mem;
   }
 }
+#endif
 
 void* caml_mem_commit(void* mem, uintnat size)
 {
+#ifdef _WIN32
+  return VirtualAlloc(mem, size, MEM_COMMIT, PAGE_READWRITE);
+#else
   void* p = map_fixed(mem, size, PROT_READ | PROT_WRITE);
   /*
     FIXME: On Linux, with overcommit, you stand a better
@@ -179,16 +216,27 @@ void* caml_mem_commit(void* mem, uintnat size)
       if (p) memset(p, 0, size);
   */
   return p;
+#endif
 }
 
 void caml_mem_decommit(void* mem, uintnat size)
 {
+#ifdef _WIN32
+  if (!VirtualFree(mem, size, MEM_DECOMMIT))
+    printf("VirtualFree failed to decommit\n");
+#else
   map_fixed(mem, size, PROT_NONE);
+#endif
 }
 
 void caml_mem_unmap(void* mem, uintnat size)
 {
+#ifdef _WIN32
+  if (!VirtualFree(mem, size, MEM_RELEASE))
+    printf("VirtualFree failed\n");
+#else
   munmap(mem, size);
+#endif
 }
 
 #define Min_sleep_ns       10000 // 10 us

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -125,10 +125,11 @@ static uintnat round_up(uintnat size, uintnat align) {
   return (size + align - 1) & ~(align - 1);
 }
 
+long caml_sys_pagesize = 0;
 
 uintnat caml_mem_round_up_pages(uintnat size)
 {
-  return round_up(size, sysconf(_SC_PAGESIZE));
+  return round_up(size, caml_sys_pagesize);
 }
 
 void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only)

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -641,7 +641,8 @@ void verify_push(void* st_v, value v, value* p)
 
   if( Is_young(v) ) {
     caml_domain_state* domain_state;
-    caml_gc_log("minor in heap: %p, hd_val: %lx, p: %p", (value*)v, Hd_val(v), p);
+    caml_gc_log("minor in heap: %p, hd_val: %" ARCH_INTNAT_PRINTF_FORMAT "x, "
+                "p: %p", (value*)v, Hd_val(v), p);
     domain_state = caml_owner_of_young_block(v);
     caml_gc_log("owner: %d, young_start: %p, young_end: %p, young_ptr: %p, young_limit: %p", domain_state->id, domain_state->young_start, domain_state->young_end, domain_state->young_ptr, (void *)domain_state->young_limit);
   }
@@ -776,12 +777,18 @@ static void verify_swept (struct caml_heap_state* local) {
       verify_pool(p, i, &pool_stats);
     }
   }
-  caml_gc_log("Pooled memory: %lu alloced, %lu free, %lu fragmentation",
+  caml_gc_log("Pooled memory: %" ARCH_INTNAT_PRINTF_FORMAT
+                "u alloced, %" ARCH_INTNAT_PRINTF_FORMAT
+                "u free, %" ARCH_INTNAT_PRINTF_FORMAT
+                "u fragmentation",
               pool_stats.alloced, pool_stats.free, pool_stats.overhead);
 
   verify_large(local->swept_large, &large_stats);
   Assert(local->unswept_large == 0);
-  caml_gc_log("Large memory: %lu alloced, %lu free, %lu fragmentation",
+  caml_gc_log("Large memory: %" ARCH_INTNAT_PRINTF_FORMAT
+                "u alloced, %" ARCH_INTNAT_PRINTF_FORMAT
+                "u free, %" ARCH_INTNAT_PRINTF_FORMAT
+                "u fragmentation",
               large_stats.alloced, large_stats.free, large_stats.overhead);
 
   /* Check stats are being computed correctly */

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -195,7 +195,7 @@ CAMLexport void caml_shutdown(void)
   shutdown_happened = 1;
 }
 
-void caml_init_exe_name(const char* exe_name)
+void caml_init_exe_name(const char_os* exe_name)
 {
   params.exe_name = exe_name;
 }

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -285,6 +285,7 @@ CAMLexport void caml_main(char_os **argv)
   caml_install_invalid_parameter_handler();
 #endif
   caml_init_custom_operations();
+  caml_init_os_params();
   caml_ext_table_init(&caml_shared_libs_path, 8);
 
   /* Determine position of bytecode file */
@@ -419,6 +420,7 @@ CAMLexport value caml_startup_code_exn(
   caml_install_invalid_parameter_handler();
 #endif
   caml_init_custom_operations();
+  caml_init_os_params();
 
   /* Initialize the abstract machine */
   caml_init_gc ();

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -108,6 +108,7 @@ value caml_startup_common(char_os **argv, int pooling)
   caml_install_invalid_parameter_handler();
 #endif
   caml_init_custom_operations();
+  caml_init_os_params();
   caml_init_gc ();
 
   if (caml_params->backtrace_enabled)

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -51,6 +51,9 @@
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #endif
+#if defined(DEBUG) || defined(NATIVE_CODE)
+#include <execinfo.h>
+#endif
 #include "caml/fail.h"
 #include "caml/memory.h"
 #include "caml/misc.h"
@@ -462,3 +465,23 @@ void caml_init_os_params(void)
   caml_sys_pagesize = sysconf(_SC_PAGESIZE);
   return;
 }
+
+#if defined(DEBUG) || defined(NATIVE_CODE)
+void caml_print_trace(void)
+{
+  void *array[10];
+  size_t size;
+  char **strings;
+  size_t i;
+
+  size = backtrace(array, 10);
+  strings = backtrace_symbols(array, size);
+
+  caml_gc_log("Obtained %ld stack frames.\n", size);
+
+  for (i = 0; i < size; i++)
+    caml_gc_log("[%02zd] %s\n", i, strings[i]);
+
+  free(strings);
+}
+#endif

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -59,6 +59,7 @@
 #include "caml/sys.h"
 #include "caml/io.h"
 #include "caml/alloc.h"
+#include "caml/platform.h"
 
 #ifndef S_ISREG
 #define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
@@ -454,4 +455,10 @@ int caml_num_rows_fd(int fd)
 #else
   return -1;
 #endif
+}
+
+void caml_init_os_params(void)
+{
+  caml_sys_pagesize = sysconf(_SC_PAGESIZE);
+  return;
 }

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -46,6 +46,7 @@
 #include "caml/osdeps.h"
 #include "caml/signals.h"
 #include "caml/sys.h"
+#include "caml/startup_aux.h"
 
 #include "caml/config.h"
 #ifdef SUPPORT_DYNAMIC_LINKING

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -37,6 +37,9 @@
 #include <errno.h>
 #include <string.h>
 #include <signal.h>
+#if defined(DEBUG) || defined(NATIVE_CODE)
+#include <dbghelp.h>
+#endif
 #include "caml/alloc.h"
 #include "caml/codefrag.h"
 #include "caml/fail.h"
@@ -1080,3 +1083,60 @@ int64_t caml_time_counter(void)
   QueryPerformanceCounter(&now);
   return (now.QuadPart * frequency.QuadPart + clock_offset.QuadPart);
 }
+
+#if defined(DEBUG) || defined(NATIVE_CODE)
+void caml_print_trace(void)
+{
+  CONTEXT context;
+  STACKFRAME64 frame;
+  HANDLE hProcess = GetCurrentProcess();
+  HANDLE hThread = GetCurrentThread();
+  static int symbols_loaded = 0;
+  int i = 0;
+
+  memset(&context, 0, sizeof(CONTEXT));
+  memset(&frame, 0, sizeof(STACKFRAME64));
+
+  /* SymCleanup at present is never called */
+  if (!symbols_loaded && SymInitialize(hProcess, NULL, TRUE)) {
+    fprintf(stderr, "Loaded symbols\n");
+    symbols_loaded = 1;
+  }
+
+  context.ContextFlags = CONTEXT_FULL;
+  RtlCaptureContext(&context);
+
+#ifdef _M_X64
+  frame.AddrPC.Mode = frame.AddrFrame.Mode = frame.AddrStack.Mode = AddrModeFlat;
+  frame.AddrPC.Offset = context.Rip;
+  frame.AddrFrame.Offset = context.Rsp;
+  frame.AddrStack.Offset = context.Rsp;
+#else
+#error Unsupported Windows architecture
+#endif
+
+  /* For the symbols to be populated, compile with ocamlopt -g and run
+     `cv2pdb prog.exe` to generate prog.pdb. The output of this stack trace is
+     limited, probably because we make no effort to emit correct DWARF
+     information on Windows.
+
+     cv2pdb can be downloaded from https://github.com/rainers/cv2pdb */
+  while (i++ < 10 && StackWalk64(IMAGE_FILE_MACHINE_AMD64,
+                                 hProcess, hThread,
+                                 &frame, &context, NULL,
+                                 SymFunctionTableAccess64, SymGetModuleBase64,
+                                 NULL)) {
+    char buffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(wchar_t)];
+    PSYMBOL_INFO symbol = (PSYMBOL_INFO)buffer;
+    DWORD64 offset = 0;
+    char *name;
+    symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+    symbol->MaxNameLen = MAX_SYM_NAME;
+    if (SymFromAddr(hProcess, frame.AddrPC.Offset, &offset, symbol))
+      name = symbol->Name;
+    else
+      name = "???";
+    caml_gc_log("[%02d] %s\n", i, name);
+  }
+}
+#endif

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1018,13 +1018,65 @@ int caml_num_rows_fd(int fd)
   return -1;
 }
 
+static LARGE_INTEGER frequency;
+static LARGE_INTEGER clock_offset;
+typedef void (WINAPI *LPFN_GETSYSTEMTIME) (LPFILETIME);
+
 void caml_init_os_params(void)
 {
   SYSTEM_INFO si;
+  LPFN_GETSYSTEMTIME pGetSystemTime;
+  FILETIME stamp;
+  ULARGE_INTEGER now;
+  LARGE_INTEGER counter;
 
   /* Get the system page size */
   GetSystemInfo(&si);
   caml_sys_pagesize = si.dwPageSize;
 
-  return;
+  /* Get the number of nanoseconds for each tick in QueryPerformanceCounter */
+  QueryPerformanceFrequency(&frequency);
+  /* Convert the frequency to the duration of 1 tick in ns */
+  frequency.QuadPart = 1000000000LL / frequency.QuadPart;
+
+  /* Get the current time as accurately as we can.
+     GetSystemTimePreciseAsFileTime is available on Windows 8 / Server 2012+ and
+     gives <1us precision. For Windows 7 and earlier, which is only accurate to
+     10-100ms. */
+  pGetSystemTime =
+    (LPFN_GETSYSTEMTIME)GetProcAddress(GetModuleHandle(L"kernel32"),
+                                       "GetSystemTimePreciseAsFileTime");
+  if (!pGetSystemTime)
+    pGetSystemTime = GetSystemTimeAsFileTime;
+
+  /* Get the time and the performance counter. Get the performance counter first
+     to ensure no quantum effects */
+  QueryPerformanceCounter(&counter);
+  pGetSystemTime(&stamp);
+
+  now.LowPart = stamp.dwLowDateTime;
+  now.HighPart = stamp.dwHighDateTime;
+
+  /* Convert a FILETIME in 100ns ticks since 1 January 1601 to
+     ns since 1 Jan 1970. */
+  clock_offset.QuadPart =
+    ((now.QuadPart - INT64_LITERAL(0x19DB1DED53E8000U)) * 100);
+
+  /* Get the offset between QueryPerformanceCounter and
+     GetSystemTimePreciseAsFileTime in order to return a true timestamp, rather
+     than just a monotonic time source */
+  clock_offset.QuadPart -= (counter.QuadPart * frequency.QuadPart);
+
+  GetSystemTimePreciseAsFileTime(&stamp);
+  now.LowPart = stamp.dwLowDateTime;
+  now.HighPart = stamp.dwHighDateTime;
+  now.QuadPart *= 100;
+}
+
+int64_t caml_time_counter(void)
+{
+  LARGE_INTEGER now;
+  /* Windows 2000 is no longer supported, so this function always succeeds */
+  QueryPerformanceCounter(&now);
+  return (now.QuadPart * frequency.QuadPart + clock_offset.QuadPart);
 }

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1015,3 +1015,8 @@ int caml_num_rows_fd(int fd)
 {
   return -1;
 }
+
+void caml_init_os_params(void)
+{
+  return;
+}

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -47,6 +47,7 @@
 #include "caml/signals.h"
 #include "caml/sys.h"
 #include "caml/startup_aux.h"
+#include "caml/platform.h"
 
 #include "caml/config.h"
 #ifdef SUPPORT_DYNAMIC_LINKING
@@ -1019,5 +1020,11 @@ int caml_num_rows_fd(int fd)
 
 void caml_init_os_params(void)
 {
+  SYSTEM_INFO si;
+
+  /* Get the system page size */
+  GetSystemInfo(&si);
+  caml_sys_pagesize = si.dwPageSize;
+
   return;
 }

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -140,7 +140,7 @@ check-failstamp:
 
 .PHONY: all-enabled
 all-enabled: lib tools
-	@sed -n 's/#.*//; /\//d; /./p' disabled > disabled-dirs
+	@cat disabled | tr -d '\r' | sed -n 's/#.*//; /\//d; /./p' > disabled-dirs
 	@ls tests | fgrep -v -f disabled-dirs | \
 	  while read LINE; do \
 	    $(MAKE) $(NO_PRINT) exec-one DIR=tests/$$LINE; \

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -93,20 +93,21 @@ OCAMLTESTFLAGS := \
 .PHONY: default
 default:
 	@echo "Available targets:"
-	@echo "  all             launch all tests"
-	@echo "  all-foo         launch all tests beginning with foo"
-	@echo "  all-enabled     launch all enabled tests"
-	@echo "  parallel        launch all tests using GNU parallel"
-	@echo "  parallel-foo    launch all tests beginning with foo using \
+	@echo "  all              launch all tests"
+	@echo "  all-foo          launch all tests beginning with foo"
+	@echo "  all-enabled      launch all enabled tests"
+	@echo "  parallel         launch all tests using GNU parallel"
+	@echo "  parallel-enabled launch all enabled tests using GNU parallel"
+	@echo "  parallel-foo     launch all tests beginning with foo using \
 	GNU parallel"
-	@echo "  one TEST=f      launch just this single test"
-	@echo "  one DIR=p       launch the tests located in path p"
-	@echo "  one LIST=f      launch the tests listed in f (one per line)"
-	@echo "  promote DIR=p   promote the reference files for the tests in p"
-	@echo "  lib             build library modules"
-	@echo "  tools           build test tools"
-	@echo "  clean           delete generated files"
-	@echo "  report          print the report for the last execution"
+	@echo "  one TEST=f       launch just this single test"
+	@echo "  one DIR=p        launch the tests located in path p"
+	@echo "  one LIST=f       launch the tests listed in f (one per line)"
+	@echo "  promote DIR=p    promote the reference files for the tests in p"
+	@echo "  lib              build library modules"
+	@echo "  tools            build test tools"
+	@echo "  clean            delete generated files"
+	@echo "  report           print the report for the last execution"
 	@echo
 	@echo "all*, parallel* and list can automatically re-run failed test"
 	@echo "directories if MAX_TESTSUITE_DIR_RETRIES permits"
@@ -197,6 +198,27 @@ parallel-%: lib tools
 
 .PHONY: parallel
 parallel: parallel-*
+
+.PHONY: parallel-enabled
+parallel-enabled: parallel-enabled-*
+
+.PHONY: parallel-enabled-%
+parallel-enabled-%: lib tools
+	@echo | parallel >/dev/null 2>/dev/null \
+	 || (echo "Unable to run the GNU parallel tool;";\
+	     echo "You should install it before using the parallel* targets.";\
+	     exit 1)
+	@echo | parallel --gnu --no-notice >/dev/null 2>/dev/null \
+	 || (echo "Your 'parallel' tool seems incompatible with GNU parallel.";\
+	     echo "This target requires GNU parallel.";\
+	     exit 1)
+	@cat disabled | tr -d '\r' | sed -n 's/#.*//; /\//d; /./p' > disabled-dirs
+	@(cd tests ; ls -d $**) | fgrep -v -f disabled-dirs | while read -r dir; do echo $$dir; done \
+	 | parallel --gnu --no-notice --keep-order \
+	     "$(MAKE) --no-print-directory exec-one DIR=tests/{} 2>&1" \
+	 | tee $(TESTLOG)
+	@rm disabled-dirs
+	@$(MAKE) report
 
 .PHONY: list
 list: lib tools

--- a/testsuite/summarize.awk
+++ b/testsuite/summarize.awk
@@ -16,6 +16,7 @@
 BEGIN {
     while ((getline line < "disabled") > 0) {
         gsub(/#.*/, "", line);
+        gsub(/\r$/, "", line);
         if (line) {
             is_disabled[line] = 1;
         }

--- a/testsuite/tests/lib-systhreads/test_c_thread_register.ml
+++ b/testsuite/tests/lib-systhreads/test_c_thread_register.ml
@@ -3,9 +3,8 @@
    * hassysthreads
    include systhreads
    ** not-bsd
-   *** libunix
-   **** bytecode
-   **** native
+   *** bytecode
+   *** native
 *)
 
 (* spins a external thread from C and register it to the OCaml runtime *)

--- a/testsuite/tests/lib-unix/common/fork_cleanup.ml
+++ b/testsuite/tests/lib-unix/common/fork_cleanup.ml
@@ -1,8 +1,9 @@
 (* TEST
 * hasunix
 include unix
-** bytecode
-** native
+** not-windows
+*** bytecode
+*** native
 *)
 
 (* this test checks that the domain lock is properly reinitialized

--- a/testsuite/tests/lib-unix/common/fork_cleanup_systhreads.ml
+++ b/testsuite/tests/lib-unix/common/fork_cleanup_systhreads.ml
@@ -1,8 +1,9 @@
 (* TEST
 * hassysthreads
 include systhreads
-** bytecode
-** native
+** not-windows
+*** bytecode
+*** native
 *)
 
 (* this test checks that the domain lock is properly reinitialized

--- a/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
+++ b/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
@@ -1,8 +1,9 @@
 (* TEST
 include unix
 * hasunix
-** bytecode
-** native
+** not-windows
+*** bytecode
+*** native
 *)
 
 (* on Multicore, fork is not allowed is another domain is, and was running. *)

--- a/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
+++ b/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
@@ -1,8 +1,9 @@
 (* TEST
 include unix
 * hasunix
-** bytecode
-** native
+** not-windows
+*** bytecode
+*** native
 *)
 
 (* on Multicore, fork is not allowed is another domain is, and was running. *)


### PR DESCRIPTION
This is the version of #351 from September 2021 rebased on to 4.12+domains+effects.

`tests/backtrace/backtrace_systhreads.ml` consistently fails with output along these lines:

```diff
--- "a\\testsuite\\tests\\backtrace\\backtrace_systhreads.reference"
+++ "b\\testsuite\\tests\\backtrace\\backtrace_systhreads\\ocamlc.byte\\backtrace_systhreads.byte.exe.output"
@@ -1,19 +1,13 @@
 Thread 2 killed on uncaught exception Failure("0")
-Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
-Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
-Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 41, characters 8-14
 Thread 3 killed on uncaught exception Failure("1")
-Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
-Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
-Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 41, characters 8-14
+Called from unknown location
+Called from unknown location
 Thread 4 killed on uncaught exception Failure("2")
-Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
-Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
-Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 41, characters 8-14
+Called from unknown location
+Called from unknown location
 Thread 5 killed on uncaught exception Failure("3")
+Called from unknown location
+Called from unknown location
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
```

IIRC this got "magically" fixed by something else on 5.00 branch in the meantime, but I the whole of the rest of the testsuite is passing, so I expect it can be ignored for the purposes of 4.12 testing.

cc @Sudha247